### PR TITLE
chore(docs): README refresh — Homebrew install, TOC, centered intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-<code>clawker</code> is basically what would happen if <code>devcontainers</code> and <code>k8s</code> had a <code>Claude Code</code> baby. It's a container orchestration and automation tool for running Claude Code agents in isolated containers on any host with docker installed. I wrote this because I didn't want to have to pay someone to run claude code agents with `--dangerously-skip-permissions` when containers have been around for a decade. <code>clawker</code> offers convenience features beyond just building and running claude code in a container using a Dockerfile.
+<code>clawker</code> is basically what would happen if <code>devcontainers</code> and <code>k8s</code> had a <code>Claude Code</code> baby. It's a container orchestration and automation tool for running Claude Code agents in isolated containers on any host with docker installed. I wrote this because I didn't want to have to pay someone to run claude code agents with <code>--dangerously-skip-permissions</code> when containers have been around for a decade, and claude code's sandbox mode is the temu version of a container. <code>clawker</code> offers convenience features beyond just building and running claude code in a container using a Dockerfile (you don't even have to write a Dockerfile it's got you covered).
 </p>
 
 ---


### PR DESCRIPTION
## Summary

- Add Homebrew as primary install method alongside curl|bash script
- Add table of contents covering all h2 sections
- Center the intro paragraph with HTML
- Collapse backstory section into a `<details>` block

## Test plan

- [x] Verify README renders correctly on GitHub (TOC links, details toggle, centered text)
- [x] Homebrew install command matches goreleaser tap config

🤖 Generated with [Claude Code](https://claude.com/claude-code)