### PR TITLE
feat(docs): add Google Analytics 4 to Mintlify site

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,6 +61,11 @@
       "website": "https://clawker.dev"
     }
   },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-TM021J82T6"
+    }
+  },
   "navigation": {
     "groups": [
       {


### PR DESCRIPTION
## Summary
- Add GA4 integration (`G-TM021J82T6`) to `docs/docs.json` using Mintlify's built-in `integrations.ga4` support

## Test plan
- [ ] `npx mintlify dev --docs-directory docs` loads without errors
- [ ] Browser DevTools Network tab shows `googletagmanager.com/gtag/js?id=G-TM021J82T6` request
- [ ] After deploy: verify hits in Google Analytics Real-Time dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)