### PR TITLE
chore: patch Go to 1.25.8, pin moq v0.6.0, update builder image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install moq
-        run: go install github.com/matryer/moq@1b3799f1e7f74e9680ed32e9f239b417d4a093e4 # v0.7.1
+        run: go install github.com/matryer/moq@66a933417c1a7ca1302529db332fecbf77e166d9 # v0.6.0
 
       - name: Verify build
         run: go build ./cmd/clawker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/schmitthub/clawker
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e

--- a/internal/bundler/dockerfile.go
+++ b/internal/bundler/dockerfile.go
@@ -108,8 +108,8 @@ const (
 	DefaultUsername          = "claude"
 	DefaultShell             = "/bin/zsh"
 	// DefaultGoBuilderImage is the Go toolchain image used for builder stages.
-	// Pinned to exact patch version + SHA digest matching go.mod (go 1.25.5).
-	DefaultGoBuilderImage = "golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb"
+	// Pinned to exact patch version + SHA digest matching go.mod (go 1.25.8).
+	DefaultGoBuilderImage = "golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa"
 )
 
 // DockerfileManager generates and persists Dockerfiles for each version/variant combination.
@@ -150,7 +150,7 @@ type DockerfileContext struct {
 	OtelIncludeSessionID   bool // OTEL_METRICS_INCLUDE_SESSION_ID=true
 
 	HasFirewallCA  bool   // CA cert exists for MITM inspection
-	GoBuilderImage string // Go toolchain image for builder stages (e.g. "golang:1.25.5-alpine@sha256:...")
+	GoBuilderImage string // Go toolchain image for builder stages (e.g. "golang:1.25.8-alpine@sha256:...")
 }
 
 // DockerfileInstructions contains type-safe Dockerfile instructions.


### PR DESCRIPTION
## Summary

- Bump `go.mod` from Go 1.25.5 to 1.25.8 (security patches)
- Pin moq to v0.6.0 (last release supporting Go 1.25, avoids `setup-go` v6 `GOTOOLCHAIN=local` conflict)
- Update `DefaultGoBuilderImage` to `golang:1.25.8-alpine` with SHA digest

## Context

`actions/setup-go` v6 (bumped in #226) sets `GOTOOLCHAIN=local`. Moq v0.7.1 requires Go >= 1.26, which breaks the release pipeline. Rather than bumping to Go 1.26, we pin moq to v0.6.0 (last Go 1.25 compatible release) and patch Go to 1.25.8 for security fixes.

## Test plan

- [ ] CI passes (lint, test, security, docs, licenses)
- [ ] Pre-release tag test to verify release pipeline end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)