### PR TITLE
fix(statusline): move worktree + before branch name

### DIFF
--- a/internal/bundler/assets/statusline.sh
+++ b/internal/bundler/assets/statusline.sh
@@ -278,7 +278,7 @@ fi
 # Git branch (+ cyan worktree indicator)
 if [ -n "$branch" ]; then
     if $is_worktree; then
-        line1+=$(printf " ${CYAN}%s+(wt)${NC}" "${GIT}$branch")
+        line1+=$(printf " ${CYAN}%s+%s(wt)${NC}" "${GIT}" "$branch")
     else
         line1+=$(printf " ${GRAY}%s${NC}" "${GIT}$branch")
     fi


### PR DESCRIPTION
## Summary
- Moves the `+` worktree indicator to appear after the git icon but before the branch name, and removes the space between branch name and `(wt)`

## Test plan
- [ ] Visual check: statusline shows `+branch(wt)` in worktree contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)