### PR TITLE
fix: update statusline colors and add subscription usage bars

### DIFF
--- a/internal/bundler/assets/statusline.sh
+++ b/internal/bundler/assets/statusline.sh
@@ -130,7 +130,7 @@ format_remaining() {
 # Refresh the subscription usage cache if stale or missing
 refresh_usage_cache() {
     if [ -f "$USAGE_CACHE" ]; then
-        cache_age=$(( $(date +%s) - $(stat -c %Y "$USAGE_CACHE") ))
+        local cache_age=$(( $(date +%s) - $(stat -c %Y "$USAGE_CACHE") ))
         [ "$cache_age" -lt "$USAGE_CACHE_MAX_AGE" ] && return 0
     fi
 


### PR DESCRIPTION
## Summary
- Clawker identity section color changed from MutedRed to Cyan; worktree indicator from Cyan to DeepSkyBlue
- Added `refresh_usage_cache()` to fetch subscription usage from the Anthropic OAuth API (cached 5min)
- Appends 5-hour and 7-day usage progress bars to line 2 when credentials are available; silently omitted otherwise
- Removed Darwin-specific date parsing — statusline runs in Linux containers only

## Test plan
- [x] Verify statusline renders correctly in a clawker container with valid credentials (usage bars appear)
- [x] Verify statusline renders correctly without credentials (usage bars silently omitted)
- [x] Verify Clawker identity shows Cyan, worktree indicator shows DeepSkyBlue
- [x] Verify color fallback on 16-color terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)