### PR TITLE
fix: macOS security fixes — Homebrew formula + GPG path override

### DIFF
--- a/internal/bundler/assets/entrypoint.sh
+++ b/internal/bundler/assets/entrypoint.sh
@@ -151,18 +151,6 @@ if [ -f "$HOST_GITCONFIG" ]; then
     else
         rm -f "$HOME/.gitconfig.tmp"
     fi
-
-    # Fix gpg.program path — host path (e.g. /opt/homebrew/bin/gpg) is never correct in container
-    current_gpg="$(git config --global gpg.program 2>/dev/null)" || true
-    if [ -n "$current_gpg" ]; then
-        container_gpg="$(command -v gpg 2>/dev/null)" || true
-        if [ -n "$container_gpg" ]; then
-            git config --global gpg.program "$container_gpg" 2>/dev/null || true
-        else
-            # Host path won't exist in container — unset so git uses PATH lookup
-            git config --global --unset gpg.program 2>/dev/null || true
-        fi
-    fi
 fi
 
 # Configure git credential helper if HTTPS forwarding is enabled

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -144,6 +144,13 @@ func RuntimeEnv(opts RuntimeEnvOpts) ([]string, error) {
 				"path": "/home/claude/.gnupg/S.gpg-agent",
 				"type": "gpg-agent",
 			})
+			// Override gpg.program via env vars so the container's gpg binary is used
+			// regardless of what the host's gitconfig (global or local) specifies.
+			// Env-based config overrides all file-based git config levels including
+			// local .git/config, which is bind-mounted from the host in bind mode.
+			m["GIT_CONFIG_COUNT"] = "1"
+			m["GIT_CONFIG_KEY_0"] = "gpg.program"
+			m["GIT_CONFIG_VALUE_0"] = "/usr/bin/gpg"
 		}
 		if opts.SSHForwardingEnabled {
 			sockets = append(sockets, map[string]string{

--- a/internal/docker/env_test.go
+++ b/internal/docker/env_test.go
@@ -393,6 +393,11 @@ func TestRuntimeEnv_GPGForwardingEnabled(t *testing.T) {
 		}
 	}
 	require.True(t, found, "expected CLAWKER_REMOTE_SOCKETS env var")
+
+	// Should override gpg.program via GIT_CONFIG env vars
+	assert.Contains(t, env, "GIT_CONFIG_COUNT=1")
+	assert.Contains(t, env, "GIT_CONFIG_KEY_0=gpg.program")
+	assert.Contains(t, env, "GIT_CONFIG_VALUE_0=/usr/bin/gpg")
 }
 
 func TestRuntimeEnv_BothForwardingEnabled(t *testing.T) {
@@ -425,6 +430,8 @@ func TestRuntimeEnv_NoForwardingNoSocketVars(t *testing.T) {
 			"should not set CLAWKER_REMOTE_SOCKETS when no forwarding")
 		assert.False(t, strings.HasPrefix(e, "SSH_AUTH_SOCK="),
 			"should not set SSH_AUTH_SOCK when no forwarding")
+		assert.False(t, strings.HasPrefix(e, "GIT_CONFIG_COUNT="),
+			"should not set GIT_CONFIG_COUNT when no forwarding")
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Switch Homebrew distribution from cask to formula** — migrates `.goreleaser.yaml` from `homebrew_casks` to `brews` with proper `Formula/` directory, `license`, and `install` block
- **Override `gpg.program` via env vars when GPG forwarding is enabled** — uses `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` to force `gpg.program=/usr/bin/gpg` inside containers. Env-based git config overrides all file-based levels (system, global, local, worktree), avoiding mutation of the host's `.git/config` which is bind-mounted read-write in bind mode

### Why env vars instead of config rewrite?

The entrypoint copies the host's `~/.gitconfig` and could rewrite `gpg.program` there. But in bind mode, the project's `.git/config` is bind-mounted from the host — and local config overrides global. Writing to local would fix the container but corrupt the host's config. `GIT_CONFIG_COUNT` env vars sit above all file-based config in git's precedence hierarchy, so they override both global and local without touching any files.

## Test plan

- [ ] `goreleaser check` passes with the updated `.goreleaser.yaml`
- [ ] Container with GPG forwarding enabled has `GIT_CONFIG_COUNT=1`, `GIT_CONFIG_KEY_0=gpg.program`, `GIT_CONFIG_VALUE_0=/usr/bin/gpg` in env
- [ ] `git config gpg.program` inside container returns `/usr/bin/gpg` even when local `.git/config` has a host path
- [ ] Host's `.git/config` is not modified after container run
- [ ] Container without GPG forwarding does not set `GIT_CONFIG_COUNT`
- [ ] `brew install schmitthub/tap/clawker` installs correctly as a formula

> **Note:** Commits 2-3 are intermediate approaches (entrypoint config rewrite) superseded by commit 4 (env var override). Consider squashing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)