### PR TITLE
chore: bump update-plugin workflow pin + clawker-support 0.10.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
     name: Plugin Release
     needs: [plugin-check]
     if: needs.plugin-check.outputs.changed == 'true'
-    uses: schmitthub/claude-plugins/.github/workflows/update-plugin.yml@fdbd6ffdc036b82f60656e70e35ce80e40f8ab07 # main
+    uses: schmitthub/claude-plugins/.github/workflows/update-plugin.yml@10a280d6fe399d2ee26b3a2c84e8b6f095083a1f # main
     with:
       plugin-name: clawker-support
       sha: ${{ github.sha }}

--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": {
     "name": "schmitthub"
   },


### PR DESCRIPTION
## Summary
- Bump pinned SHA of `schmitthub/claude-plugins/.github/workflows/update-plugin.yml` from `fdbd6ffd...` → `10a280d6...` to pick up [schmitthub/claude-plugins#1](https://github.com/schmitthub/claude-plugins/pull/1) (gh-api repo derived from `.source.url` instead of using the literal field).
- Bump `clawker-support` plugin to 0.10.2 so `plugin-check` fires and the freshly-pinned workflow actually runs.

## Why
Previous run of update-plugin against full-HTTPS `.source.url` failed silently on the `gh api repos/<full-url>/...` call → `VERSION` resolved empty → marketplace.json's `version` never bumped past `0.10.0`. Re-running with the old pinned SHA reproduced the same silent fallback. Fix is in `claude-plugins`; this PR pulls it in.

## Test plan
- [ ] CI green
- [ ] After merge, `marketplace.json` on `schmitthub/claude-plugins` lands at version `0.10.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)