### PR TITLE
feat(volume): narrow prune default to agent volumes; collapse purpose label

### DIFF
--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "author": {
     "name": "schmitthub"
   },

--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "author": {
     "name": "schmitthub"
   },

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/docker-hygiene.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/docker-hygiene.md
@@ -57,8 +57,10 @@ resources and won't touch other Docker workloads:
 2. `clawker volume list` + `clawker volume remove <name>` — targeted volume cleanup
 3. `clawker rm <name>` — remove specific stopped containers
 
-**Avoid `clawker volume prune`** unless the user explicitly wants a full reset —
-it removes all unattached clawker volumes including config and shell history.
+`clawker volume prune` (no flags) removes only unattached agent workspace
+volumes — safe default. **Avoid `clawker volume prune --all`** unless the user
+explicitly wants a full reset — it removes all unattached clawker volumes
+including config and shell history.
 
 **If that's not enough, escalate to Docker-wide commands:**
 

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/docker-hygiene.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/docker-hygiene.md
@@ -57,10 +57,13 @@ resources and won't touch other Docker workloads:
 2. `clawker volume list` + `clawker volume remove <name>` — targeted volume cleanup
 3. `clawker rm <name>` — remove specific stopped containers
 
-`clawker volume prune` (no flags) removes only unattached agent workspace
-volumes — safe default. **Avoid `clawker volume prune --all`** unless the user
-explicitly wants a full reset — it removes all unattached clawker volumes
-including config and shell history.
+`clawker volume prune` (no flags) removes **all** unattached agent volumes —
+config, history, AND workspace. This wipes per-agent settings and shell
+history for any agent whose container isn't running at prune time, so prefer
+`clawker volume list` + `clawker volume remove <name>` for targeted cleanup.
+**`clawker volume prune --all`** additionally removes infrastructure volumes
+(monitoring stack and any other clawker-managed volumes) — only suggest it
+when the user explicitly wants a full reset.
 
 **If that's not enough, escalate to Docker-wide commands:**
 

--- a/docs/cli-reference/clawker_volume.md
+++ b/docs/cli-reference/clawker_volume.md
@@ -31,7 +31,7 @@ configuration, and command history between container runs.
 * [clawker volume create](clawker_volume_create) - Create a volume
 * [clawker volume inspect](clawker_volume_inspect) - Display detailed information on one or more volumes
 * [clawker volume list](clawker_volume_list) - List volumes
-* [clawker volume prune](clawker_volume_prune) - Remove unused local volumes
+* [clawker volume prune](clawker_volume_prune) - Remove unused agent volumes
 * [clawker volume remove](clawker_volume_remove) - Remove one or more volumes
 
 ### Options

--- a/docs/cli-reference/clawker_volume_prune.md
+++ b/docs/cli-reference/clawker_volume_prune.md
@@ -4,13 +4,14 @@ title: "clawker volume prune"
 
 ## clawker volume prune
 
-Remove unused local volumes
+Remove unused agent volumes
 
 ### Synopsis
 
-Removes all clawker-managed volumes that are not currently in use.
+Removes unused clawker-managed agent volumes (volumes labeled with purpose=agent).
 
-This command removes volumes that are not attached to any container.
+By default only agent volumes are pruned. Other clawker-managed volumes
+(monitoring, firewall, control plane, etc.) are preserved unless --all is set.
 Use with caution as this will permanently delete data.
 
 ```
@@ -20,8 +21,11 @@ clawker volume prune [OPTIONS] [flags]
 ### Examples
 
 ```
-  # Remove all unused clawker volumes
+  # Remove unused agent volumes
   clawker volume prune
+
+  # Remove all unused clawker-managed volumes (agent, monitoring, etc.)
+  clawker volume prune --all
 
   # Remove without confirmation prompt
   clawker volume prune --force
@@ -30,6 +34,7 @@ clawker volume prune [OPTIONS] [flags]
 ### Options
 
 ```
+  -a, --all     Remove all clawker-managed volumes (default: only agent volumes)
   -f, --force   Do not prompt for confirmation
   -h, --help    help for prune
 ```

--- a/docs/cli-reference/clawker_volume_prune.md
+++ b/docs/cli-reference/clawker_volume_prune.md
@@ -10,8 +10,13 @@ Remove unused agent volumes
 
 Removes unused clawker-managed agent volumes (volumes labeled with purpose=agent).
 
-By default only agent volumes are pruned. Other clawker-managed volumes
-(monitoring, firewall, control plane, etc.) are preserved unless --all is set.
+By default all agent volumes are pruned — workspace, config, AND command
+history. Config and history volumes persist per-agent settings and shell
+history across sessions, so they will be lost if the matching agent container
+is not running at prune time. Infrastructure volumes (monitoring stack and
+any other clawker-managed volumes) are preserved unless --all is set.
+
+For targeted cleanup, prefer 'clawker volume list' + 'clawker volume remove'.
 Use with caution as this will permanently delete data.
 
 ```
@@ -21,10 +26,10 @@ clawker volume prune [OPTIONS] [flags]
 ### Examples
 
 ```
-  # Remove unused agent volumes
+  # Remove unused agent volumes (workspace, config, history)
   clawker volume prune
 
-  # Remove all unused clawker-managed volumes (agent, monitoring, etc.)
+  # Also remove infrastructure volumes (monitoring stack, etc.)
   clawker volume prune --all
 
   # Remove without confirmation prompt

--- a/docs/container-internals.mdx
+++ b/docs/container-internals.mdx
@@ -150,7 +150,7 @@ All resources are tagged with labels (`dev.clawker.project`, `dev.clawker.agent`
 
 ### Volume Lifecycle
 
-- **Config and history volumes** persist independently of containers. Removing a container does not remove its volumes. Use `clawker volume prune` to clean up orphaned volumes.
+- **Config and history volumes** persist independently of containers. Removing a container does not remove its volumes. `clawker volume prune` only sweeps agent workspace volumes by default; use `clawker volume prune --all` to also clean up config, history, and other clawker-managed volumes (monitoring, firewall, control plane).
 - **Workspace volumes** (snapshot mode only) are ephemeral and tied to the container lifecycle.
 - **Volume cleanup on failure** — If container creation fails partway through, only volumes created during that attempt are cleaned up. Pre-existing volumes with your session data are never touched.
 

--- a/docs/container-internals.mdx
+++ b/docs/container-internals.mdx
@@ -150,7 +150,7 @@ All resources are tagged with labels (`dev.clawker.project`, `dev.clawker.agent`
 
 ### Volume Lifecycle
 
-- **Config and history volumes** persist independently of containers. Removing a container does not remove its volumes. `clawker volume prune` only sweeps agent workspace volumes by default; use `clawker volume prune --all` to also clean up config, history, and other clawker-managed volumes (monitoring, firewall, control plane).
+- **Config and history volumes** persist independently of containers. Removing a container does not remove its volumes. `clawker volume prune` sweeps all unused agent volumes by default — config, history, and workspace. Use `clawker volume prune --all` to additionally clean up infrastructure volumes (monitoring stack and any other clawker-managed volumes). For targeted cleanup, prefer `clawker volume list` + `clawker volume remove`.
 - **Workspace volumes** (snapshot mode only) are ephemeral and tied to the container lifecycle.
 - **Volume cleanup on failure** — If container creation fails partway through, only volumes created during that attempt are cleaned up. Pre-existing volumes with your session data are never touched.
 

--- a/docs/docker-hygiene.mdx
+++ b/docs/docker-hygiene.mdx
@@ -42,7 +42,7 @@ clawker rm <container-name>
 ```
 
 <Warning>
-`clawker volume prune` removes **all** clawker-managed volumes not currently attached to a running container — including config and command history volumes that persist your agent's settings and shell history across sessions. Use `clawker volume list` and `clawker volume remove` for targeted cleanup instead.
+`clawker volume prune` removes unused agent workspace volumes by default. Passing `--all` widens the sweep to **all** clawker-managed volumes not currently attached to a running container — including config and command history volumes that persist your agent's settings and shell history across sessions. Use `clawker volume list` and `clawker volume remove` for targeted cleanup instead.
 </Warning>
 
 ### Docker-wide cleanup

--- a/docs/docker-hygiene.mdx
+++ b/docs/docker-hygiene.mdx
@@ -42,7 +42,7 @@ clawker rm <container-name>
 ```
 
 <Warning>
-`clawker volume prune` removes unused agent workspace volumes by default. Passing `--all` widens the sweep to **all** clawker-managed volumes not currently attached to a running container — including config and command history volumes that persist your agent's settings and shell history across sessions. Use `clawker volume list` and `clawker volume remove` for targeted cleanup instead.
+`clawker volume prune` removes **all** unused agent volumes by default — workspace, config, and command history. Config and history volumes persist your agent's settings and shell history across sessions, so they will be lost if the matching agent container is not running at prune time. Passing `--all` widens the sweep further to infrastructure volumes (monitoring stack and any other clawker-managed volumes). Use `clawker volume list` and `clawker volume remove` for targeted cleanup instead.
 </Warning>
 
 ### Docker-wide cleanup

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -158,7 +158,7 @@ clawker volume ls                     # List volumes
 
 clawker stop --agent dev              # Stop a container
 clawker rm --agent dev                # Remove a container
-clawker volume prune                  # Clean up orphaned agent volumes (add --all to include monitoring, firewall, config, history)
+clawker volume prune                  # Remove unused agent volumes — config, history, workspace (add --all for infra volumes like monitoring stack)
 ```
 
 ### Firewall Management

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -158,7 +158,7 @@ clawker volume ls                     # List volumes
 
 clawker stop --agent dev              # Stop a container
 clawker rm --agent dev                # Remove a container
-clawker volume prune                  # Clean up orphaned volumes
+clawker volume prune                  # Clean up orphaned agent volumes (add --all to include monitoring, firewall, config, history)
 ```
 
 ### Firewall Management

--- a/internal/cmd/volume/CLAUDE.md
+++ b/internal/cmd/volume/CLAUDE.md
@@ -13,7 +13,7 @@ Volume management for persistent workspace data and state.
 - `volume create` — create clawker volume
 - `volume inspect` — inspect volume details
 - `volume list` / `volume ls` — list clawker volumes
-- `volume prune` — remove unused volumes
+- `volume prune` — remove unused agent volumes (default); `-a`/`--all` extends to all clawker-managed purposes
 - `volume remove` / `volume rm` — remove specific volumes
 
 ## Key Symbols

--- a/internal/cmd/volume/prune/prune.go
+++ b/internal/cmd/volume/prune/prune.go
@@ -36,13 +36,18 @@ func NewCmdPrune(f *cmdutil.Factory, runF func(context.Context, *PruneOptions) e
 		Short: "Remove unused agent volumes",
 		Long: `Removes unused clawker-managed agent volumes (volumes labeled with purpose=agent).
 
-By default only agent volumes are pruned. Other clawker-managed volumes
-(monitoring, firewall, control plane, etc.) are preserved unless --all is set.
+By default all agent volumes are pruned — workspace, config, AND command
+history. Config and history volumes persist per-agent settings and shell
+history across sessions, so they will be lost if the matching agent container
+is not running at prune time. Infrastructure volumes (monitoring stack and
+any other clawker-managed volumes) are preserved unless --all is set.
+
+For targeted cleanup, prefer 'clawker volume list' + 'clawker volume remove'.
 Use with caution as this will permanently delete data.`,
-		Example: `  # Remove unused agent volumes
+		Example: `  # Remove unused agent volumes (workspace, config, history)
   clawker volume prune
 
-  # Remove all unused clawker-managed volumes (agent, monitoring, etc.)
+  # Also remove infrastructure volumes (monitoring stack, etc.)
   clawker volume prune --all
 
   # Remove without confirmation prompt

--- a/internal/cmd/volume/prune/prune.go
+++ b/internal/cmd/volume/prune/prune.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/schmitthub/clawker/internal/cmdutil"
+	"github.com/schmitthub/clawker/internal/consts"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/iostreams"
 	"github.com/schmitthub/clawker/internal/prompter"
@@ -19,6 +20,7 @@ type PruneOptions struct {
 	Prompter  func() *prompter.Prompter
 
 	Force bool
+	All   bool
 }
 
 // NewCmdPrune creates the volume prune command.
@@ -31,13 +33,17 @@ func NewCmdPrune(f *cmdutil.Factory, runF func(context.Context, *PruneOptions) e
 
 	cmd := &cobra.Command{
 		Use:   "prune [OPTIONS]",
-		Short: "Remove unused local volumes",
-		Long: `Removes all clawker-managed volumes that are not currently in use.
+		Short: "Remove unused agent volumes",
+		Long: `Removes unused clawker-managed agent volumes (volumes labeled with purpose=agent).
 
-This command removes volumes that are not attached to any container.
+By default only agent volumes are pruned. Other clawker-managed volumes
+(monitoring, firewall, control plane, etc.) are preserved unless --all is set.
 Use with caution as this will permanently delete data.`,
-		Example: `  # Remove all unused clawker volumes
+		Example: `  # Remove unused agent volumes
   clawker volume prune
+
+  # Remove all unused clawker-managed volumes (agent, monitoring, etc.)
+  clawker volume prune --all
 
   # Remove without confirmation prompt
   clawker volume prune --force`,
@@ -50,6 +56,7 @@ Use with caution as this will permanently delete data.`,
 	}
 
 	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Do not prompt for confirmation")
+	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Remove all clawker-managed volumes (default: only agent volumes)")
 
 	return cmd
 }
@@ -58,18 +65,22 @@ func pruneRun(ctx context.Context, opts *PruneOptions) error {
 	ios := opts.IOStreams
 	cs := ios.ColorScheme()
 
-	// Connect to Docker
 	client, err := opts.Client(ctx)
 	if err != nil {
-		cmdutil.HandleError(ios, err)
-		return err
+		return fmt.Errorf("connect to docker: %w", err)
 	}
 
-	// Prompt for confirmation if not forced
+	scope := "unused agent volumes"
+	emptyMsg := "No unused agent volumes to remove."
+	if opts.All {
+		scope = "all unused clawker-managed volumes"
+		emptyMsg = "No unused clawker volumes to remove."
+	}
+
 	if !opts.Force {
-		confirmed, err := opts.Prompter().Confirm(fmt.Sprintf("%s This will remove all unused clawker-managed volumes.", cs.WarningIcon()), false)
+		confirmed, err := opts.Prompter().Confirm(fmt.Sprintf("%s This will remove %s.", cs.WarningIcon(), scope), false)
 		if err != nil {
-			return err
+			return fmt.Errorf("confirm prune: %w", err)
 		}
 		if !confirmed {
 			fmt.Fprintln(ios.ErrOut, "Aborted.")
@@ -77,15 +88,18 @@ func pruneRun(ctx context.Context, opts *PruneOptions) error {
 		}
 	}
 
-	// Prune all unused managed volumes (all=true to include named volumes)
-	report, err := client.VolumesPrune(ctx, true)
+	var extraFilters []map[string]string
+	if !opts.All {
+		extraFilters = append(extraFilters, map[string]string{consts.LabelPurpose: consts.PurposeAgent})
+	}
+
+	report, err := client.VolumesPrune(ctx, true, extraFilters...)
 	if err != nil {
-		cmdutil.HandleError(ios, err)
-		return err
+		return fmt.Errorf("prune volumes: %w", err)
 	}
 
 	if len(report.Report.VolumesDeleted) == 0 {
-		fmt.Fprintln(ios.ErrOut, "No unused clawker volumes to remove.")
+		fmt.Fprintln(ios.ErrOut, emptyMsg)
 		return nil
 	}
 

--- a/internal/cmd/volume/prune/prune_test.go
+++ b/internal/cmd/volume/prune/prune_test.go
@@ -32,6 +32,16 @@ func TestNewCmdPrune(t *testing.T) {
 			input:    "-f",
 			wantOpts: PruneOptions{Force: true},
 		},
+		{
+			name:     "all flag",
+			input:    "--all",
+			wantOpts: PruneOptions{All: true},
+		},
+		{
+			name:     "all flag short",
+			input:    "-a",
+			wantOpts: PruneOptions{All: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -62,6 +72,7 @@ func TestNewCmdPrune(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, gotOpts)
 			require.Equal(t, tt.wantOpts.Force, gotOpts.Force)
+			require.Equal(t, tt.wantOpts.All, gotOpts.All)
 		})
 	}
 }
@@ -81,9 +92,11 @@ func TestCmdPrune_Properties(t *testing.T) {
 
 	// Test flags exist
 	require.NotNil(t, cmd.Flags().Lookup("force"))
+	require.NotNil(t, cmd.Flags().Lookup("all"))
 
 	// Test shorthand flags
 	require.NotNil(t, cmd.Flags().ShorthandLookup("f"))
+	require.NotNil(t, cmd.Flags().ShorthandLookup("a"))
 }
 
 func TestFormatBytes(t *testing.T) {

--- a/internal/docker/CLAUDE.md
+++ b/internal/docker/CLAUDE.md
@@ -23,7 +23,7 @@ Full terminal session lifecycle for interactive container sessions. `NewPTYHandl
 - **Volumes**: `clawker.project.agent-purpose` (workspace, config, history)
 - **Global volumes**: `clawker-<purpose>` — **Network**: from `config.Config.ClawkerNetwork()` (no constant in this package)
 
-Functions: `ValidateResourceName(name) error`, `ContainerName(project, agent) (string, error)`, `VolumeName(project, agent, purpose) (string, error)`, `ContainerNamesFromAgents(project, agents) ([]string, error)`, `GlobalVolumeName`, `ContainerNamePrefix`, `ImageTag`, `ParseContainerName`, `GenerateRandomName`. Constants: `NamePrefix = "clawker"`.
+Functions: `ValidateResourceName(name) error`, `ContainerName(project, agent) (string, error)`, `VolumeName(project, agent, purpose) (string, error)`, `ContainerNamesFromAgents(project, agents) ([]string, error)`, `ContainerNamePrefix`, `ImageTag`, `ParseContainerName`, `GenerateRandomName`. Constants: `NamePrefix = "clawker"`.
 
 **Validation**: `ValidateResourceName` validates user-sourced inputs (agent, project names) against Docker's container name rules: `^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`, max 128 chars. Built into `ContainerName` and `VolumeName` — callers cannot bypass validation. Internal `purpose` strings (`"config"`, `"history"`, `"workspace"`) are not validated.
 
@@ -31,7 +31,7 @@ Functions: `ValidateResourceName(name) error`, `ContainerName(project, agent) (s
 
 All label keys come from `config.Config` interface methods (`LabelManaged()`, `LabelProject()`, etc.). No label constants are exported from this package — callers use `(*Client)` methods which read keys from `c.cfg`.
 
-**Client methods** (all on `*Client`): `ContainerLabels(project, agent, version, image, workdir)`, `GlobalVolumeLabels(purpose)`, `VolumeLabels(project, agent, purpose)`, `ImageLabels(project, version)`, `NetworkLabels()`
+**Client methods** (all on `*Client`): `ContainerLabels(project, agent, version, image, workdir)`, `AgentVolumeLabels(project, agent)`, `ImageLabels(project, version)`, `NetworkLabels()`. `AgentVolumeLabels` always sets `purpose=PurposeAgent`; the config/history/workspace role lives in the volume name suffix, not the label.
 
 **Filters** (all on `*Client`): `ClawkerFilter()`, `ProjectFilter(project)`, `AgentFilter(project, agent)` — return `whail.Filters`.
 

--- a/internal/docker/CLAUDE.md
+++ b/internal/docker/CLAUDE.md
@@ -21,7 +21,7 @@ Full terminal session lifecycle for interactive container sessions. `NewPTYHandl
 
 - **3-segment** (project-scoped agent): `clawker.project.agent` — **2-segment** (global-scope agent, no project namespace): `clawker.agent`
 - **Volumes**: `clawker.project.agent-purpose` (workspace, config, history)
-- **Global volumes**: `clawker-<purpose>` — **Network**: from `config.Config.ClawkerNetwork()` (no constant in this package)
+- **Network**: from `config.Config.ClawkerNetwork()` (no constant in this package)
 
 Functions: `ValidateResourceName(name) error`, `ContainerName(project, agent) (string, error)`, `VolumeName(project, agent, purpose) (string, error)`, `ContainerNamesFromAgents(project, agents) ([]string, error)`, `ContainerNamePrefix`, `ImageTag`, `ParseContainerName`, `GenerateRandomName`. Constants: `NamePrefix = "clawker"`.
 

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -607,10 +607,9 @@ func (c *Client) RemoveContainerWithVolumes(ctx context.Context, containerID str
 // removeAgentVolumes removes all volumes associated with an agent.
 // Returns an error if any volume removal fails (unless the volume doesn't exist).
 //
-// NOTE: Global volumes (e.g. "clawker-globals") are NOT affected by this function.
-// Label-based lookup filters by project+agent, which global volumes lack.
-// Name fallback only targets "clawker.<project>.<agent>-*" patterns, which don't
-// match the "clawker-<purpose>" naming convention used by global volumes.
+// Scope: only volumes that carry both LabelProject and LabelAgent matching
+// the given pair, or whose names match "clawker.<project>.<agent>-*". Any
+// volume without that project+agent identity is untouched.
 func (c *Client) removeAgentVolumes(ctx context.Context, project, agent string, force bool) error {
 	var errs []string
 	removedByLabel := make(map[string]bool)

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -25,26 +25,19 @@ func (c *Client) ContainerLabels(project, agent, version, image, workdir string)
 	return labels
 }
 
-// VolumeLabels returns labels for a new volume.
-func (c *Client) VolumeLabels(project, agent, purpose string) map[string]string {
+// AgentVolumeLabels returns labels for an agent-scoped volume (config,
+// history, or workspace). All agent volumes carry purpose=PurposeAgent;
+// the per-volume role lives in the volume name suffix, not the label.
+func (c *Client) AgentVolumeLabels(project, agent string) map[string]string {
 	labels := map[string]string{
 		c.cfg.LabelManaged(): c.cfg.ManagedLabelValue(),
 		c.cfg.LabelAgent():   agent,
-		c.cfg.LabelPurpose(): purpose,
+		c.cfg.LabelPurpose(): c.cfg.PurposeAgent(),
 	}
 	if project != "" {
 		labels[c.cfg.LabelProject()] = project
 	}
 	return labels
-}
-
-// GlobalVolumeLabels returns labels for a global (non-agent-scoped) volume.
-// Only includes managed and purpose labels — no project or agent.
-func (c *Client) GlobalVolumeLabels(purpose string) map[string]string {
-	return map[string]string{
-		c.cfg.LabelManaged(): c.cfg.ManagedLabelValue(),
-		c.cfg.LabelPurpose(): purpose,
-	}
 }
 
 // ImageLabels returns labels for a built image.

--- a/internal/docker/labels_test.go
+++ b/internal/docker/labels_test.go
@@ -94,17 +94,17 @@ func TestContainerLabels(t *testing.T) {
 	})
 }
 
-func TestVolumeLabels(t *testing.T) {
+func TestAgentVolumeLabels(t *testing.T) {
 	c, cfg := testClient(t)
 
 	t.Run("with project", func(t *testing.T) {
-		labels := c.VolumeLabels("myproject", "myagent", "workspace")
+		labels := c.AgentVolumeLabels("myproject", "myagent")
 
 		expected := map[string]string{
 			cfg.LabelManaged(): cfg.ManagedLabelValue(),
 			cfg.LabelProject(): "myproject",
 			cfg.LabelAgent():   "myagent",
-			cfg.LabelPurpose(): "workspace",
+			cfg.LabelPurpose(): cfg.PurposeAgent(),
 		}
 
 		for key, want := range expected {
@@ -113,14 +113,14 @@ func TestVolumeLabels(t *testing.T) {
 			}
 		}
 
-		// VolumeLabels should NOT include created timestamp
+		// AgentVolumeLabels should NOT include created timestamp
 		if _, ok := labels[cfg.LabelCreated()]; ok {
-			t.Error("VolumeLabels should not include LabelCreated")
+			t.Error("AgentVolumeLabels should not include LabelCreated")
 		}
 	})
 
 	t.Run("empty project omits LabelProject", func(t *testing.T) {
-		labels := c.VolumeLabels("", "dev", "workspace")
+		labels := c.AgentVolumeLabels("", "dev")
 
 		if _, ok := labels[cfg.LabelProject()]; ok {
 			t.Error("labels should not contain LabelProject when project is empty")
@@ -129,36 +129,6 @@ func TestVolumeLabels(t *testing.T) {
 			t.Errorf("labels[LabelAgent] = %q, want %q", got, "dev")
 		}
 	})
-}
-
-func TestGlobalVolumeLabels(t *testing.T) {
-	c, cfg := testClient(t)
-
-	labels := c.GlobalVolumeLabels("globals")
-
-	expected := map[string]string{
-		cfg.LabelManaged(): cfg.ManagedLabelValue(),
-		cfg.LabelPurpose(): "globals",
-	}
-
-	for key, want := range expected {
-		if got := labels[key]; got != want {
-			t.Errorf("labels[%q] = %q, want %q", key, got, want)
-		}
-	}
-
-	// Should NOT include project or agent labels
-	if _, ok := labels[cfg.LabelProject()]; ok {
-		t.Error("GlobalVolumeLabels should not include LabelProject")
-	}
-	if _, ok := labels[cfg.LabelAgent()]; ok {
-		t.Error("GlobalVolumeLabels should not include LabelAgent")
-	}
-
-	// Should have exactly 2 labels
-	if got := len(labels); got != 2 {
-		t.Errorf("len(labels) = %d, want 2", got)
-	}
 }
 
 func TestImageLabels(t *testing.T) {

--- a/internal/docker/names.go
+++ b/internal/docker/names.go
@@ -211,9 +211,3 @@ func ImageTag(project string) string {
 	}
 	return fmt.Sprintf("%s-%s:latest", NamePrefix, project)
 }
-
-// GlobalVolumeName returns the name for a global (non-agent-scoped) volume.
-// Example: GlobalVolumeName("globals") → "clawker-globals"
-func GlobalVolumeName(purpose string) string {
-	return fmt.Sprintf("%s-%s", NamePrefix, purpose)
-}

--- a/internal/docker/names_test.go
+++ b/internal/docker/names_test.go
@@ -238,22 +238,3 @@ func TestImageTag(t *testing.T) {
 		})
 	}
 }
-
-func TestGlobalVolumeName(t *testing.T) {
-	tests := []struct {
-		purpose string
-		want    string
-	}{
-		{"globals", "clawker-globals"},
-		{"cache", "clawker-cache"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.purpose, func(t *testing.T) {
-			got := GlobalVolumeName(tt.purpose)
-			if got != tt.want {
-				t.Errorf("GlobalVolumeName(%q) = %q, want %q", tt.purpose, got, tt.want)
-			}
-		})
-	}
-}

--- a/internal/workspace/snapshot.go
+++ b/internal/workspace/snapshot.go
@@ -64,8 +64,8 @@ func (s *SnapshotStrategy) Prepare(ctx context.Context, cli *docker.Client) erro
 		return nil
 	}
 
-	// Create the volume with clawker's standard agent-volume labels so
-	// label-based cleanup in (*Client).removeAgentVolumes can find it.
+	// Use the standard agent-volume labels so cleanup queries on
+	// LabelProject + LabelAgent find this volume.
 	labels := cli.AgentVolumeLabels(s.config.ProjectName, s.config.AgentName)
 
 	created, err := cli.EnsureVolume(ctx, s.volumeName, labels)

--- a/internal/workspace/snapshot.go
+++ b/internal/workspace/snapshot.go
@@ -64,12 +64,9 @@ func (s *SnapshotStrategy) Prepare(ctx context.Context, cli *docker.Client) erro
 		return nil
 	}
 
-	// Create the volume
-	labels := map[string]string{
-		"clawker.project": s.config.ProjectName,
-		"clawker.type":    "workspace",
-		"clawker.mode":    "snapshot",
-	}
+	// Create the volume with clawker's standard agent-volume labels so
+	// label-based cleanup in (*Client).removeAgentVolumes can find it.
+	labels := cli.AgentVolumeLabels(s.config.ProjectName, s.config.AgentName)
 
 	created, err := cli.EnsureVolume(ctx, s.volumeName, labels)
 	if err != nil {

--- a/internal/workspace/snapshot_test.go
+++ b/internal/workspace/snapshot_test.go
@@ -1,0 +1,74 @@
+package workspace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/moby/api/types/volume"
+	mobyclient "github.com/moby/moby/client"
+
+	configmocks "github.com/schmitthub/clawker/internal/config/mocks"
+	"github.com/schmitthub/clawker/internal/docker/mocks"
+	"github.com/schmitthub/clawker/internal/logger"
+)
+
+// TestSnapshotStrategy_Prepare_UsesAgentVolumeLabels pins the contract that
+// SnapshotStrategy.Prepare creates its workspace volume with the standard
+// agent-volume labels. Without this, the cleanup query on
+// LabelProject + LabelAgent would miss the volume and only the name
+// fallback would catch it.
+func TestSnapshotStrategy_Prepare_UsesAgentVolumeLabels(t *testing.T) {
+	mockCfg := configmocks.NewBlankConfig()
+	fake := mocks.NewFakeClient(mockCfg)
+	fake.SetupVolumeExists("", false)
+
+	var captured map[string]string
+	fake.FakeAPI.VolumeCreateFn = func(_ context.Context, opts mobyclient.VolumeCreateOptions) (mobyclient.VolumeCreateResult, error) {
+		captured = opts.Labels
+		return mobyclient.VolumeCreateResult{
+			Volume: volume.Volume{Name: opts.Name, Labels: opts.Labels},
+		}, nil
+	}
+	// CopyToVolume errors during Prepare trigger a cleanup VolumeRemove.
+	fake.FakeAPI.VolumeRemoveFn = func(_ context.Context, _ string, _ mobyclient.VolumeRemoveOptions) (mobyclient.VolumeRemoveResult, error) {
+		return mobyclient.VolumeRemoveResult{}, nil
+	}
+
+	cfg := Config{
+		ProjectName: "myproj",
+		AgentName:   "myagent",
+		HostPath:    "/nonexistent-path-for-test",
+		RemotePath:  "/workspace",
+	}
+	s, err := NewSnapshotStrategy(cfg, logger.Nop())
+	if err != nil {
+		t.Fatalf("NewSnapshotStrategy: %v", err)
+	}
+
+	// Prepare fails inside CopyToVolume because HostPath doesn't exist, but
+	// labels are captured by EnsureVolume which runs first.
+	_ = s.Prepare(t.Context(), fake.Client)
+
+	if captured == nil {
+		t.Fatal("VolumeCreate was never called — labels not captured")
+	}
+	if got := captured[mockCfg.LabelPurpose()]; got != mockCfg.PurposeAgent() {
+		t.Errorf("LabelPurpose = %q, want %q", got, mockCfg.PurposeAgent())
+	}
+	if got := captured[mockCfg.LabelProject()]; got != "myproj" {
+		t.Errorf("LabelProject = %q, want %q", got, "myproj")
+	}
+	if got := captured[mockCfg.LabelAgent()]; got != "myagent" {
+		t.Errorf("LabelAgent = %q, want %q", got, "myagent")
+	}
+	if _, ok := captured[mockCfg.LabelManaged()]; !ok {
+		t.Error("LabelManaged missing")
+	}
+	// Guard against regression to the pre-fix hand-rolled label map.
+	for k := range captured {
+		switch k {
+		case "clawker.project", "clawker.type", "clawker.mode":
+			t.Errorf("legacy label %q must not be present", k)
+		}
+	}
+}

--- a/internal/workspace/strategy.go
+++ b/internal/workspace/strategy.go
@@ -127,7 +127,7 @@ func EnsureConfigVolumes(ctx context.Context, cli *docker.Client, projectName, a
 	if err != nil {
 		return result, err
 	}
-	configLabels := cli.VolumeLabels(projectName, agentName, "config")
+	configLabels := cli.AgentVolumeLabels(projectName, agentName)
 	created, err := cli.EnsureVolume(ctx, configVolume, configLabels)
 	if err != nil {
 		return result, err
@@ -138,7 +138,7 @@ func EnsureConfigVolumes(ctx context.Context, cli *docker.Client, projectName, a
 	if err != nil {
 		return result, err
 	}
-	historyLabels := cli.VolumeLabels(projectName, agentName, "history")
+	historyLabels := cli.AgentVolumeLabels(projectName, agentName)
 	created, err = cli.EnsureVolume(ctx, historyVolume, historyLabels)
 	if err != nil {
 		return result, err

--- a/pkg/whail/CLAUDE.md
+++ b/pkg/whail/CLAUDE.md
@@ -96,7 +96,7 @@ Domain helpers for build progress display. These live in `whail` (bottom of the 
 
 ## Volume Operations (8 methods)
 
-`VolumeCreate(ctx, opts, extraLabels...)`, `VolumeRemove(ctx, id, force)`, `VolumeInspect(ctx, id)`, `VolumeExists(ctx, id)`, `VolumeList(ctx, extraFilters...)`, `VolumeListAll(ctx)`, `IsVolumeManaged(ctx, name)`, `VolumesPrune(ctx, all)`
+`VolumeCreate(ctx, opts, extraLabels...)`, `VolumeRemove(ctx, id, force)`, `VolumeInspect(ctx, id)`, `VolumeExists(ctx, id)`, `VolumeList(ctx, extraFilters...)`, `VolumeListAll(ctx)`, `IsVolumeManaged(ctx, name)`, `VolumesPrune(ctx, all, extraFilters...)`
 
 **Note:** `VolumeExists` delegates to `IsVolumeManaged` — an unmanaged volume with the same name is treated as "not found".
 

--- a/pkg/whail/volume.go
+++ b/pkg/whail/volume.go
@@ -107,11 +107,17 @@ func (e *Engine) IsVolumeManaged(ctx context.Context, name string) (bool, error)
 
 // VolumesPrune removes all unused managed volumes.
 // The managed label filter is automatically injected to ensure only
-// managed volumes are affected.
+// managed volumes are affected. Additional label filters from extraFilters
+// are ANDed onto the managed filter to narrow the prune scope.
 // If all is true, prunes all unused volumes including named ones.
 // If all is false, only prunes anonymous volumes (Docker's default behavior).
-func (e *Engine) VolumesPrune(ctx context.Context, all bool) (client.VolumePruneResult, error) {
+func (e *Engine) VolumesPrune(ctx context.Context, all bool, extraFilters ...map[string]string) (client.VolumePruneResult, error) {
 	f := e.newManagedFilter()
+	for _, labels := range extraFilters {
+		for k, v := range labels {
+			f = f.Add("label", k+"="+v)
+		}
+	}
 	result, err := e.APIClient.VolumePrune(ctx, client.VolumePruneOptions{All: all, Filters: f})
 	if err != nil {
 		return client.VolumePruneResult{}, ErrVolumesPruneFailed(err)


### PR DESCRIPTION
## Summary

- **`clawker volume prune` default narrowed.** Previously removed every unused clawker-managed volume (agent workspaces, config, history, monitoring, firewall, control plane). Now removes only volumes labeled `dev.clawker.purpose=agent`. New `-a` / `--all` flag restores the prior broader behavior.
- **Agent volume purpose label collapsed** from `agent_workspace` to `agent`, simplifying the `purpose=` taxonomy (`agent`, `monitoring`, `firewall`, `controlplane`, `config`, `history`).
- **`whail.Engine.VolumesPrune` signature extended** with variadic `extraFilters ...map[string]string`, mirroring the existing `VolumeList` pattern; existing callers unaffected.
- Documentation sweep across `docs/`, `CLAUDE.md` files, and the `clawker-support` skill reference to correct stale descriptions of the old prune behavior. `clawker-support` plugin bumped 0.12.0 → 0.12.1.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cmd/volume/... ./pkg/whail/... ./internal/docs/...`
- [x] `make pre-commit` (unit tests, golangci-lint, govulncheck, semgrep, doc freshness)
- [x] Manual end-to-end on host: create agent + monitoring stack, confirm `clawker volume prune --force` only removes `purpose=agent` volumes, then `clawker volume prune --all --force` removes the remaining unused managed volumes
- [x] `npx mintlify dev --docs-directory docs` to visually verify regenerated `clawker_volume_prune.md` reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)