### PR TITLE
refactor(hostproxy): DRY OAuth callback HTML with terminal-themed redesign

### DIFF
--- a/.serena/memories/html-preview-workflow.md
+++ b/.serena/memories/html-preview-workflow.md
@@ -5,7 +5,7 @@ When working inside a clawker container, you need to preview HTML files in the h
 The container has `host-open` (BROWSER env) which sends URLs to the host proxy, but:
 - `file://` URLs are rejected by the host proxy (only http/https allowed)
 - Container ports are not published to the host by default
-- `data:` URIs are too large for the host-open script
+- `data:` URIs are rejected by the host proxy (only http/https schemes allowed)
 
 ## Solution: Python HTTP Server + Docker Relay Container
 

--- a/internal/hostproxy/html.go
+++ b/internal/hostproxy/html.go
@@ -1,14 +1,17 @@
 package hostproxy
 
-import "fmt"
+import (
+	"fmt"
+	"html"
+)
 
 // ─── Callback page HTML ────────────────────────────────────────────
-//
+
 // callbackPage renders a full HTML document with the shared callback chrome.
 // title sets <title> and body is raw HTML injected inside the centered container.
+// Callers are responsible for escaping any user-supplied content in body.
 //
 // Colors are drawn from the project's semantic theme (internal/iostreams/styles.go).
-
 func callbackPage(title, body string) string {
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
@@ -22,12 +25,9 @@ func callbackPage(title, body string) string {
 
             /* Semantic theme — mirrors internal/iostreams/styles.go */
             --primary:   #E8714A;  /* ColorBurntOrange */
-            --secondary: #00BFFF;  /* ColorDeepSkyBlue */
             --success:   #04B575;  /* ColorEmerald     */
             --error:     #FF5F87;  /* ColorHotPink     */
-            --muted:     #626262;  /* ColorDimGray     */
             --bg:        #1A1A1A;  /* ColorJet         */
-            --bg-alt:    #2A2A2A;  /* ColorGunmetal    */
             --subtle:    #A0A0A0;  /* ColorSilver      */
         }
 
@@ -81,7 +81,7 @@ func callbackPage(title, body string) string {
         %s
     </div>
 </body>
-</html>`, title, body)
+</html>`, html.EscapeString(title), body)
 }
 
 // ─── Body content ───────────────────────────────────────────────────
@@ -93,3 +93,8 @@ const callbackSuccessBody = `<h1><span class="ok">&#10004;</span> Authentication
 const callbackErrorBodyFmt = `<h1><span class="err">&#10008;</span> Authentication Error</h1>
         <p class="subtitle">&#9646;&#9646; %s</p>
         <div class="brand">clawker</div>`
+
+// callbackErrorBody formats the error body with a safely escaped message.
+func callbackErrorBody(message string) string {
+	return fmt.Sprintf(callbackErrorBodyFmt, html.EscapeString(message))
+}

--- a/internal/hostproxy/server.go
+++ b/internal/hostproxy/server.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"net"
 	"net/http"
 	"net/url"
@@ -613,13 +612,16 @@ func (s *Server) handleCallbackCapture(w http.ResponseWriter, r *http.Request) {
 func (s *Server) writeCallbackSuccessPage(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(callbackPage("Authentication Complete", callbackSuccessBody)))
+	if _, err := w.Write([]byte(callbackPage("Authentication Complete", callbackSuccessBody))); err != nil {
+		logger.Debug().Err(err).Msg("failed to write callback success page")
+	}
 }
 
 // writeCallbackErrorPage writes an HTML error page for OAuth callbacks.
 func (s *Server) writeCallbackErrorPage(w http.ResponseWriter, message string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusInternalServerError)
-	w.Write([]byte(callbackPage("Authentication Error",
-		fmt.Sprintf(callbackErrorBodyFmt, html.EscapeString(message)))))
+	if _, err := w.Write([]byte(callbackPage("Authentication Error", callbackErrorBody(message)))); err != nil {
+		logger.Debug().Err(err).Msg("failed to write callback error page")
+	}
 }


### PR DESCRIPTION
## Summary

- Extract ~190 lines of duplicated inline HTML/CSS from `writeCallbackSuccessPage` and `writeCallbackErrorPage` into a shared `callbackPage()` wrapper in new `internal/hostproxy/html.go`
- Redesign callback pages with terminal aesthetic: monospace fonts, dark background, viewport-scaled text, inline ANSI-style icons (green `✔` / pink `✘`), semantic theme colors from `iostreams/styles.go`
- Fix XSS vulnerability: error messages now escaped via `html.EscapeString` instead of raw string concatenation

## Test plan

- [x] `go build ./internal/hostproxy/...` — compiles clean
- [x] `go vet ./internal/hostproxy/...` — no issues
- [x] `go test ./internal/hostproxy/... -v` — all tests pass
- [x] Visual review of success/error pages in browser via preview server

🤖 Generated with [Claude Code](https://claude.com/claude-code)