### PR TITLE
Fixed use of old methods. cleaned up client imports

### DIFF
--- a/.serena/memories/current_session_status.md
+++ b/.serena/memories/current_session_status.md
@@ -1,0 +1,42 @@
+# Current Session Status - COMPLETED
+
+## Last Task: Docker Client Import Cleanup
+**Status: COMPLETED**
+
+The architectural layering cleanup for Docker client imports is fully complete.
+
+### What Was Done
+1. Created `pkg/whail/types.go` with type aliases for Docker SDK types
+2. Created `internal/docker/types.go` re-exporting types from whail
+3. Updated all production files to follow the layering:
+   - `github.com/moby/moby/client` → only in `pkg/whail` and `internal/testutil`
+   - `pkg/whail` → only imported by `internal/docker`
+   - All pkg/cmd/*, pkg/cmdutil/*, internal/term/ → use `internal/docker`
+
+4. Key files updated in this session:
+   - `pkg/cmdutil/resolve.go` - Changed client.Filters/ImageListOptions to docker.*
+   - `pkg/cmdutil/output.go` - Changed whail.DockerError to docker.DockerError
+   - `internal/term/pty.go` - Changed client.HijackedResponse to docker.HijackedResponse
+   - `internal/docker/types.go` - Added DockerError type alias
+
+### Verification
+- ✅ `go build ./...` succeeds
+- ✅ `go test ./...` all unit tests pass
+- ✅ No moby/client imports outside allowed locations (verified with grep)
+- ✅ No pkg/whail imports outside internal/docker (verified with grep)
+
+### Memory Updated
+- `docker_client_import_cleanup_status` - Marked as COMPLETED with full details
+
+### No Pending Work
+All tasks from the todo list are completed. No uncommitted critical changes.
+
+### Git Status at Session End
+Branch: a/e2e-fixes
+Modified files (from cleanup work):
+- pkg/whail/types.go
+- internal/docker/types.go
+- internal/docker/client.go, labels.go, volume.go
+- Multiple pkg/cmd/* files
+- pkg/cmdutil/resolve.go, output.go
+- internal/term/pty.go

--- a/.serena/memories/docker_client_import_cleanup_status.md
+++ b/.serena/memories/docker_client_import_cleanup_status.md
@@ -1,0 +1,68 @@
+# Docker Client Import Cleanup - COMPLETED
+
+## Task Overview
+Cleaned up Docker client import violations to enforce the architectural layering:
+- **`pkg/whail`** - The ONLY package allowed to import `github.com/moby/moby/client`
+- **`internal/docker`** - The ONLY package that should import `pkg/whail`
+- **All other packages** - Use `internal/docker` exclusively
+
+## Implementation
+
+### Type Aliases Created
+
+**`pkg/whail/types.go`** - Type aliases for Docker SDK types:
+- Filters, ContainerAttachOptions, ContainerListOptions, ContainerLogsOptions
+- ContainerRemoveOptions, SDKContainerCreateOptions, ContainerInspectResult
+- ExecCreateOptions, ExecStartOptions, ExecAttachOptions, ExecResizeOptions
+- CopyToContainerOptions, CopyFromContainerOptions
+- ImageListOptions, ImageRemoveOptions, ImageBuildOptions, ImagePullOptions
+- VolumeCreateOptions, NetworkCreateOptions, NetworkInspectOptions
+- HijackedResponse
+
+Note: `SDKContainerCreateOptions` is for raw SDK API bypass (e.g., in volume.go for temp containers).
+`ContainerCreateOptions` is whail's custom struct with clawker-specific fields.
+
+**`internal/docker/types.go`** - Re-exports from whail plus whail-specific types:
+- All whail type aliases
+- ContainerStartOptions, EnsureNetworkOptions, Labels (whail-specific)
+- DockerError (error type)
+
+### Files Updated
+
+#### internal/docker (use whail types)
+- `client.go` - Changed client.* to whail.*
+- `labels.go` - Changed client.Filters to whail.Filters  
+- `volume.go` - Changed to whail types; uses SDKContainerCreateOptions for raw API calls
+
+#### pkg/cmd/* (use internal/docker types)
+- container: exec.go, attach.go, logs.go, cp.go, run.go, start.go, inspect.go, create.go, restart.go
+- volume: create.go
+- network: create.go, inspect.go
+- image: list.go, remove.go
+- monitor: up.go
+
+#### Utility files
+- `pkg/cmdutil/resolve.go` - docker.Filters, docker.ImageListOptions
+- `pkg/cmdutil/output.go` - docker.DockerError
+- `internal/term/pty.go` - docker.HijackedResponse
+
+### Test Files Exception
+Test files (e.g., `*_integration_test.go`) may import `github.com/moby/moby/client` directly
+when using `testutil.NewRawDockerClient()`, which returns a raw `*client.Client`. This is
+acceptable because tests need low-level access for setup/fixtures.
+
+## Verification Commands
+```bash
+# Verify moby/client ONLY in pkg/whail and internal/testutil (excluding test files)
+grep -r "github.com/moby/moby/client" . --include="*.go" | grep -v "pkg/whail" | grep -v "internal/testutil" | grep -v "_test.go"
+
+# Verify pkg/whail ONLY in internal/docker
+grep -r "schmitthub/clawker/pkg/whail" internal/docker --include="*.go"
+
+# Build and test
+go build ./...
+go test ./...
+```
+
+## Status: COMPLETED
+All production code now follows the architectural layering. Build and tests pass.

--- a/.serena/memories/key_learnings.md
+++ b/.serena/memories/key_learnings.md
@@ -6,7 +6,7 @@
   - Once subcommands are added, they move to "Available Commands"
   - Commands use positional args for container names (Docker-like)
   - Helper function `splitArgs` shared across test files in same package
-  - Commands use `internal/docker.Client` instead of legacy `internal/engine`
+  - Commands MUST USE `internal/docker.Client` instead of legacy `internal/engine` or `github.com/moby/moby/client.Client`
   - Terminal visual state (alternate screen buffer, cursor visibility, text attributes) is separate from termios mode. `term.Restore()` sends ANSI escape sequences (`\x1b[?1049l\x1b[?25h\x1b[0m\x1b(B`) to reset visual state before restoring termios after container detach/exit.
   - Never bypass whail - scaffold with TODO if method missing
   - Stats streaming requires goroutines for concurrent container stat collection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,8 @@ CONTAINER                              HOST PROXY (:18374)               HOST
 ## Code Style
 
 - **Logging**: `zerolog` only (never `fmt.Print` for debug)
+- **Whail Client Enforcement**: No go package should be using the `github.com/moby/moby/client` library directly except for `@pkg/whail`. And no go package should be using `@pkg/whail` directly except for `@internal/docker`
+- **Whail Client is a Decorator**: `@pkg/whail` decorates `github.com/moby/moby/client` and exposes the same interface so higher-level code can remain agnostic. All of the methods offered through `github.com/moby/moby/client` are available through `@pkg/whail` regardless of whether they are explicitly defined in `@pkg/whail` or not.
 - **User output**: `cmdutil.PrintError()`, `cmdutil.PrintNextSteps()` to stderr
 - **Data output**: stdout only for scripting (e.g., `ls` table)
 - **Errors**: `cmdutil.HandleError(err)` for Docker errors

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -11,7 +11,6 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/client"
 	"github.com/schmitthub/clawker/pkg/logger"
 	"github.com/schmitthub/clawker/pkg/whail"
 )
@@ -51,8 +50,8 @@ func (c *Client) Close() error {
 func (c *Client) IsMonitoringActive(ctx context.Context) bool {
 	// Use raw API client to bypass managed label filtering
 	// since monitoring containers aren't clawker-managed
-	f := client.Filters{}.Add("name", "otel-collector").Add("status", "running")
-	result, err := c.APIClient.ContainerList(ctx, client.ContainerListOptions{
+	f := whail.Filters{}.Add("name", "otel-collector").Add("status", "running")
+	result, err := c.APIClient.ContainerList(ctx, whail.ContainerListOptions{
 		Filters: f,
 	})
 	if err != nil {
@@ -105,7 +104,7 @@ type BuildImageOpts struct {
 // BuildImage builds a Docker image from a build context.
 // It processes the build output and logs progress.
 func (c *Client) BuildImage(ctx context.Context, buildContext io.Reader, opts BuildImageOpts) error {
-	options := client.ImageBuildOptions{
+	options := whail.ImageBuildOptions{
 		Tags:           opts.Tags,
 		Dockerfile:     opts.Dockerfile,
 		Remove:         true,
@@ -242,7 +241,7 @@ type Container struct {
 
 // ListContainers returns all clawker-managed containers.
 func (c *Client) ListContainers(ctx context.Context, includeAll bool) ([]Container, error) {
-	opts := client.ContainerListOptions{
+	opts := whail.ContainerListOptions{
 		All:     includeAll,
 		Filters: ClawkerFilter(),
 	}
@@ -257,7 +256,7 @@ func (c *Client) ListContainers(ctx context.Context, includeAll bool) ([]Contain
 
 // ListContainersByProject returns containers for a specific project.
 func (c *Client) ListContainersByProject(ctx context.Context, project string, includeAll bool) ([]Container, error) {
-	opts := client.ContainerListOptions{
+	opts := whail.ContainerListOptions{
 		All:     includeAll,
 		Filters: ProjectFilter(project),
 	}

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -5,7 +5,7 @@ package docker
 import (
 	"time"
 
-	"github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/pkg/whail"
 )
 
 // Clawker label keys for managed resources.
@@ -82,20 +82,20 @@ func NetworkLabels() map[string]string {
 }
 
 // ClawkerFilter returns Docker filter for listing all clawker resources.
-func ClawkerFilter() client.Filters {
-	return client.Filters{}.Add("label", LabelManaged+"="+ManagedLabelValue)
+func ClawkerFilter() whail.Filters {
+	return whail.Filters{}.Add("label", LabelManaged+"="+ManagedLabelValue)
 }
 
 // ProjectFilter returns Docker filter for a specific project.
-func ProjectFilter(project string) client.Filters {
-	return client.Filters{}.
+func ProjectFilter(project string) whail.Filters {
+	return whail.Filters{}.
 		Add("label", LabelManaged+"="+ManagedLabelValue).
 		Add("label", LabelProject+"="+project)
 }
 
 // AgentFilter returns Docker filter for a specific agent within a project.
-func AgentFilter(project, agent string) client.Filters {
-	return client.Filters{}.
+func AgentFilter(project, agent string) whail.Filters {
+	return whail.Filters{}.
 		Add("label", LabelManaged+"="+ManagedLabelValue).
 		Add("label", LabelProject+"="+project).
 		Add("label", LabelAgent+"="+agent)

--- a/internal/docker/types.go
+++ b/internal/docker/types.go
@@ -1,0 +1,59 @@
+// Package docker re-exports types from whail for use by commands.
+// This allows commands to import internal/docker as their single Docker interface.
+package docker
+
+import "github.com/schmitthub/clawker/pkg/whail"
+
+// Type aliases re-exported from whail.
+// Commands should use these types rather than importing whail directly.
+type (
+	// Filters for filtering resources.
+	Filters = whail.Filters
+
+	// Container operation options.
+	// ContainerCreateOptions is whail's custom struct with clawker-specific fields.
+	// SDKContainerCreateOptions is the raw Docker SDK type for direct API calls.
+	ContainerAttachOptions    = whail.ContainerAttachOptions
+	ContainerListOptions      = whail.ContainerListOptions
+	ContainerLogsOptions      = whail.ContainerLogsOptions
+	ContainerRemoveOptions    = whail.ContainerRemoveOptions
+	ContainerCreateOptions    = whail.ContainerCreateOptions
+	SDKContainerCreateOptions = whail.SDKContainerCreateOptions
+
+	// Container result types.
+	ContainerInspectResult = whail.ContainerInspectResult
+
+	// Whail-specific container types.
+	ContainerStartOptions = whail.ContainerStartOptions
+	EnsureNetworkOptions  = whail.EnsureNetworkOptions
+	Labels                = whail.Labels
+
+	// Exec operation options.
+	ExecCreateOptions = whail.ExecCreateOptions
+	ExecStartOptions  = whail.ExecStartOptions
+	ExecAttachOptions = whail.ExecAttachOptions
+	ExecResizeOptions = whail.ExecResizeOptions
+
+	// Copy operation options.
+	CopyToContainerOptions   = whail.CopyToContainerOptions
+	CopyFromContainerOptions = whail.CopyFromContainerOptions
+
+	// Image operation options.
+	ImageListOptions   = whail.ImageListOptions
+	ImageRemoveOptions = whail.ImageRemoveOptions
+	ImageBuildOptions  = whail.ImageBuildOptions
+	ImagePullOptions   = whail.ImagePullOptions
+
+	// Volume operation options.
+	VolumeCreateOptions = whail.VolumeCreateOptions
+
+	// Network operation options.
+	NetworkCreateOptions  = whail.NetworkCreateOptions
+	NetworkInspectOptions = whail.NetworkInspectOptions
+
+	// Connection types.
+	HijackedResponse = whail.HijackedResponse
+
+	// Error types.
+	DockerError = whail.DockerError
+)

--- a/internal/term/pty.go
+++ b/internal/term/pty.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/logger"
 )
 
@@ -86,7 +86,7 @@ func (p *PTYHandler) resetVisualStateUnlocked() {
 }
 
 // Stream handles bidirectional I/O between local terminal and container
-func (p *PTYHandler) Stream(ctx context.Context, hijacked client.HijackedResponse) error {
+func (p *PTYHandler) Stream(ctx context.Context, hijacked docker.HijackedResponse) error {
 	defer hijacked.Close()
 
 	outputDone := make(chan struct{})
@@ -127,7 +127,7 @@ func (p *PTYHandler) Stream(ctx context.Context, hijacked client.HijackedRespons
 // StreamWithResize handles bidirectional I/O with terminal resize support
 func (p *PTYHandler) StreamWithResize(
 	ctx context.Context,
-	hijacked client.HijackedResponse,
+	hijacked docker.HijackedResponse,
 	resizeFunc func(height, width uint) error,
 ) error {
 	defer hijacked.Close()

--- a/pkg/cmd/container/attach/attach.go
+++ b/pkg/cmd/container/attach/attach.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/term"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -108,7 +108,7 @@ func run(f *cmdutil.Factory, opts *Options, args []string) error {
 	hasTTY := info.Container.Config.Tty
 
 	// Create attach options
-	attachOpts := dockerclient.ContainerAttachOptions{
+	attachOpts := docker.ContainerAttachOptions{
 		Stream: true,
 		Stdin:  !opts.NoStdin,
 		Stdout: true,

--- a/pkg/cmd/container/cp/cp.go
+++ b/pkg/cmd/container/cp/cp.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	dockerclient "github.com/moby/moby/client"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -202,7 +201,7 @@ func copyFromContainer(ctx context.Context, client *docker.Client, containerName
 	}
 
 	// Get tar archive from container
-	copyResult, err := client.CopyFromContainer(ctx, c.ID, dockerclient.CopyFromContainerOptions{SourcePath: srcPath})
+	copyResult, err := client.CopyFromContainer(ctx, c.ID, docker.CopyFromContainerOptions{SourcePath: srcPath})
 	if err != nil {
 		cmdutil.HandleError(err)
 		return err
@@ -231,7 +230,7 @@ func copyToContainer(ctx context.Context, client *docker.Client, containerName, 
 
 	// If source is stdin, read tar directly
 	if srcPath == "-" {
-		copyOpts := dockerclient.CopyToContainerOptions{
+		copyOpts := docker.CopyToContainerOptions{
 			DestinationPath:           dstPath,
 			Content:                   os.Stdin,
 			AllowOverwriteDirWithFile: true,
@@ -248,7 +247,7 @@ func copyToContainer(ctx context.Context, client *docker.Client, containerName, 
 	}
 
 	// Copy to container
-	copyOpts := dockerclient.CopyToContainerOptions{
+	copyOpts := docker.CopyToContainerOptions{
 		DestinationPath:           dstPath,
 		Content:                   tarReader,
 		AllowOverwriteDirWithFile: true,

--- a/pkg/cmd/container/create/create.go
+++ b/pkg/cmd/container/create/create.go
@@ -18,7 +18,6 @@ import (
 	"github.com/schmitthub/clawker/internal/workspace"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/schmitthub/clawker/pkg/logger"
-	"github.com/schmitthub/clawker/pkg/whail"
 	"github.com/spf13/cobra"
 )
 
@@ -246,13 +245,13 @@ func run(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	// Create container (whail injects managed labels and auto-connects to clawker-net)
-	resp, err := client.ContainerCreate(ctx, whail.ContainerCreateOptions{
+	resp, err := client.ContainerCreate(ctx, docker.ContainerCreateOptions{
 		Config:           containerConfig,
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkConfig,
 		Name:             containerName,
-		ExtraLabels:      whail.Labels{extraLabels},
-		EnsureNetwork: &whail.EnsureNetworkOptions{
+		ExtraLabels:      docker.Labels{extraLabels},
+		EnsureNetwork: &docker.EnsureNetworkOptions{
 			Name: docker.NetworkName,
 		},
 	})

--- a/pkg/cmd/container/exec/exec.go
+++ b/pkg/cmd/container/exec/exec.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/moby/moby/api/pkg/stdcopy"
-	dockerclient "github.com/moby/moby/client"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/term"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
@@ -155,7 +154,7 @@ func run(f *cmdutil.Factory, opts *Options, containerName string, command []stri
 	}
 
 	// Create exec configuration
-	execConfig := dockerclient.ExecCreateOptions{
+	execConfig := docker.ExecCreateOptions{
 		AttachStdin:  opts.Interactive,
 		AttachStdout: true,
 		AttachStderr: true,
@@ -183,7 +182,7 @@ func run(f *cmdutil.Factory, opts *Options, containerName string, command []stri
 
 	// If detached, just start and return
 	if opts.Detach {
-		_, err := client.ExecStart(ctx, execID, dockerclient.ExecStartOptions{
+		_, err := client.ExecStart(ctx, execID, docker.ExecStartOptions{
 			Detach: true,
 			TTY:    opts.TTY,
 		})
@@ -206,7 +205,7 @@ func run(f *cmdutil.Factory, opts *Options, containerName string, command []stri
 	}
 
 	// Attach to exec
-	attachOpts := dockerclient.ExecAttachOptions{
+	attachOpts := docker.ExecAttachOptions{
 		TTY: opts.TTY,
 	}
 
@@ -221,7 +220,7 @@ func run(f *cmdutil.Factory, opts *Options, containerName string, command []stri
 	if opts.TTY && pty != nil {
 		// Use PTY handler for TTY mode with resize support
 		resizeFunc := func(height, width uint) error {
-			_, err := client.ExecResize(ctx, execID, dockerclient.ExecResizeOptions{
+			_, err := client.ExecResize(ctx, execID, docker.ExecResizeOptions{
 				Height: height,
 				Width:  width,
 			})

--- a/pkg/cmd/container/exec/exec_integration_test.go
+++ b/pkg/cmd/container/exec/exec_integration_test.go
@@ -391,9 +391,9 @@ func TestExecIntegration_ErrorCases(t *testing.T) {
 		containerName := h.ContainerName(agentName)
 
 		// Create and start a container
-		resp, err := rawClient.ContainerCreate(ctx, container.CreateOptions{
+		resp, err := rawClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 			Name: containerName,
-			ContainerConfig: &container.Config{
+			Config: &container.Config{
 				Image: imageTag,
 				Cmd:   []string{"sleep", "300"},
 				Labels: testutil.AddClawkerLabels(map[string]string{
@@ -402,7 +402,7 @@ func TestExecIntegration_ErrorCases(t *testing.T) {
 			},
 		})
 		require.NoError(t, err, "failed to create container")
-		err = rawClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
+		_, err = rawClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{})
 		require.NoError(t, err, "failed to start container")
 
 		// Wait for container to be ready
@@ -439,9 +439,9 @@ func TestExecIntegration_ErrorCases(t *testing.T) {
 		containerName := h.ContainerName(agentName)
 
 		// Create a container but don't start it
-		_, err := rawClient.ContainerCreate(ctx, container.CreateOptions{
+		_, err := rawClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 			Name: containerName,
-			ContainerConfig: &container.Config{
+			Config: &container.Config{
 				Image: imageTag,
 				Cmd:   []string{"sleep", "300"},
 				Labels: testutil.AddClawkerLabels(map[string]string{
@@ -513,9 +513,9 @@ func TestExecIntegration_ScriptExecution(t *testing.T) {
 	containerName := h.ContainerName(agentName)
 
 	// Create and start a container
-	resp, err := rawClient.ContainerCreate(ctx, container.CreateOptions{
+	resp, err := rawClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Name: containerName,
-		ContainerConfig: &container.Config{
+		Config: &container.Config{
 			Image: imageTag,
 			Cmd:   []string{"sleep", "300"},
 			Labels: testutil.AddClawkerLabels(map[string]string{
@@ -524,7 +524,7 @@ func TestExecIntegration_ScriptExecution(t *testing.T) {
 		},
 	})
 	require.NoError(t, err, "failed to create container")
-	err = rawClient.ContainerStart(ctx, resp.ID, container.StartOptions{})
+	_, err = rawClient.ContainerStart(ctx, resp.ID, client.ContainerStartOptions{})
 	require.NoError(t, err, "failed to start container")
 
 	// Wait for container to be ready
@@ -548,7 +548,7 @@ chmod +x /tmp/test-script.sh`}
 	}
 	execResp, err := rawClient.ExecCreate(ctx, resp.ID, execConfig)
 	require.NoError(t, err)
-	err = rawClient.ExecStart(ctx, execResp.ID, client.ExecStartOptions{})
+	_, err = rawClient.ExecStart(ctx, execResp.ID, client.ExecStartOptions{})
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/pkg/cmd/container/inspect/inspect.go
+++ b/pkg/cmd/container/inspect/inspect.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +79,7 @@ func runInspect(f *cmdutil.Factory, opts *InspectOptions, args []string) error {
 		return err
 	}
 
-	var results []client.ContainerInspectResult
+	var results []docker.ContainerInspectResult
 	var errs []error
 
 	for _, name := range containers {
@@ -133,7 +133,7 @@ func outputJSON(data any) error {
 // outputFormatted outputs results using a Go template format string.
 // Templates execute against the Container field (InspectResponse) for Docker CLI compatibility.
 // This means templates like '{{.State.Status}}' work as expected.
-func outputFormatted(format string, results []client.ContainerInspectResult) error {
+func outputFormatted(format string, results []docker.ContainerInspectResult) error {
 	tmpl, err := template.New("format").Parse(format)
 	if err != nil {
 		return fmt.Errorf("invalid format template: %w", err)

--- a/pkg/cmd/container/logs/logs.go
+++ b/pkg/cmd/container/logs/logs.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -98,7 +98,7 @@ func runLogs(f *cmdutil.Factory, opts *LogsOptions, args []string) error {
 	}
 
 	// Build log options
-	logOpts := dockerclient.ContainerLogsOptions{
+	logOpts := docker.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Follow:     opts.Follow,

--- a/pkg/cmd/container/restart/restart.go
+++ b/pkg/cmd/container/restart/restart.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
-	"github.com/schmitthub/clawker/pkg/whail"
 	"github.com/spf13/cobra"
 )
 
@@ -111,9 +110,9 @@ func restartContainer(ctx context.Context, client *docker.Client, name string, o
 		if _, err := client.ContainerKill(ctx, c.ID, opts.Signal); err != nil {
 			return err
 		}
-		_, err = client.ContainerStart(ctx, whail.ContainerStartOptions{
+		_, err = client.ContainerStart(ctx, docker.ContainerStartOptions{
 			ContainerID: c.ID,
-			EnsureNetwork: &whail.EnsureNetworkOptions{
+			EnsureNetwork: &docker.EnsureNetworkOptions{
 				Name: docker.NetworkName,
 			},
 		})

--- a/pkg/cmd/container/run/run.go
+++ b/pkg/cmd/container/run/run.go
@@ -15,14 +15,12 @@ import (
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/strslice"
-	dockerclient "github.com/moby/moby/client"
 	"github.com/schmitthub/clawker/internal/config"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/term"
 	"github.com/schmitthub/clawker/internal/workspace"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/schmitthub/clawker/pkg/logger"
-	"github.com/schmitthub/clawker/pkg/whail"
 	"github.com/spf13/cobra"
 )
 
@@ -266,13 +264,13 @@ func run(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	// Create container (whail injects managed labels and auto-connects to clawker-net)
-	resp, err := client.ContainerCreate(ctx, whail.ContainerCreateOptions{
+	resp, err := client.ContainerCreate(ctx, docker.ContainerCreateOptions{
 		Config:           containerConfig,
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkConfig,
 		Name:             containerName,
-		ExtraLabels:      whail.Labels{extraLabels},
-		EnsureNetwork: &whail.EnsureNetworkOptions{
+		ExtraLabels:      docker.Labels{extraLabels},
+		EnsureNetwork: &docker.EnsureNetworkOptions{
 			Name: docker.NetworkName,
 		},
 	})
@@ -289,7 +287,7 @@ func run(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	// Start the container
-	if _, err := client.ContainerStart(ctx, whail.ContainerStartOptions{ContainerID: containerID}); err != nil {
+	if _, err := client.ContainerStart(ctx, docker.ContainerStartOptions{ContainerID: containerID}); err != nil {
 		cmdutil.HandleError(err)
 		return err
 	}
@@ -307,7 +305,7 @@ func run(f *cmdutil.Factory, opts *Options) error {
 // attachAndWait attaches to a running container and waits for it to exit.
 func attachAndWait(ctx context.Context, client *docker.Client, containerID string, opts *Options) error {
 	// Create attach options
-	attachOpts := dockerclient.ContainerAttachOptions{
+	attachOpts := docker.ContainerAttachOptions{
 		Stream: true,
 		Stdin:  opts.Stdin,
 		Stdout: true,

--- a/pkg/cmd/container/start/start.go
+++ b/pkg/cmd/container/start/start.go
@@ -8,12 +8,10 @@ import (
 
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
-	dockerclient "github.com/moby/moby/client"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/term"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/schmitthub/clawker/pkg/logger"
-	"github.com/schmitthub/clawker/pkg/whail"
 	"github.com/spf13/cobra"
 )
 
@@ -134,9 +132,9 @@ func startContainer(ctx context.Context, client *docker.Client, name string, opt
 	}
 
 	// Start the container (ensuring it's connected to clawker-net)
-	_, err = client.ContainerStart(ctx, whail.ContainerStartOptions{
+	_, err = client.ContainerStart(ctx, docker.ContainerStartOptions{
 		ContainerID: c.ID,
-		EnsureNetwork: &whail.EnsureNetworkOptions{
+		EnsureNetwork: &docker.EnsureNetworkOptions{
 			Name: docker.NetworkName,
 		},
 	})
@@ -174,7 +172,7 @@ func attachAfterStart(ctx context.Context, client *docker.Client, containerID st
 	hasTTY := info.Container.Config.Tty
 
 	// Create attach options
-	attachOpts := dockerclient.ContainerAttachOptions{
+	attachOpts := docker.ContainerAttachOptions{
 		Stream: true,
 		Stdin:  opts.Interactive,
 		Stdout: true,

--- a/pkg/cmd/image/list/list.go
+++ b/pkg/cmd/image/list/list.go
@@ -9,7 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -65,7 +65,7 @@ func run(f *cmdutil.Factory, opts *Options) error {
 	}
 
 	// List images
-	listOpts := dockerclient.ImageListOptions{
+	listOpts := docker.ImageListOptions{
 		All: opts.All,
 	}
 	images, err := client.ImageList(ctx, listOpts)

--- a/pkg/cmd/image/remove/remove.go
+++ b/pkg/cmd/image/remove/remove.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -67,7 +67,7 @@ func run(f *cmdutil.Factory, opts *Options, images []string) error {
 		return err
 	}
 
-	removeOpts := dockerclient.ImageRemoveOptions{
+	removeOpts := docker.ImageRemoveOptions{
 		Force:         opts.Force,
 		PruneChildren: !opts.NoPrune,
 	}

--- a/pkg/cmd/monitor/up.go
+++ b/pkg/cmd/monitor/up.go
@@ -11,7 +11,6 @@ import (
 	internalmonitor "github.com/schmitthub/clawker/internal/monitor"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/schmitthub/clawker/pkg/logger"
-	"github.com/schmitthub/clawker/pkg/whail"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +74,7 @@ func runUp(f *cmdutil.Factory, opts *upOptions) error {
 	}
 	defer client.Close()
 
-	if _, err := client.EnsureNetwork(ctx, whail.EnsureNetworkOptions{
+	if _, err := client.EnsureNetwork(ctx, docker.EnsureNetworkOptions{
 		Name: config.ClawkerNetwork,
 	}); err != nil {
 		return fmt.Errorf("failed to ensure Docker network '%s': %w", config.ClawkerNetwork, err)

--- a/pkg/cmd/network/create/create.go
+++ b/pkg/cmd/network/create/create.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +72,7 @@ func run(f *cmdutil.Factory, opts *Options, name string) error {
 	}
 
 	// Build create options
-	createOpts := dockerclient.NetworkCreateOptions{
+	createOpts := docker.NetworkCreateOptions{
 		Driver:     opts.Driver,
 		Options:    parseDriverOpts(opts.DriverOpts),
 		Labels:     parseLabels(opts.Labels),

--- a/pkg/cmd/network/inspect/inspect.go
+++ b/pkg/cmd/network/inspect/inspect.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +63,7 @@ func run(f *cmdutil.Factory, opts *Options, networks []string) error {
 
 	for _, name := range networks {
 		// Inspect the network
-		net, err := client.NetworkInspect(ctx, name, dockerclient.NetworkInspectOptions{
+		net, err := client.NetworkInspect(ctx, name, docker.NetworkInspectOptions{
 			Verbose: opts.Verbose,
 		})
 		if err != nil {

--- a/pkg/cmd/volume/create/create.go
+++ b/pkg/cmd/volume/create/create.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 
-	dockerclient "github.com/moby/moby/client"
+	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -70,7 +70,7 @@ func run(f *cmdutil.Factory, opts *Options, name string) error {
 	}
 
 	// Build create options
-	createOpts := dockerclient.VolumeCreateOptions{
+	createOpts := docker.VolumeCreateOptions{
 		Name:       name,
 		Driver:     opts.Driver,
 		DriverOpts: parseDriverOpts(opts.DriverOpts),

--- a/pkg/cmdutil/output.go
+++ b/pkg/cmdutil/output.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/schmitthub/clawker/pkg/whail"
+	"github.com/schmitthub/clawker/internal/docker"
 )
 
 // HandleError prints an error to stderr with user-friendly formatting.
@@ -16,7 +16,7 @@ func HandleError(err error) {
 		return
 	}
 
-	if dockerErr, ok := err.(*whail.DockerError); ok {
+	if dockerErr, ok := err.(*docker.DockerError); ok {
 		fmt.Fprint(os.Stderr, dockerErr.FormatUserError())
 		return
 	}

--- a/pkg/cmdutil/resolve.go
+++ b/pkg/cmdutil/resolve.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/moby/moby/client"
 	"github.com/schmitthub/clawker/internal/config"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/pkg/logger"
@@ -39,11 +38,11 @@ func FindProjectImage(ctx context.Context, dockerClient *docker.Client, project 
 
 	// Build filter for project label
 	// Images built by clawker have com.clawker.project=<project>
-	f := client.Filters{}.
+	f := docker.Filters{}.
 		Add("label", docker.LabelManaged+"="+docker.ManagedLabelValue).
 		Add("label", docker.LabelProject+"="+project)
 
-	result, err := dockerClient.ImageList(ctx, client.ImageListOptions{
+	result, err := dockerClient.ImageList(ctx, docker.ImageListOptions{
 		Filters: f,
 	})
 	if err != nil {

--- a/pkg/whail/types.go
+++ b/pkg/whail/types.go
@@ -1,0 +1,50 @@
+// Package whail re-exports Docker SDK types as aliases.
+// This allows higher-level packages to use these types without importing moby/client directly.
+package whail
+
+import "github.com/moby/moby/client"
+
+// Type aliases for Docker SDK types.
+// These allow packages to use whail as their single import for Docker interactions.
+type (
+	// Filters wraps Docker client.Filters for filtering resources.
+	Filters = client.Filters
+
+	// Container operation options.
+	// Note: ContainerCreateOptions is a custom whail struct defined in container.go.
+	// SDKContainerCreateOptions is the raw Docker SDK type for direct API calls.
+	ContainerAttachOptions    = client.ContainerAttachOptions
+	ContainerListOptions      = client.ContainerListOptions
+	ContainerLogsOptions      = client.ContainerLogsOptions
+	ContainerRemoveOptions    = client.ContainerRemoveOptions
+	SDKContainerCreateOptions = client.ContainerCreateOptions
+
+	// Container result types.
+	ContainerInspectResult = client.ContainerInspectResult
+
+	// Exec operation options.
+	ExecCreateOptions = client.ExecCreateOptions
+	ExecStartOptions  = client.ExecStartOptions
+	ExecAttachOptions = client.ExecAttachOptions
+	ExecResizeOptions = client.ExecResizeOptions
+
+	// Copy operation options.
+	CopyToContainerOptions   = client.CopyToContainerOptions
+	CopyFromContainerOptions = client.CopyFromContainerOptions
+
+	// Image operation options.
+	ImageListOptions   = client.ImageListOptions
+	ImageRemoveOptions = client.ImageRemoveOptions
+	ImageBuildOptions  = client.ImageBuildOptions
+	ImagePullOptions   = client.ImagePullOptions
+
+	// Volume operation options.
+	VolumeCreateOptions = client.VolumeCreateOptions
+
+	// Network operation options.
+	NetworkCreateOptions  = client.NetworkCreateOptions
+	NetworkInspectOptions = client.NetworkInspectOptions
+
+	// Connection types.
+	HijackedResponse = client.HijackedResponse
+)


### PR DESCRIPTION
- Finalize architectural layering for Docker client imports.
- Introduced `pkg/whail` for Docker SDK type aliases, restricting direct imports of `github.com/moby/moby/client`.
- Created `internal/docker` to re-export types from `whail`, ensuring all other packages use `internal/docker`.
- Updated multiple files across the codebase to adhere to the new import structure, replacing direct `client` usage with `whail` and `docker` types.
- Verified successful builds and tests, confirming no violations of the new import rules.
- Documented the cleanup process and verification steps in `current_session_status.md` and `docker_client_import_cleanup_status.md`.
