### PR TITLE
feat: add GitHub artifact attestation for SLSA build provenance

### DIFF
--- a/.clawker.yaml
+++ b/.clawker.yaml
@@ -114,6 +114,7 @@ security:
       - vuln.go.dev
       - production.cloudflare.docker.com
       - www.envoyproxy.io
+      - goreleaser.com
     enable: true
     rules:
       - action: allow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -61,3 +62,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-checksums: ./dist/checksums.txt


### PR DESCRIPTION
## Summary

- Adds `actions/attest-build-provenance@v4.1.0` (SHA-pinned) to the release workflow
- Attests all release artifacts via GoReleaser's `checksums.txt` (archives, SBOMs)
- Adds `attestations: write` permission for GitHub's attestation store
- Keeps existing cosign signing as a complementary portable verification mechanism

Users can verify downloaded artifacts with:
```bash
gh attestation verify clawker_x.y.z_linux_amd64.tar.gz --repo schmitthub/clawker
```

## Test plan

- [ ] Tag a pre-release and verify the attest step runs after GoReleaser
- [ ] Verify attestations appear at github.com/schmitthub/clawker/attestations
- [ ] Verify `gh attestation verify` works against a downloaded artifact
- [ ] Verify existing cosign signing still produces `.sig` on the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)