### PR TITLE
fix: prevent textarea editor exit on arrow key hold and correct save hint

### DIFF
--- a/internal/cmd/project/init/init.go
+++ b/internal/cmd/project/init/init.go
@@ -620,10 +620,10 @@ func performProjectSetup(ctx context.Context, in performSetupInput) error {
 				ID:    "customize",
 				Title: "Customize",
 				Page: tui.NewBrowserPage(browser,
-					tui.WithDoneKey("s"),
+					tui.WithDoneKey("ctrl+s"),
 					tui.WithCancelKey("q"),
 				),
-				HelpKeys: []string{"↑↓", "navigate", "enter", "edit", "s", "save", "q", "quit", "esc", "back"},
+				HelpKeys: []string{"↑↓", "navigate", "enter", "edit", "ctrl+s", "save", "q", "quit", "esc", "back"},
 			},
 		})
 		if wizErr != nil {

--- a/internal/tui/fieldbrowser.go
+++ b/internal/tui/fieldbrowser.go
@@ -584,14 +584,18 @@ func (m *FieldBrowserModel) updateEdit(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case ekTextarea:
+		// Intercept Esc before delegating — matches ekSelect/ekText pattern.
+		// Prevents accidental cancellation from fragmented arrow-key escape
+		// sequences (e.g. holding left arrow generates rapid ESC [ D; read
+		// boundaries can split ESC from [D, delivering a standalone Esc).
+		if msg, ok := msg.(tea.KeyMsg); ok && IsEscape(msg) {
+			m.state = bsStateBrowse
+			return m, nil
+		}
 		var cmd tea.Cmd
 		m.taEditor, cmd = m.taEditor.Update(msg)
 		if m.taEditor.IsConfirmed() {
 			return m, m.enterPickLayer(f.Path, m.taEditor.Value())
-		}
-		if m.taEditor.IsCancelled() {
-			m.state = bsStateBrowse
-			return m, nil
 		}
 		return m, cmd
 

--- a/internal/tui/fieldbrowser_test.go
+++ b/internal/tui/fieldbrowser_test.go
@@ -505,3 +505,63 @@ func TestFieldBrowser_StructSliceStillUsesTextarea(t *testing.T) {
 	require.Equal(t, bsStateEdit, m.state)
 	assert.Equal(t, ekTextarea, m.editKind, "struct slice should still use textarea editor")
 }
+
+func TestFieldBrowser_TextareaArrowKeysStayInEdit(t *testing.T) {
+	fields := []BrowserField{
+		{Path: "agent.post_init", Label: "post_init", Kind: BrowserStructSlice, Value: "echo hi", EditValue: "echo hi"},
+	}
+	cfg := BrowserConfig{
+		Title:        "Test",
+		Fields:       fields,
+		LayerTargets: testLayerTargets(),
+	}
+	m := NewFieldBrowser(cfg)
+
+	// Enter textarea edit mode.
+	m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, bsStateEdit, m.state)
+	require.Equal(t, ekTextarea, m.editKind)
+
+	// Simulate rapid left arrow keys — must stay in edit mode.
+	for range 20 {
+		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+		m = updated.(*FieldBrowserModel)
+	}
+	assert.Equal(t, bsStateEdit, m.state, "left arrow keys must not exit textarea edit mode")
+
+	// Right arrow also stays in edit.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight})
+	m = updated.(*FieldBrowserModel)
+	assert.Equal(t, bsStateEdit, m.state, "right arrow must not exit textarea edit mode")
+
+	// Up/down also stay in edit.
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = updated.(*FieldBrowserModel)
+	assert.Equal(t, bsStateEdit, m.state, "up arrow must not exit textarea edit mode")
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = updated.(*FieldBrowserModel)
+	assert.Equal(t, bsStateEdit, m.state, "down arrow must not exit textarea edit mode")
+}
+
+func TestFieldBrowser_TextareaEscExitsToBrowseNotQuit(t *testing.T) {
+	fields := []BrowserField{
+		{Path: "agent.post_init", Label: "post_init", Kind: BrowserStructSlice, Value: "echo hi", EditValue: "echo hi"},
+	}
+	cfg := BrowserConfig{
+		Title:        "Test",
+		Fields:       fields,
+		LayerTargets: testLayerTargets(),
+	}
+	m := NewFieldBrowser(cfg)
+
+	// Enter textarea edit mode.
+	m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Equal(t, bsStateEdit, m.state)
+
+	// Esc returns to browse (not quit).
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(*FieldBrowserModel)
+	assert.Equal(t, bsStateBrowse, m.state, "esc from textarea should return to browse")
+	assert.False(t, m.cancelled, "esc from textarea should not cancel the browser")
+}


### PR DESCRIPTION
## Summary

- **Textarea arrow key hold exit**: Intercept Esc in the field browser's `ekTextarea` handler before delegating to the textarea model, matching the existing `ekSelect`/`ekText` pattern. Prevents accidental cancellation from fragmented arrow-key escape sequences (terminal sends `ESC [ D` for left arrow; read boundaries can split `ESC` from `[D`, delivering a standalone Esc that cascades: textarea cancels → browse state → next fragmented Esc quits).
- **Wrong save hint**: Change the customize wizard's done key from `"s"` to `"ctrl+s"` so the help bar matches the textarea's actual save binding. The done key is only checked in browse state (`InBaseState()`), so `ctrl+s` in the textarea still saves content — no conflict.

Fixes #201

## Test plan

- [x] `TestFieldBrowser_TextareaArrowKeysStayInEdit` — 20 rapid left arrows + right/up/down all stay in edit mode
- [x] `TestFieldBrowser_TextareaEscExitsToBrowseNotQuit` — Esc returns to browse without cancelling the browser
- [x] All existing field browser, textarea, storeui, and project init tests pass
- [x] Full unit test suite passes (`go test ./internal/... ./pkg/... ./cmd/...`)
- [x] Manual: `clawker project init` → customize preset → open multiline field → hold left arrow → editor stays open
- [x] Manual: verify help bar shows `ctrl+s save` (not `s save`) in customize wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)