### PR TITLE
fix(homebrew): switch from formula to cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,18 +33,25 @@ archives:
       - LICENSE
       - README.md
 
-brews:
+homebrew_casks:
   - name: clawker
+    ids:
+      - default
+    binaries:
+      - clawker
     repository:
       owner: schmitthub
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
     homepage: https://github.com/schmitthub/clawker
     description: "Development containers for AI coding agents"
     license: "MIT"
-    install: |
-      bin.install "clawker"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/clawker"]
+          end
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Summary

- Replace deprecated `brews` (Formula) with `homebrew_casks` (Cask) in GoReleaser config
- Add postflight hook to strip macOS quarantine attribute, preventing Gatekeeper from blocking unsigned binaries

## Context

GoReleaser is [deprecating the `brews` section](https://goreleaser.com/deprecations/#brews) in favor of `homebrew_casks`. The postflight `xattr` hook is the [documented approach](https://goreleaser.com/customization/homebrew_casks/) for unsigned binaries.

Note: Homebrew is ending support for unsigned casks [Sept 2026](https://github.com/Homebrew/brew/issues/20755) — code signing + notarization is the long-term fix.

Closes #170

## Test plan

- [ ] Delete `Formula/clawker.rb` from homebrew-tap
- [ ] Tag a prerelease (`v0.x.x-rc.1`) to trigger GoReleaser
- [ ] Verify `Casks/clawker.rb` is created in homebrew-tap
- [ ] `brew install schmitthub/tap/clawker` on macOS — confirm no Gatekeeper block
- [ ] `clawker version` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)