### PR TITLE
Architecture migration 3.5: Network subcommands (Session C)

### DIFF
--- a/.serena/memories/architecture_migration_status.md
+++ b/.serena/memories/architecture_migration_status.md
@@ -101,7 +101,7 @@ A.1 → A.2 → A.3 → B → C → D → G → E → F
 | A.2 | Container: top, stats, update | 25 min |
 | A.3 | Container: exec, attach, cp | 30 min |
 | B | Volume: list, inspect, create, remove, prune | 30 min | ✅ |
-| C | Network: list, inspect, create, remove, prune | 30 min |
+| C | Network: list, inspect, create, remove, prune | 30 min | ✅ |
 | D | Image: list, inspect, remove, build, prune | 30 min |
 | G | Documentation update | 30 min |
 | E | Missing whail methods | 30 min |
@@ -213,6 +213,9 @@ Session A.3: ✅ COMPLETED
 Session B: ✅ COMPLETED
 - [x] `volume list`, `volume inspect`, `volume create`, `volume remove`, `volume prune`
 
+Session C: ✅ COMPLETED (2026-01-16)
+- [x] `network list`, `network inspect`, `network create`, `network remove`, `network prune`
+
 Session F (deferred):
 - [ ] `create`, `run`
 
@@ -278,6 +281,7 @@ type Client struct {
 13. **Commands use positional args**: Docker-like interface - `clawker container rm NAME` not `clawker container rm --name NAME`
 14. **Parent commands**: Add subcommands alphabetically with `cmd.AddCommand()`, Cobra auto-sorts in help output
 15. **Test expectedSubcommands**: Keep sorted alphabetically to match Cobra's output order
+16. **Global flag shorthand conflict**: Don't use `-d` shorthand in subcommands - it conflicts with the global `--debug` flag
 
 ## How to Resume
 

--- a/.serena/memories/architecture_migration_tasks.md
+++ b/.serena/memories/architecture_migration_tasks.md
@@ -310,13 +310,13 @@ The assistant should:
 - [x] `volume remove` (alias: rm)
 - [x] `volume prune` (scaffold with TODO for whail method)
 
-### Task 3.5: Network Commands (Session C - ~30 min)
+### Task 3.5: Network Commands (Session C - ~30 min) - ✅ COMPLETED (2026-01-16)
 
-- [ ] `network list` (alias: ls)
-- [ ] `network inspect`
-- [ ] `network create`
-- [ ] `network remove` (alias: rm)
-- [ ] `network prune` (scaffold with TODO for whail method)
+- [x] `network list` (alias: ls)
+- [x] `network inspect`
+- [x] `network create`
+- [x] `network remove` (alias: rm)
+- [x] `network prune` (uses list+remove workaround like volume prune)
 
 ### Task 3.6: Image Commands (Session D - ~30 min)
 
@@ -431,6 +431,7 @@ After each session if you've learned anything add it to this list, avoid verbosi
   - Subcommands go in their own subpackages (volume/list/list.go not volume/list.go)
   - shlex.Split strips quotes, so test expected values shouldn't include quotes
   - prune workaround: list+remove individual volumes instead of waiting for VolumesPrune
+  - Global flag `-d/--debug` reserves `-d` shorthand; don't reuse it in subcommands
 
 Summarize subtasks and tasks into short summaries after they are complete to keep this file footprint small
 
@@ -443,4 +444,4 @@ Summarize subtasks and tasks into short summaries after they are complete to kee
 - **Integration tests**: `go test ./pkg/cmd/... -tags=integration -v -timeout 10m`
 - **Plan file**: `~/.claude/plans/curried-floating-pizza.md`
 - **Architecture constraint**: All Docker SDK calls must go through `pkg/whail`
-- **Session order**: ~~A.1~~ → ~~A.2~~ → ~~A.3~~ → ~~B~~ → C → D → G → E → F
+- **Session order**: ~~A.1~~ → ~~A.2~~ → ~~A.3~~ → ~~B~~ → ~~C~~ → D → G → E → F

--- a/pkg/cmd/network/create/create.go
+++ b/pkg/cmd/network/create/create.go
@@ -1,0 +1,135 @@
+// Package create provides the network create command.
+package create
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Options holds options for the create command.
+type Options struct {
+	Driver     string
+	DriverOpts []string
+	Labels     []string
+	Internal   bool
+	IPv6       bool
+	Attachable bool
+}
+
+// NewCmd creates the network create command.
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "create [OPTIONS] NETWORK",
+		Short: "Create a network",
+		Long: `Creates a new clawker-managed network.
+
+The network will be labeled as a clawker-managed resource.
+By default, a bridge network driver is used.`,
+		Example: `  # Create a network
+  clawker network create mynetwork
+
+  # Create an internal network (no external connectivity)
+  clawker network create --internal mynetwork
+
+  # Create a network with custom driver options
+  clawker network create --driver bridge --opt com.docker.network.bridge.name=mybridge mynetwork
+
+  # Create a network with labels
+  clawker network create --label env=test --label project=myapp mynetwork`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Driver, "driver", "bridge", "Driver to manage the network")
+	cmd.Flags().StringArrayVarP(&opts.DriverOpts, "opt", "o", nil, "Set driver specific options")
+	cmd.Flags().StringArrayVar(&opts.Labels, "label", nil, "Set metadata for a network")
+	cmd.Flags().BoolVar(&opts.Internal, "internal", false, "Restrict external access to the network")
+	cmd.Flags().BoolVar(&opts.IPv6, "ipv6", false, "Enable IPv6 networking")
+	cmd.Flags().BoolVar(&opts.Attachable, "attachable", false, "Enable manual container attachment")
+
+	return cmd
+}
+
+func run(_ *cmdutil.Factory, opts *Options, name string) error {
+	ctx := context.Background()
+
+	// Connect to Docker
+	client, err := docker.NewClient(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+	defer client.Close()
+
+	// Build create options
+	createOpts := network.CreateOptions{
+		Driver:     opts.Driver,
+		Options:    parseDriverOpts(opts.DriverOpts),
+		Labels:     parseLabels(opts.Labels),
+		Internal:   opts.Internal,
+		EnableIPv6: &opts.IPv6,
+		Attachable: opts.Attachable,
+	}
+
+	// Create the network
+	resp, err := client.NetworkCreate(ctx, name, createOpts)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+
+	// Print the network ID
+	fmt.Println(resp.ID)
+	return nil
+}
+
+// parseDriverOpts converts --opt key=value flags to a map.
+func parseDriverOpts(opts []string) map[string]string {
+	if len(opts) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for _, opt := range opts {
+		k, v := parseKeyValue(opt)
+		if k != "" {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// parseLabels converts --label key=value flags to a map.
+func parseLabels(labels []string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for _, label := range labels {
+		k, v := parseKeyValue(label)
+		if k != "" {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// parseKeyValue splits a key=value string.
+func parseKeyValue(s string) (string, string) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '=' {
+			return s[:i], s[i+1:]
+		}
+	}
+	return s, ""
+}

--- a/pkg/cmd/network/create/create_test.go
+++ b/pkg/cmd/network/create/create_test.go
@@ -1,0 +1,172 @@
+package create
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/schmitthub/clawker/pkg/cmd/testutil"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOpts Options
+		wantName string
+		wantErr  bool
+	}{
+		{
+			name:     "basic network",
+			input:    "mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "bridge", DriverOpts: []string{}, Labels: []string{}},
+		},
+		{
+			name:     "custom driver",
+			input:    "--driver overlay mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "overlay", DriverOpts: []string{}, Labels: []string{}},
+		},
+		{
+			name:     "internal network",
+			input:    "--internal mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "bridge", Internal: true, DriverOpts: []string{}, Labels: []string{}},
+		},
+		{
+			name:     "ipv6 enabled",
+			input:    "--ipv6 mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "bridge", IPv6: true, DriverOpts: []string{}, Labels: []string{}},
+		},
+		{
+			name:     "attachable network",
+			input:    "--attachable mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "bridge", Attachable: true, DriverOpts: []string{}, Labels: []string{}},
+		},
+		{
+			name:     "driver opts",
+			input:    "-o key1=value1 -o key2=value2 mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "bridge", DriverOpts: []string{"key1=value1", "key2=value2"}, Labels: []string{}},
+		},
+		{
+			name:     "labels",
+			input:    "--label env=test --label project=myapp mynetwork",
+			wantName: "mynetwork",
+			wantOpts: Options{Driver: "bridge", DriverOpts: []string{}, Labels: []string{"env=test", "project=myapp"}},
+		},
+		{
+			name:    "no arguments",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "too many arguments",
+			input:   "net1 net2",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			var cmdOpts *Options
+			var cmdName string
+			cmd := NewCmd(f)
+
+			// Override RunE to capture options instead of executing
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				cmdOpts = &Options{}
+				cmdOpts.Driver, _ = cmd.Flags().GetString("driver")
+				cmdOpts.DriverOpts, _ = cmd.Flags().GetStringArray("opt")
+				cmdOpts.Labels, _ = cmd.Flags().GetStringArray("label")
+				cmdOpts.Internal, _ = cmd.Flags().GetBool("internal")
+				cmdOpts.IPv6, _ = cmd.Flags().GetBool("ipv6")
+				cmdOpts.Attachable, _ = cmd.Flags().GetBool("attachable")
+				cmdName = args[0]
+				return nil
+			}
+
+			// Cobra hack-around for help flag
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			// Parse arguments
+			argv := testutil.SplitArgs(tt.input)
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantName, cmdName)
+			require.Equal(t, tt.wantOpts.Driver, cmdOpts.Driver)
+			require.Equal(t, tt.wantOpts.Internal, cmdOpts.Internal)
+			require.Equal(t, tt.wantOpts.IPv6, cmdOpts.IPv6)
+			require.Equal(t, tt.wantOpts.Attachable, cmdOpts.Attachable)
+			require.Equal(t, tt.wantOpts.DriverOpts, cmdOpts.DriverOpts)
+			require.Equal(t, tt.wantOpts.Labels, cmdOpts.Labels)
+		})
+	}
+}
+
+func TestCmd_Properties(t *testing.T) {
+	f := &cmdutil.Factory{}
+	cmd := NewCmd(f)
+
+	// Test command basics
+	require.Equal(t, "create [OPTIONS] NETWORK", cmd.Use)
+	require.Empty(t, cmd.Aliases)
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+	require.NotEmpty(t, cmd.Example)
+	require.NotNil(t, cmd.RunE)
+
+	// Test flags exist
+	require.NotNil(t, cmd.Flags().Lookup("driver"))
+	require.NotNil(t, cmd.Flags().Lookup("opt"))
+	require.NotNil(t, cmd.Flags().Lookup("label"))
+	require.NotNil(t, cmd.Flags().Lookup("internal"))
+	require.NotNil(t, cmd.Flags().Lookup("ipv6"))
+	require.NotNil(t, cmd.Flags().Lookup("attachable"))
+
+	// Test shorthand flags
+	require.NotNil(t, cmd.Flags().ShorthandLookup("o"))
+
+	// Test args validation
+	require.NotNil(t, cmd.Args)
+}
+
+func TestParseKeyValue(t *testing.T) {
+	tests := []struct {
+		input string
+		key   string
+		value string
+	}{
+		{"key=value", "key", "value"},
+		{"key=", "key", ""},
+		{"key", "key", ""},
+		{"key=value=with=equals", "key", "value=with=equals"},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			k, v := parseKeyValue(tt.input)
+			require.Equal(t, tt.key, k)
+			require.Equal(t, tt.value, v)
+		})
+	}
+}

--- a/pkg/cmd/network/inspect/inspect.go
+++ b/pkg/cmd/network/inspect/inspect.go
@@ -1,0 +1,100 @@
+// Package inspect provides the network inspect command.
+package inspect
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Options holds options for the inspect command.
+type Options struct {
+	// Format is reserved for future Go template support
+	Verbose bool
+}
+
+// NewCmd creates the network inspect command.
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "inspect NETWORK [NETWORK...]",
+		Short: "Display detailed information on one or more networks",
+		Long: `Returns low-level information about clawker networks.
+
+Outputs detailed network information in JSON format, including
+connected containers and configuration.`,
+		Example: `  # Inspect a network
+  clawker network inspect clawker-net
+
+  # Inspect multiple networks
+  clawker network inspect clawker-net myapp-net
+
+  # Inspect with verbose output (includes services and tasks)
+  clawker network inspect --verbose clawker-net`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(f, opts, args)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Verbose, "verbose", "v", false, "Verbose output for swarm networks")
+
+	return cmd
+}
+
+func run(_ *cmdutil.Factory, opts *Options, networks []string) error {
+	ctx := context.Background()
+
+	// Connect to Docker
+	client, err := docker.NewClient(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+	defer client.Close()
+
+	var results []any
+	var errs []error
+
+	for _, name := range networks {
+		// Inspect the network
+		net, err := client.NetworkInspect(ctx, name, network.InspectOptions{
+			Verbose: opts.Verbose,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to inspect network %q: %w", name, err))
+			continue
+		}
+
+		results = append(results, net)
+	}
+
+	// Output results
+	if len(results) > 0 {
+		if err := outputJSON(results); err != nil {
+			return err
+		}
+	}
+
+	if len(errs) > 0 {
+		for _, e := range errs {
+			cmdutil.HandleError(e)
+		}
+		return fmt.Errorf("failed to inspect %d network(s)", len(errs))
+	}
+
+	return nil
+}
+
+func outputJSON(data any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "    ")
+	return encoder.Encode(data)
+}

--- a/pkg/cmd/network/inspect/inspect_test.go
+++ b/pkg/cmd/network/inspect/inspect_test.go
@@ -1,0 +1,112 @@
+package inspect
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/schmitthub/clawker/pkg/cmd/testutil"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOpts Options
+		wantArgs []string
+		wantErr  bool
+	}{
+		{
+			name:     "single network",
+			input:    "clawker-net",
+			wantOpts: Options{},
+			wantArgs: []string{"clawker-net"},
+		},
+		{
+			name:     "multiple networks",
+			input:    "clawker-net myapp-net",
+			wantOpts: Options{},
+			wantArgs: []string{"clawker-net", "myapp-net"},
+		},
+		{
+			name:     "verbose flag",
+			input:    "-v clawker-net",
+			wantOpts: Options{Verbose: true},
+			wantArgs: []string{"clawker-net"},
+		},
+		{
+			name:     "verbose flag long",
+			input:    "--verbose clawker-net",
+			wantOpts: Options{Verbose: true},
+			wantArgs: []string{"clawker-net"},
+		},
+		{
+			name:    "no arguments",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			var cmdOpts *Options
+			var cmdArgs []string
+			cmd := NewCmd(f)
+
+			// Override RunE to capture options instead of executing
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				cmdOpts = &Options{}
+				cmdOpts.Verbose, _ = cmd.Flags().GetBool("verbose")
+				cmdArgs = args
+				return nil
+			}
+
+			// Cobra hack-around for help flag
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			// Parse arguments
+			argv := testutil.SplitArgs(tt.input)
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOpts.Verbose, cmdOpts.Verbose)
+			require.Equal(t, tt.wantArgs, cmdArgs)
+		})
+	}
+}
+
+func TestCmd_Properties(t *testing.T) {
+	f := &cmdutil.Factory{}
+	cmd := NewCmd(f)
+
+	// Test command basics
+	require.Equal(t, "inspect NETWORK [NETWORK...]", cmd.Use)
+	require.Empty(t, cmd.Aliases)
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+	require.NotEmpty(t, cmd.Example)
+	require.NotNil(t, cmd.RunE)
+
+	// Test flags exist
+	require.NotNil(t, cmd.Flags().Lookup("verbose"))
+
+	// Test shorthand flags
+	require.NotNil(t, cmd.Flags().ShorthandLookup("v"))
+
+	// Test args validation
+	require.NotNil(t, cmd.Args)
+}

--- a/pkg/cmd/network/list/list.go
+++ b/pkg/cmd/network/list/list.go
@@ -1,0 +1,103 @@
+// Package list provides the network list command.
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Options holds options for the list command.
+type Options struct {
+	Quiet bool
+}
+
+// NewCmd creates the network list command.
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List networks",
+		Long: `Lists all networks created by clawker.
+
+Networks are used for container communication and monitoring stack
+integration. The primary network is clawker-net.`,
+		Example: `  # List all clawker networks
+  clawker network list
+
+  # List networks (short form)
+  clawker network ls
+
+  # List network names only
+  clawker network ls -q`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(f, opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display network names")
+
+	return cmd
+}
+
+func run(_ *cmdutil.Factory, opts *Options) error {
+	ctx := context.Background()
+
+	// Connect to Docker
+	client, err := docker.NewClient(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+	defer client.Close()
+
+	// List networks
+	networks, err := client.NetworkList(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+
+	if len(networks) == 0 {
+		fmt.Fprintln(os.Stderr, "No clawker networks found.")
+		return nil
+	}
+
+	// Quiet mode - just print names
+	if opts.Quiet {
+		for _, n := range networks {
+			fmt.Println(n.Name)
+		}
+		return nil
+	}
+
+	// Print table
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NETWORK ID\tNAME\tDRIVER\tSCOPE")
+
+	for _, n := range networks {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			truncateID(n.ID),
+			n.Name,
+			n.Driver,
+			n.Scope,
+		)
+	}
+
+	return w.Flush()
+}
+
+// truncateID shortens a Docker ID to 12 characters.
+func truncateID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}

--- a/pkg/cmd/network/list/list_test.go
+++ b/pkg/cmd/network/list/list_test.go
@@ -1,0 +1,85 @@
+package list
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/schmitthub/clawker/pkg/cmd/testutil"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOpts Options
+	}{
+		{
+			name:     "no flags",
+			input:    "",
+			wantOpts: Options{},
+		},
+		{
+			name:     "quiet flag",
+			input:    "-q",
+			wantOpts: Options{Quiet: true},
+		},
+		{
+			name:     "quiet flag long",
+			input:    "--quiet",
+			wantOpts: Options{Quiet: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			var cmdOpts *Options
+			cmd := NewCmd(f)
+
+			// Override RunE to capture options instead of executing
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				cmdOpts = &Options{}
+				cmdOpts.Quiet, _ = cmd.Flags().GetBool("quiet")
+				return nil
+			}
+
+			// Cobra hack-around for help flag
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			// Parse arguments
+			argv := testutil.SplitArgs(tt.input)
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOpts.Quiet, cmdOpts.Quiet)
+		})
+	}
+}
+
+func TestCmd_Properties(t *testing.T) {
+	f := &cmdutil.Factory{}
+	cmd := NewCmd(f)
+
+	// Test command basics
+	require.Equal(t, "list", cmd.Use)
+	require.Contains(t, cmd.Aliases, "ls")
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+	require.NotEmpty(t, cmd.Example)
+	require.NotNil(t, cmd.RunE)
+
+	// Test flags exist
+	require.NotNil(t, cmd.Flags().Lookup("quiet"))
+
+	// Test shorthand flags
+	require.NotNil(t, cmd.Flags().ShorthandLookup("q"))
+}

--- a/pkg/cmd/network/network.go
+++ b/pkg/cmd/network/network.go
@@ -2,6 +2,11 @@
 package network
 
 import (
+	"github.com/schmitthub/clawker/pkg/cmd/network/create"
+	"github.com/schmitthub/clawker/pkg/cmd/network/inspect"
+	"github.com/schmitthub/clawker/pkg/cmd/network/list"
+	"github.com/schmitthub/clawker/pkg/cmd/network/prune"
+	"github.com/schmitthub/clawker/pkg/cmd/network/remove"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -20,14 +25,22 @@ and monitoring stack integration.`,
   clawker network ls
 
   # Inspect the clawker network
-  clawker network inspect clawker-net`,
+  clawker network inspect clawker-net
+
+  # Create a new network
+  clawker network create mynetwork
+
+  # Remove a network
+  clawker network rm mynetwork`,
 		// No RunE - this is a parent command
 	}
 
 	// Add subcommands
-	// Note: Subcommands will be added in a future task
-	// cmd.AddCommand(NewCmdLs(f))
-	// cmd.AddCommand(NewCmdInspect(f))
+	cmd.AddCommand(create.NewCmd(f))
+	cmd.AddCommand(inspect.NewCmd(f))
+	cmd.AddCommand(list.NewCmd(f))
+	cmd.AddCommand(prune.NewCmd(f))
+	cmd.AddCommand(remove.NewCmd(f))
 
 	return cmd
 }

--- a/pkg/cmd/network/network_test.go
+++ b/pkg/cmd/network/network_test.go
@@ -37,12 +37,22 @@ func TestNewCmdNetwork_Subcommands(t *testing.T) {
 	f := cmdutil.New("1.0.0", "abc123")
 	cmd := NewCmdNetwork(f)
 
-	// Currently no subcommands are registered
-	// This test will be expanded when subcommands are added
 	subcommands := cmd.Commands()
 
-	// For now, expect no subcommands
-	if len(subcommands) != 0 {
-		t.Errorf("expected 0 subcommands (none registered yet), got %d", len(subcommands))
+	// Expect 5 subcommands: create, inspect, list, prune, remove
+	if len(subcommands) != 5 {
+		t.Errorf("expected 5 subcommands, got %d", len(subcommands))
+	}
+
+	// Verify subcommand names (sorted alphabetically by Cobra)
+	expectedSubcommands := []string{"create", "inspect", "list", "prune", "remove"}
+	for i, expected := range expectedSubcommands {
+		if i >= len(subcommands) {
+			t.Errorf("missing subcommand: %s", expected)
+			continue
+		}
+		if subcommands[i].Name() != expected {
+			t.Errorf("expected subcommand %d to be '%s', got '%s'", i, expected, subcommands[i].Name())
+		}
 	}
 }

--- a/pkg/cmd/network/prune/prune.go
+++ b/pkg/cmd/network/prune/prune.go
@@ -1,0 +1,123 @@
+// Package prune provides the network prune command.
+package prune
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/docker/docker/api/types/network"
+	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Options holds options for the prune command.
+type Options struct {
+	Force bool
+}
+
+// NewCmd creates the network prune command.
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:   "prune [OPTIONS]",
+		Short: "Remove unused networks",
+		Long: `Removes all clawker-managed networks that are not currently in use.
+
+This command removes networks that have no connected containers.
+Use with caution as this may affect container communication.
+
+Note: The built-in clawker-net network will be preserved if containers
+are using it for the monitoring stack.`,
+		Example: `  # Remove all unused clawker networks
+  clawker network prune
+
+  # Remove without confirmation prompt
+  clawker network prune --force`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(f, opts)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Do not prompt for confirmation")
+
+	return cmd
+}
+
+func run(_ *cmdutil.Factory, opts *Options) error {
+	ctx := context.Background()
+
+	// Connect to Docker
+	client, err := docker.NewClient(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+	defer client.Close()
+
+	// Prompt for confirmation if not forced
+	if !opts.Force {
+		fmt.Fprint(os.Stderr, "WARNING! This will remove all unused clawker-managed networks.\nAre you sure you want to continue? [y/N] ")
+		var response string
+		if _, err := fmt.Scanln(&response); err != nil {
+			// Treat read errors (EOF, etc.) as "no"
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+		if response != "y" && response != "Y" {
+			fmt.Fprintln(os.Stderr, "Aborted.")
+			return nil
+		}
+	}
+
+	// TODO: implement NetworksPrune in pkg/whail/network.go
+	// For now, list networks and check if they have containers connected
+	networks, err := client.NetworkList(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+
+	if len(networks) == 0 {
+		fmt.Fprintln(os.Stderr, "No unused clawker networks to remove.")
+		return nil
+	}
+
+	var removed int
+	for _, n := range networks {
+		// Inspect network to check for connected containers
+		info, err := client.NetworkInspect(ctx, n.Name, network.InspectOptions{})
+		if err != nil {
+			// If we can't inspect, skip it
+			fmt.Fprintf(os.Stderr, "Warning: failed to inspect network %s: %v\n", n.Name, err)
+			continue
+		}
+
+		// Skip networks with connected containers
+		if len(info.Containers) > 0 {
+			continue
+		}
+
+		// Try to remove the network
+		if err := client.NetworkRemove(ctx, n.Name); err != nil {
+			// Check if it's an "in use" error vs unexpected error
+			if strings.Contains(err.Error(), "has active endpoints") {
+				continue
+			}
+			// Log unexpected errors but continue with other networks
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove network %s: %v\n", n.Name, err)
+			continue
+		}
+		removed++
+		fmt.Fprintf(os.Stderr, "Deleted: %s\n", n.Name)
+	}
+
+	if removed == 0 {
+		fmt.Fprintln(os.Stderr, "No unused clawker networks to remove.")
+	}
+
+	return nil
+}

--- a/pkg/cmd/network/prune/prune_test.go
+++ b/pkg/cmd/network/prune/prune_test.go
@@ -1,0 +1,85 @@
+package prune
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/schmitthub/clawker/pkg/cmd/testutil"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOpts Options
+	}{
+		{
+			name:     "no flags",
+			input:    "",
+			wantOpts: Options{},
+		},
+		{
+			name:     "force flag",
+			input:    "-f",
+			wantOpts: Options{Force: true},
+		},
+		{
+			name:     "force flag long",
+			input:    "--force",
+			wantOpts: Options{Force: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			var cmdOpts *Options
+			cmd := NewCmd(f)
+
+			// Override RunE to capture options instead of executing
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				cmdOpts = &Options{}
+				cmdOpts.Force, _ = cmd.Flags().GetBool("force")
+				return nil
+			}
+
+			// Cobra hack-around for help flag
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			// Parse arguments
+			argv := testutil.SplitArgs(tt.input)
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOpts.Force, cmdOpts.Force)
+		})
+	}
+}
+
+func TestCmd_Properties(t *testing.T) {
+	f := &cmdutil.Factory{}
+	cmd := NewCmd(f)
+
+	// Test command basics
+	require.Equal(t, "prune [OPTIONS]", cmd.Use)
+	require.Empty(t, cmd.Aliases)
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+	require.NotEmpty(t, cmd.Example)
+	require.NotNil(t, cmd.RunE)
+
+	// Test flags exist
+	require.NotNil(t, cmd.Flags().Lookup("force"))
+
+	// Test shorthand flags
+	require.NotNil(t, cmd.Flags().ShorthandLookup("f"))
+}

--- a/pkg/cmd/network/remove/remove.go
+++ b/pkg/cmd/network/remove/remove.go
@@ -1,0 +1,77 @@
+// Package remove provides the network remove command.
+package remove
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// Options holds options for the remove command.
+type Options struct {
+	Force bool
+}
+
+// NewCmd creates the network remove command.
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:     "remove NETWORK [NETWORK...]",
+		Aliases: []string{"rm"},
+		Short:   "Remove one or more networks",
+		Long: `Removes one or more clawker-managed networks.
+
+Only removes networks that are not currently in use by any container.
+Containers must be disconnected from the network before it can be removed.
+
+Note: Only clawker-managed networks can be removed with this command.`,
+		Example: `  # Remove a network
+  clawker network remove mynetwork
+
+  # Remove multiple networks
+  clawker network rm mynetwork1 mynetwork2
+
+  # Force remove (future: disconnect containers first)
+  clawker network remove --force mynetwork`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(f, opts, args)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force removal (reserved for future use)")
+
+	return cmd
+}
+
+func run(_ *cmdutil.Factory, _ *Options, networks []string) error {
+	ctx := context.Background()
+
+	// Connect to Docker
+	client, err := docker.NewClient(ctx)
+	if err != nil {
+		cmdutil.HandleError(err)
+		return err
+	}
+	defer client.Close()
+
+	var errs []error
+	for _, name := range networks {
+		if err := client.NetworkRemove(ctx, name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove network %q: %w", name, err))
+			cmdutil.HandleError(err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Removed: %s\n", name)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to remove %d network(s)", len(errs))
+	}
+	return nil
+}

--- a/pkg/cmd/network/remove/remove_test.go
+++ b/pkg/cmd/network/remove/remove_test.go
@@ -1,0 +1,112 @@
+package remove
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/schmitthub/clawker/pkg/cmd/testutil"
+	"github.com/schmitthub/clawker/pkg/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantOpts Options
+		wantArgs []string
+		wantErr  bool
+	}{
+		{
+			name:     "single network",
+			input:    "mynetwork",
+			wantOpts: Options{},
+			wantArgs: []string{"mynetwork"},
+		},
+		{
+			name:     "multiple networks",
+			input:    "mynetwork1 mynetwork2",
+			wantOpts: Options{},
+			wantArgs: []string{"mynetwork1", "mynetwork2"},
+		},
+		{
+			name:     "force flag",
+			input:    "-f mynetwork",
+			wantOpts: Options{Force: true},
+			wantArgs: []string{"mynetwork"},
+		},
+		{
+			name:     "force flag long",
+			input:    "--force mynetwork",
+			wantOpts: Options{Force: true},
+			wantArgs: []string{"mynetwork"},
+		},
+		{
+			name:    "no arguments",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &cmdutil.Factory{}
+
+			var cmdOpts *Options
+			var cmdArgs []string
+			cmd := NewCmd(f)
+
+			// Override RunE to capture options instead of executing
+			cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				cmdOpts = &Options{}
+				cmdOpts.Force, _ = cmd.Flags().GetBool("force")
+				cmdArgs = args
+				return nil
+			}
+
+			// Cobra hack-around for help flag
+			cmd.Flags().BoolP("help", "x", false, "")
+
+			// Parse arguments
+			argv := testutil.SplitArgs(tt.input)
+
+			cmd.SetArgs(argv)
+			cmd.SetIn(&bytes.Buffer{})
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+
+			_, err := cmd.ExecuteC()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOpts.Force, cmdOpts.Force)
+			require.Equal(t, tt.wantArgs, cmdArgs)
+		})
+	}
+}
+
+func TestCmd_Properties(t *testing.T) {
+	f := &cmdutil.Factory{}
+	cmd := NewCmd(f)
+
+	// Test command basics
+	require.Equal(t, "remove NETWORK [NETWORK...]", cmd.Use)
+	require.Contains(t, cmd.Aliases, "rm")
+	require.NotEmpty(t, cmd.Short)
+	require.NotEmpty(t, cmd.Long)
+	require.NotEmpty(t, cmd.Example)
+	require.NotNil(t, cmd.RunE)
+
+	// Test flags exist
+	require.NotNil(t, cmd.Flags().Lookup("force"))
+
+	// Test shorthand flags
+	require.NotNil(t, cmd.Flags().ShorthandLookup("f"))
+
+	// Test args validation
+	require.NotNil(t, cmd.Args)
+}


### PR DESCRIPTION
## Summary
- Add 5 Docker CLI-compatible network management subcommands: `list`, `inspect`, `create`, `remove`, `prune`
- All commands use `internal/docker.Client` and follow patterns from volume subcommands
- Includes comprehensive unit tests for all commands

## Test plan
- [x] `go test ./pkg/cmd/network/...` - All unit tests pass
- [x] `go test ./...` - Full test suite passes
- [x] `go build ./cmd/clawker` - Binary builds successfully
- [x] `./bin/clawker network --help` - Shows all subcommands
- [ ] Manual testing with Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)