### PR TITLE
feat(version): wire build version to container environment

### DIFF
--- a/internal/bundler/assets/statusline.sh
+++ b/internal/bundler/assets/statusline.sh
@@ -100,7 +100,7 @@ if [ "$STYLE" != "null" ] && [ "$STYLE" != "default" ]; then
 fi
 
 # Clawker info
-output=$(printf "${GRAY}Clawker v%s |${NC}" "${CLAWKER_VERSION:-0.1.0}")
+output=$(printf "${GRAY}Clawker v%s |${NC}" "${CLAWKER_VERSION:-dev}")
 
 # Version - dim gray
 VERSION=$(get_version)

--- a/internal/cmd/container/shared/init.go
+++ b/internal/cmd/container/shared/init.go
@@ -25,6 +25,7 @@ import (
 type ContainerInitializer struct {
 	ios       *iostreams.IOStreams
 	tui       *tui.TUI
+	version   string
 	gitMgr    func() (*git.GitManager, error)
 	hostProxy func() *hostproxy.Manager
 }
@@ -34,6 +35,7 @@ func NewContainerInitializer(f *cmdutil.Factory) *ContainerInitializer {
 	return &ContainerInitializer{
 		ios:       f.IOStreams,
 		tui:       f.TUI,
+		version:   f.Version,
 		gitMgr:    f.GitManager,
 		hostProxy: f.HostProxy,
 	}
@@ -324,6 +326,7 @@ func (ci *ContainerInitializer) buildRuntimeEnv(cfg *config.Project, containerOp
 	}
 
 	envOpts := docker.RuntimeEnvOpts{
+		Version:         ci.version,
 		Project:         cfg.Project,
 		Agent:           agentName,
 		WorkspaceMode:   workspaceMode,

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -13,6 +13,7 @@ import (
 // Each field maps to a specific env var or category of env vars.
 type RuntimeEnvOpts struct {
 	// Clawker identity (consumed by statusline)
+	Version         string
 	Project         string
 	Agent           string
 	WorkspaceMode   string // "bind" or "snapshot"
@@ -59,6 +60,9 @@ func RuntimeEnv(opts RuntimeEnvOpts) ([]string, error) {
 	}
 	if opts.WorkspaceSource != "" {
 		m["CLAWKER_WORKSPACE_SOURCE"] = opts.WorkspaceSource
+	}
+	if opts.Version != "" {
+		m["CLAWKER_VERSION"] = opts.Version
 	}
 
 	// Base defaults: editor/visual

--- a/internal/docker/env_test.go
+++ b/internal/docker/env_test.go
@@ -308,6 +308,7 @@ func TestRuntimeEnv_FirewallDisabledNoIPRangeSources(t *testing.T) {
 
 func TestRuntimeEnv_ClawkerIdentity(t *testing.T) {
 	env, err := RuntimeEnv(RuntimeEnvOpts{
+		Version:         "0.5.0",
 		Project:         "myproject",
 		Agent:           "ralph",
 		WorkspaceMode:   "bind",
@@ -315,6 +316,7 @@ func TestRuntimeEnv_ClawkerIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	assert.Contains(t, env, "CLAWKER_VERSION=0.5.0")
 	assert.Contains(t, env, "CLAWKER_PROJECT=myproject")
 	assert.Contains(t, env, "CLAWKER_AGENT=ralph")
 	assert.Contains(t, env, "CLAWKER_WORKSPACE_MODE=bind")
@@ -455,4 +457,25 @@ func TestRuntimeEnv_ClawkerIdentityPartial(t *testing.T) {
 	assert.Contains(t, env, "CLAWKER_AGENT=ralph")
 	assert.Contains(t, env, "CLAWKER_WORKSPACE_MODE=bind")
 	assert.Contains(t, env, "CLAWKER_WORKSPACE_SOURCE=/tmp/orphaned-dir")
+}
+
+func TestRuntimeEnv_ClawkerVersion(t *testing.T) {
+	env, err := RuntimeEnv(RuntimeEnvOpts{Version: "1.2.3"})
+	require.NoError(t, err)
+	assert.Contains(t, env, "CLAWKER_VERSION=1.2.3")
+}
+
+func TestRuntimeEnv_ClawkerVersionDev(t *testing.T) {
+	env, err := RuntimeEnv(RuntimeEnvOpts{Version: "DEV"})
+	require.NoError(t, err)
+	assert.Contains(t, env, "CLAWKER_VERSION=DEV")
+}
+
+func TestRuntimeEnv_ClawkerVersionEmpty(t *testing.T) {
+	env, err := RuntimeEnv(RuntimeEnvOpts{})
+	require.NoError(t, err)
+	for _, e := range env {
+		assert.False(t, strings.HasPrefix(e, "CLAWKER_VERSION="),
+			"should not set CLAWKER_VERSION when empty")
+	}
 }


### PR DESCRIPTION
## Summary

- Thread `build.Version` through `Factory` → `ContainerInitializer` → `RuntimeEnvOpts` into the container as `CLAWKER_VERSION` env var, so the statusline displays the actual clawker version instead of the hardcoded `0.1.0` fallback
- Add `Version` field to `RuntimeEnvOpts` and emit it in the identity block of `RuntimeEnv()`
- Capture `f.Version` in `ContainerInitializer` and pass it through to env opts
- Update statusline shell fallback from `0.1.0` to `dev` to align with `build.Version`'s `DEV` default

## Test plan

- [x] `TestRuntimeEnv_ClawkerVersion` — version string set correctly
- [x] `TestRuntimeEnv_ClawkerVersionDev` — DEV default propagates
- [x] `TestRuntimeEnv_ClawkerVersionEmpty` — empty string omits env var
- [x] `TestRuntimeEnv_ClawkerIdentity` — updated to include version assertion
- [x] All 3660 unit tests pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)