### PR TITLE
fix: show denied destination in Envoy monitoring logs

### DIFF
--- a/internal/firewall/envoy.go
+++ b/internal/firewall/envoy.go
@@ -83,13 +83,16 @@ const (
 )
 
 // buildHTTPAccessLog returns an Envoy stdout access log for http_connection_manager contexts.
-// Includes HTTP-specific fields (method, path, response_code) that are only available
-// when Envoy terminates HTTP — used by TLS filter chains and the HTTP listener.
+// Includes HTTP-specific fields (method, path, response_code, request_host) that are only
+// available when Envoy terminates HTTP — used by TLS filter chains and the HTTP listener.
+// request_host captures the Host/:authority header, which is the only domain source for
+// plaintext HTTP (where SNI/%REQUESTED_SERVER_NAME% is empty).
 func buildHTTPAccessLog(proto string) []any {
 	return []any{accessLogEntry(proto, map[string]any{
 		"method":        "%REQ(:METHOD)%",
 		"path":          "%REQ(:PATH)%",
 		"response_code": "%RESPONSE_CODE%",
+		"request_host":  "%REQ(Host)%",
 	})}
 }
 

--- a/internal/firewall/envoy_test.go
+++ b/internal/firewall/envoy_test.go
@@ -292,6 +292,7 @@ func TestBuildHTTPAccessLog(t *testing.T) {
 	assert.Equal(t, "%RESPONSE_CODE%", jf["response_code"])
 	assert.Equal(t, "%REQ(:METHOD)%", jf["method"])
 	assert.Equal(t, "%REQ(:PATH)%", jf["path"])
+	assert.Equal(t, "%REQ(Host)%", jf["request_host"])
 }
 
 func TestBuildTCPAccessLog(t *testing.T) {

--- a/internal/monitor/templates/grafana-dashboard.json
+++ b/internal/monitor/templates/grafana-dashboard.json
@@ -2198,7 +2198,7 @@
             "type": "loki",
             "uid": "${lokidatasource}"
           },
-          "expr": "{service_name=\"envoy\", source=\"envoy\", client_ip=~\"${agent_ips:regex}\"} | json | line_format `{{if or (eq .proto \"deny\") (and (eq .proto \"http\") (eq .response_code \"403\"))}}✗ DENIED{{else}}✓ {{if eq .proto \"tls\"}}https{{else}}{{.proto}}{{end}}{{end}} → {{if and .request_host (ne .request_host \"-\")}}{{.request_host}}{{if and .path (ne .path \"-\")}}{{.path}}{{end}}{{else if .domain}}{{.domain}}{{else}}unknown from {{.client_ip}}{{end}}{{if .method}} {{.method}} {{.response_code}}{{end}}{{if and .upstream_host (ne .upstream_host \"-\")}} [{{.upstream_host}}]{{end}}{{if and .response_flags (ne .response_flags \"-\")}} flags={{.response_flags}}{{end}} ↑{{.bytes_sent}} ↓{{.bytes_received}} {{.duration_ms}}ms`",
+          "expr": "{service_name=\"envoy\", source=\"envoy\", client_ip=~\"${agent_ips:regex}\"} | json | line_format `{{if or (eq .proto \"deny\") (and (eq .response_code \"403\") (or (not .upstream_host) (eq .upstream_host \"-\")))}}✗ DENIED{{else}}✓ {{if eq .proto \"tls\"}}https{{else}}{{.proto}}{{end}}{{end}} → {{if and .request_host (ne .request_host \"-\")}}{{.request_host}}{{if and .path (ne .path \"-\")}}{{.path}}{{end}}{{else if .domain}}{{.domain}}{{else}}unknown from {{.client_ip}}{{end}}{{if .method}} {{.method}} {{.response_code}}{{end}}{{if and .upstream_host (ne .upstream_host \"-\")}} [{{.upstream_host}}]{{end}}{{if and .response_flags (ne .response_flags \"-\")}} flags={{.response_flags}}{{end}} ↑{{.bytes_sent}} ↓{{.bytes_received}} {{.duration_ms}}ms`",
           "legendFormat": "",
           "refId": "A"
         }

--- a/internal/monitor/templates/grafana-dashboard.json
+++ b/internal/monitor/templates/grafana-dashboard.json
@@ -2198,7 +2198,7 @@
             "type": "loki",
             "uid": "${lokidatasource}"
           },
-          "expr": "{service_name=\"envoy\", source=\"envoy\", client_ip=~\"${agent_ips:regex}\"} | json | line_format `{{if eq .proto \"deny\"}}DENIED{{else if eq .proto \"tls\"}}https{{else}}{{.proto}}{{end}} → {{if .domain}}{{.domain}}{{if and .path (ne .path \"-\")}}{{.path}}{{end}}{{else}}{{.upstream_host}}{{end}}{{if .method}} {{.method}} {{.response_code}}{{end}}{{if and .domain .upstream_host (ne .upstream_host \"-\")}} [{{.upstream_host}}]{{end}}{{if and .response_flags (ne .response_flags \"-\")}} flags={{.response_flags}}{{end}} ↑{{.bytes_sent}} ↓{{.bytes_received}} {{.duration_ms}}ms`",
+          "expr": "{service_name=\"envoy\", source=\"envoy\", client_ip=~\"${agent_ips:regex}\"} | json | line_format `{{if or (eq .proto \"deny\") (and (eq .proto \"http\") (eq .response_code \"403\"))}}✗ DENIED{{else}}✓ {{if eq .proto \"tls\"}}https{{else}}{{.proto}}{{end}}{{end}} → {{if and .request_host (ne .request_host \"-\")}}{{.request_host}}{{if and .path (ne .path \"-\")}}{{.path}}{{end}}{{else if .domain}}{{.domain}}{{else}}unknown from {{.client_ip}}{{end}}{{if .method}} {{.method}} {{.response_code}}{{end}}{{if and .upstream_host (ne .upstream_host \"-\")}} [{{.upstream_host}}]{{end}}{{if and .response_flags (ne .response_flags \"-\")}} flags={{.response_flags}}{{end}} ↑{{.bytes_sent}} ↓{{.bytes_received}} {{.duration_ms}}ms`",
           "legendFormat": "",
           "refId": "A"
         }

--- a/internal/monitor/templates/promtail-config.yaml.tmpl
+++ b/internal/monitor/templates/promtail-config.yaml.tmpl
@@ -65,6 +65,7 @@ scrape_configs:
                 client_ip:
                 response_code:
                 response_flags:
+                upstream_host:
                 agent:
                 project:
                 action:
@@ -81,6 +82,9 @@ scrape_configs:
           stages:
             - static_labels:
                 detected_level: error
+      # Drop upstream_host after match evaluation to avoid label cardinality.
+      - labeldrop:
+          - upstream_host
 
       # CoreDNS log lines have an [INFO] prefix before the logfmt data:
       #   [INFO] source=coredns client_ip=172.18.0.8:12345 domain=example.com. qtype=A rcode=NOERROR duration=0.001s

--- a/internal/monitor/templates/promtail-config.yaml.tmpl
+++ b/internal/monitor/templates/promtail-config.yaml.tmpl
@@ -61,7 +61,6 @@ scrape_configs:
             - labels:
                 source:
                 domain:
-                request_host:
                 proto:
                 client_ip:
                 response_code:
@@ -78,7 +77,7 @@ scrape_configs:
                 detected_level: error
       # HTTP 403 = deny_all virtual host rejecting unlisted Host headers.
       - match:
-          selector: '{service_name="envoy", proto="http", response_code="403"}'
+          selector: '{service_name="envoy", proto="http", response_code="403", upstream_host="-"}'
           stages:
             - static_labels:
                 detected_level: error

--- a/internal/monitor/templates/promtail-config.yaml.tmpl
+++ b/internal/monitor/templates/promtail-config.yaml.tmpl
@@ -36,6 +36,7 @@ scrape_configs:
                 expressions:
                   source: source
                   domain: domain
+                  request_host: request_host
                   upstream_host: upstream_host
                   listener_port: listener_port
                   client_ip: client_ip
@@ -60,6 +61,7 @@ scrape_configs:
             - labels:
                 source:
                 domain:
+                request_host:
                 proto:
                 client_ip:
                 response_code:
@@ -67,6 +69,19 @@ scrape_configs:
                 agent:
                 project:
                 action:
+      # Denied traffic gets error level for Grafana red coloring.
+      # Deny chain (proto=deny) logs from Envoy's TCP catch-all.
+      - match:
+          selector: '{service_name="envoy", proto="deny"}'
+          stages:
+            - static_labels:
+                detected_level: error
+      # HTTP 403 = deny_all virtual host rejecting unlisted Host headers.
+      - match:
+          selector: '{service_name="envoy", proto="http", response_code="403"}'
+          stages:
+            - static_labels:
+                detected_level: error
 
       # CoreDNS log lines have an [INFO] prefix before the logfmt data:
       #   [INFO] source=coredns client_ip=172.18.0.8:12345 domain=example.com. qtype=A rcode=NOERROR duration=0.001s


### PR DESCRIPTION
## Summary

- Add `request_host` (`%REQ(Host)%`) to HTTP access logs so denied plaintext HTTP connections show the destination domain (SNI is empty for non-TLS)
- Update dashboard `line_format` to prefer `request_host` over SNI, with fallback to `unknown from {client_ip}` for TCP deny chain
- Add ✗/✓ status prefix to Envoy traffic log lines; denied lines get `detected_level=error` for red Grafana coloring
- Extract and label `request_host` in Promtail pipeline

## Test plan

- [x] Unit tests pass (`make test` — 4387 tests)
- [x] Pre-commit hooks pass (gitleaks, semgrep, golangci-lint, govulncheck)
- [x] Verified via Grafana MCP: `request_host` populates on live traffic, `detected_level=error` on denied logs
- [x] Verify denied HTTP traffic (403 from deny_all vhost) shows Host header as destination
- [x] Verify dashboard renders ✗ DENIED (red) and ✓ https (default) correctly after `clawker monitor init --force && clawker monitor down --volumes && clawker monitor up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)