### PR TITLE
chore(plugin): bump clawker-support to 0.10.1

### DIFF
--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "schmitthub"
   },


### PR DESCRIPTION
## Summary
- Bump `clawker-support` plugin version 0.10.0 → 0.10.1
- Triggers `plugin-release` workflow on merge → updates SHA + version in `schmitthub/claude-plugins/marketplace.json` so Claude Code users pulling the plugin get the latest reference content (recent monitoring stack swap, CP host-id changes, etc.)

## Test plan
- [ ] CI passes (`Plugin Dockerfile.tmpl drift check`, lint, etc.)
- [ ] After merge, verify `plugin-release` job runs and `schmitthub/claude-plugins` commit lands

## Note
Install via marketplace still fails on SSH because `schmitthub/claude-plugins/marketplace.json` has a shorthand `"url": "schmitthub/clawker"` that resolves to SSH. Separate one-line fix needed there to flip url to `https://github.com/schmitthub/clawker.git` — workflow never rewrites url, so once fixed it stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)