### PR TITLE
feat(errors): Docker connectivity sentinel with install helper

### DIFF
--- a/internal/clawker/cmd.go
+++ b/internal/clawker/cmd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/schmitthub/clawker/internal/iostreams"
 	"github.com/schmitthub/clawker/internal/logger"
 	"github.com/schmitthub/clawker/internal/update"
+	"github.com/schmitthub/clawker/pkg/whail"
 )
 
 // Main is the entry point for the clawker CLI.
@@ -66,7 +67,11 @@ func Main() int {
 	updateCancel()
 
 	if err != nil {
-		if !errors.Is(err, cmdutil.SilentError) {
+		if errors.Is(err, cmdutil.SilentError) {
+			// Already displayed — no-op
+		} else if errors.Is(err, whail.ErrDockerNotAvailable) {
+			printDockerInstallHelper(f.IOStreams.ErrOut, f.IOStreams.ColorScheme(), err)
+		} else {
 			printError(f.IOStreams.ErrOut, f.IOStreams.ColorScheme(), err, cmd)
 		}
 
@@ -125,6 +130,24 @@ func updateStatePath() string {
 		return ""
 	}
 	return filepath.Join(stateDir, "update-state.yaml")
+}
+
+// printDockerInstallHelper renders a user-friendly message when the Docker
+// daemon cannot be reached, showing the actual error and troubleshooting steps.
+func printDockerInstallHelper(out io.Writer, cs *iostreams.ColorScheme, err error) {
+	// Extract the actual cause from the DockerError chain
+	detail := err.Error()
+	var dockerErr *whail.DockerError
+	if errors.As(err, &dockerErr) && dockerErr.Unwrap() != nil {
+		detail = dockerErr.Unwrap().Error()
+	}
+
+	fmt.Fprintf(out, "%s Failed to connect to Docker: %s\n\n", cs.FailureIcon(), cs.Muted(cs.Italic(detail)))
+	fmt.Fprintf(out, "%s\n", cs.Bold("Troubleshooting:"))
+	fmt.Fprintf(out, "  1. Install Docker Desktop: %s\n", cs.Cyan("https://docs.docker.com/get-docker/"))
+	fmt.Fprintf(out, "  2. Start Docker Desktop or run %s\n", cs.Bold("sudo systemctl start docker"))
+	fmt.Fprintf(out, "  3. Verify the daemon is reachable: %s\n", cs.Bold("docker info"))
+	fmt.Fprintf(out, "  4. Re-run your command\n")
 }
 
 // userFormattedError is a duck-typed interface for errors that provide

--- a/internal/clawker/cmd_test.go
+++ b/internal/clawker/cmd_test.go
@@ -1,12 +1,53 @@
 package clawker
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/schmitthub/clawker/internal/iostreams"
 	"github.com/schmitthub/clawker/internal/iostreams/iostreamstest"
 	"github.com/schmitthub/clawker/internal/update"
+	"github.com/schmitthub/clawker/pkg/whail"
 )
+
+func TestPrintDockerInstallHelper(t *testing.T) {
+	var buf bytes.Buffer
+	cs := iostreams.NewColorScheme(false, "") // no color for test assertions
+	pingErr := errors.New("dial unix /var/run/docker.sock: connect: connection refused")
+	dockerErr := whail.ErrDockerHealthCheckFailed(pingErr)
+	wrapped := fmt.Errorf("connecting to Docker: %w", dockerErr)
+
+	printDockerInstallHelper(&buf, cs, wrapped)
+
+	output := buf.String()
+	wantParts := []string{
+		"Failed to connect to Docker",
+		"dial unix /var/run/docker.sock: connect: connection refused",
+		"https://docs.docker.com/get-docker/",
+		"docker info",
+		"Re-run your command",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(output, part) {
+			t.Errorf("output missing %q, got:\n%s", part, output)
+		}
+	}
+}
+
+func TestPrintDockerInstallHelper_SentinelDetection(t *testing.T) {
+	// Simulate the full error chain: whail → docker → factory → command
+	underlying := errors.New("dial unix /var/run/docker.sock: connect: no such file or directory")
+	dockerErr := whail.ErrDockerHealthCheckFailed(underlying)
+	commandWrapped := fmt.Errorf("connecting to Docker: %w", dockerErr)
+
+	// Verify the sentinel is detectable at the top level
+	if !errors.Is(commandWrapped, whail.ErrDockerNotAvailable) {
+		t.Fatal("sentinel not detectable through command wrapping")
+	}
+}
 
 func TestPrintUpdateNotification_NilResult(t *testing.T) {
 	tio := iostreamstest.New()

--- a/pkg/whail/engine.go
+++ b/pkg/whail/engine.go
@@ -59,7 +59,9 @@ func NewWithOptions(ctx context.Context, opts EngineOptions) (*Engine, error) {
 		opts.ManagedLabel = DefaultManagedLabel
 	}
 
-	// Create the underlying Docker client using moby/moby v0.2.1 API
+	// Create the underlying Docker client using moby/moby v0.2.1 API.
+	// client.New is lazy — it only configures the client, not connecting to
+	// the daemon. Connection errors surface at HealthCheck (Ping) below.
 	realClient, err := client.New(client.FromEnv)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docker client: %w", err)
@@ -81,7 +83,7 @@ func NewWithOptions(ctx context.Context, opts EngineOptions) (*Engine, error) {
 	// Verify connectivity
 
 	if err := e.HealthCheck(ctx); err != nil {
-		return nil, err
+		return nil, ErrDockerHealthCheckFailed(err)
 	}
 	// logger.Printf("[Engine] Connected to Docker daemon")
 
@@ -109,10 +111,7 @@ func NewFromExisting(c client.APIClient, opts ...EngineOptions) *Engine {
 // HealthCheck verifies the Docker daemon is reachable.
 func (e *Engine) HealthCheck(ctx context.Context) error {
 	_, err := e.Ping(ctx, client.PingOptions{})
-	if err != nil {
-		return ErrDockerNotRunning(err)
-	}
-	return nil
+	return err
 }
 
 // Options returns the engine options.

--- a/pkg/whail/errors.go
+++ b/pkg/whail/errors.go
@@ -1,9 +1,15 @@
 package whail
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrDockerNotAvailable is a sentinel error indicating the Docker daemon
+// cannot be reached — either not installed or not running.
+// Use errors.Is(err, ErrDockerNotAvailable) to detect this condition.
+var ErrDockerNotAvailable = errors.New("docker not available")
 
 // DockerError represents a user-friendly Docker error with remediation steps.
 // It wraps underlying Docker SDK errors with context and actionable guidance.
@@ -20,6 +26,13 @@ func (e *DockerError) Error() string {
 
 func (e *DockerError) Unwrap() error {
 	return e.Err
+}
+
+// Is supports sentinel error matching. A DockerError with Op "connect"
+// matches ErrDockerNotAvailable, allowing errors.Is detection through
+// any depth of fmt.Errorf wrapping without polluting the Err chain.
+func (e *DockerError) Is(target error) bool {
+	return target == ErrDockerNotAvailable && e.Op == "connect"
 }
 
 // FormatUserError formats the error for display to users with next steps.
@@ -43,12 +56,15 @@ func (e *DockerError) FormatUserError() string {
 
 // Common error constructors
 
-// ErrDockerNotRunning returns an error for when Docker daemon is not accessible.
-func ErrDockerNotRunning(err error) *DockerError {
+// ErrDockerHealthCheckFailed returns an error for when the Docker daemon
+// health check (Ping) fails. The returned error wraps ErrDockerNotAvailable
+// so callers can detect Docker connectivity failures via
+// errors.Is(err, ErrDockerNotAvailable).
+func ErrDockerHealthCheckFailed(err error) *DockerError {
 	return &DockerError{
 		Op:      "connect",
 		Err:     err,
-		Message: "Cannot connect to Docker daemon",
+		Message: "Docker health check failed",
 		NextSteps: []string{
 			"Ensure Docker is installed",
 			"Start Docker Desktop (macOS/Windows) or run 'sudo systemctl start docker' (Linux)",

--- a/pkg/whail/errors_test.go
+++ b/pkg/whail/errors_test.go
@@ -2,6 +2,7 @@ package whail
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -80,9 +81,9 @@ func TestDockerError_FormatUserError(t *testing.T) {
 	}
 }
 
-func TestErrDockerNotRunning(t *testing.T) {
+func TestErrDockerHealthCheckFailed(t *testing.T) {
 	underlying := errors.New("connection refused")
-	err := ErrDockerNotRunning(underlying)
+	err := ErrDockerHealthCheckFailed(underlying)
 
 	if err.Op != "connect" {
 		t.Errorf("Op = %q, want %q", err.Op, "connect")
@@ -92,6 +93,39 @@ func TestErrDockerNotRunning(t *testing.T) {
 	}
 	if len(err.NextSteps) == 0 {
 		t.Error("should have next steps")
+	}
+}
+
+func TestErrDockerHealthCheckFailed_SentinelChain(t *testing.T) {
+	underlying := errors.New("connection refused")
+	err := ErrDockerHealthCheckFailed(underlying)
+
+	if !errors.Is(err, ErrDockerNotAvailable) {
+		t.Error("ErrDockerHealthCheckFailed should satisfy errors.Is(err, ErrDockerNotAvailable)")
+	}
+}
+
+func TestErrDockerNotAvailable_SurvivesCommandWrapping(t *testing.T) {
+	// Commands wrap with fmt.Errorf("connecting to Docker: %w", err)
+	// The sentinel must survive this wrapping.
+	underlying := errors.New("connection refused")
+	dockerErr := ErrDockerHealthCheckFailed(underlying)
+	wrapped := fmt.Errorf("connecting to Docker: %w", dockerErr)
+
+	if !errors.Is(wrapped, ErrDockerNotAvailable) {
+		t.Error("sentinel must survive fmt.Errorf wrapping in commands")
+	}
+}
+
+func TestErrDockerNotAvailable_SurvivesDoubleWrapping(t *testing.T) {
+	// Factory wraps, then command wraps again.
+	underlying := errors.New("dial unix /var/run/docker.sock: connect: no such file or directory")
+	dockerErr := ErrDockerHealthCheckFailed(underlying)
+	factoryWrapped := fmt.Errorf("failed to get config: %w", dockerErr)
+	commandWrapped := fmt.Errorf("connecting to Docker: %w", factoryWrapped)
+
+	if !errors.Is(commandWrapped, ErrDockerNotAvailable) {
+		t.Error("sentinel must survive double wrapping through factory and command layers")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `ErrDockerNotAvailable` sentinel error and `ErrDockerHealthCheckFailed` constructor in `pkg/whail/errors.go`
- Implements `DockerError.Is()` for sentinel matching via `Op=="connect"`, keeping the raw Ping error in `Err` without sentinel noise
- Adds `if/else` dispatch chain in `Main()` (`internal/clawker/cmd.go`) that intercepts the sentinel before the generic `printError` fallback
- Renders a `printDockerInstallHelper` with the actual error detail (muted italic) and troubleshooting steps including Docker install link

## Test plan
- [x] Sentinel survives `fmt.Errorf` wrapping through command and factory layers
- [x] `printDockerInstallHelper` renders actual Ping error, install link, and troubleshooting steps
- [x] All 3873 unit tests pass (`make test`)
- [x] Manual: stop Docker Desktop → run any Docker command → verify install helper renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)