### PR TITLE
fix(firewall): default-block claude.ai UGC paths + longest-prefix route order

### DIFF
--- a/cmd/clawkerd/session_test.go
+++ b/cmd/clawkerd/session_test.go
@@ -325,7 +325,13 @@ func TestStartShellCommand_InitialStdinCloseStdinRace(t *testing.T) {
 	const id = "init-stdin-race-1"
 
 	s, _ := newTestSession()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Deadlines are decoupled so the success path can never be pre-empted by
+	// a timeout firing first: the test read deadline (20s) is the smallest, so
+	// a genuine hang fails with the useful "Done never arrived" message rather
+	// than the ctx silently dropping the terminal Done or the command timeout
+	// surfacing ERROR_CODE_TIMEOUT. All three are far above the fork/exec +
+	// pipe + reap cost of /bin/cat, so a loaded CI runner won't false-fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Dispatch ShellCommand and CloseStdin back-to-back via dispatch().
@@ -338,7 +344,7 @@ func TestStartShellCommand_InitialStdinCloseStdinRace(t *testing.T) {
 		Payload: &clawkerdv1.Command_Shell{Shell: &clawkerdv1.ShellCommand{
 			Stages:         []*clawkerdv1.PipeStage{{Argv: []string{"/bin/cat"}}},
 			InitialStdin:   []byte(payload),
-			TimeoutSeconds: 5,
+			TimeoutSeconds: 30,
 		}},
 	})
 	s.dispatch(ctx, &clawkerdv1.Command{
@@ -348,7 +354,7 @@ func TestStartShellCommand_InitialStdinCloseStdinRace(t *testing.T) {
 
 	// Drain Responses until Done; assemble stdout.
 	var stdout strings.Builder
-	deadline := time.After(4 * time.Second)
+	deadline := time.After(20 * time.Second)
 	for {
 		select {
 		case r := <-s.sendCh:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -469,6 +469,24 @@ func TestRequiredFirewallRules(t *testing.T) {
 	// Returned slice is a copy
 	rules[0].Dst = "mutated.com"
 	assert.Equal(t, "api.anthropic.com", cfg.RequiredFirewallRules()[0].Dst)
+
+	// Nested PathRules are deep-copied: mutating a returned rule's PathRules
+	// must not corrupt the package-level defaults (these are load-bearing
+	// security denies, e.g. .claude.ai /public/ + /share/ UGC paths).
+	idx := -1
+	for i := range rules {
+		if len(rules[i].PathRules) > 0 {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, idx, 0, "expected at least one default rule with PathRules")
+	rules[idx].PathRules[0].Action = "allow"
+	rules[idx].PathRules = append(rules[idx].PathRules, PathRule{Path: "/injected/", Action: "allow"})
+
+	fresh := cfg.RequiredFirewallRules()[idx]
+	assert.Equal(t, "deny", fresh.PathRules[0].Action, "PathRules must be deep-copied; mutation leaked into defaults")
+	assert.Len(t, fresh.PathRules, 2, "appending to returned PathRules must not grow the defaults")
 }
 
 // --- Generated defaults validation ---

--- a/internal/config/consts.go
+++ b/internal/config/consts.go
@@ -120,6 +120,14 @@ func (c *configImpl) CoreDNSHealthPath() string { return consts.CoreDNSHealthPat
 func (c *configImpl) RequiredFirewallRules() []EgressRule {
 	result := make([]EgressRule, len(requiredFirewallRules))
 	copy(result, requiredFirewallRules)
+	// Deep-copy PathRules so callers can't mutate the package-level defaults.
+	for i := range result {
+		if len(result[i].PathRules) > 0 {
+			pr := make([]PathRule, len(result[i].PathRules))
+			copy(pr, result[i].PathRules)
+			result[i].PathRules = pr
+		}
+	}
 	return result
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -17,7 +17,21 @@ var requiredFirewallRules = []EgressRule{
 	{Dst: "api.anthropic.com", Proto: "https", Port: 443, Action: "allow"},
 	{Dst: "claude.com", Proto: "https", Port: 443, Action: "allow"},
 	{Dst: "platform.claude.com", Proto: "https", Port: 443, Action: "allow"},
-	{Dst: ".claude.ai", Proto: "https", Port: 443, Action: "allow"},
+	// .claude.ai serves both Claude Code OAuth + Anthropic-hosted UGC. The
+	// host-scope allow is required for login; the explicit deny PathRules
+	// scope out documented UGC surfaces so an injected prompt can't pivot
+	// an agent into fetching attacker-authored content from a trusted
+	// origin (public artifacts render HTML/JS; shared chats are UGC by
+	// definition). PathDefault is left empty so EffectivePathDefault
+	// returns "allow" — denylist mode keeps OAuth/login flows intact under
+	// `/` and `/login` (the only Allow patterns in claude.ai's robots.txt).
+	{
+		Dst: ".claude.ai", Proto: "https", Port: 443, Action: "allow",
+		PathRules: []PathRule{
+			{Path: "/public/", Action: "deny"},
+			{Path: "/share/", Action: "deny"},
+		},
+	},
 	// Claude Code — MCP proxy
 	{Dst: "mcp-proxy.anthropic.com", Proto: "https", Port: 443, Action: "allow"},
 	// Node.js / npm — registry for `npm install -g` (presets + user_run) and

--- a/internal/controlplane/firewall/envoy_config.go
+++ b/internal/controlplane/firewall/envoy_config.go
@@ -1032,7 +1032,17 @@ func buildHTTPRoutes(r config.EgressRule, clusterName string) []any {
 	// (%METADATA(ROUTE:clawker:action)%) reads this at emit time so the
 	// firewall verdict is concrete per record (never inferred from
 	// response_code). See clawkerActionMetadata.
-	for _, pr := range r.PathRules {
+	//
+	// Sort longest-prefix-first: Envoy route matching is first-match-wins on
+	// prefix, so slice order would let a broad rule (deny /public/) shadow a
+	// narrower override (allow /public/sub/). Stable sort keeps insertion
+	// order for equal-length prefixes, preserving MergeRule's caller-wins
+	// semantics on identical-path collisions.
+	prs := append([]config.PathRule(nil), r.PathRules...)
+	sort.SliceStable(prs, func(i, j int) bool {
+		return len(prs[i].Path) > len(prs[j].Path)
+	})
+	for _, pr := range prs {
 		if strings.EqualFold(pr.Action, "allow") {
 			routes = append(routes, map[string]any{
 				"match":    map[string]any{"prefix": pr.Path},

--- a/internal/controlplane/firewall/envoy_config_test.go
+++ b/internal/controlplane/firewall/envoy_config_test.go
@@ -233,6 +233,44 @@ func TestGenerateEnvoyConfig_TLSClusterAutoConfig(t *testing.T) {
 	}
 }
 
+// routesForDomain walks a generated Envoy config and returns the ordered
+// route entries emitted under the HCM virtual host whose domains include the
+// given SNI. Only that virtual host is inspected — sibling hosts (e.g. the
+// deny_all SNI catch-all) carry their own routes by design. Returns routes in
+// emission order, which is the order Envoy evaluates them (first-match-wins).
+func routesForDomain(t *testing.T, cfg map[string]any, domain string) []map[string]any {
+	t.Helper()
+	var routes []map[string]any
+	listeners := cfg["static_resources"].(map[string]any)["listeners"].([]any)
+	for _, l := range listeners {
+		for _, c := range l.(map[string]any)["filter_chains"].([]any) {
+			for _, f := range c.(map[string]any)["filters"].([]any) {
+				flt := f.(map[string]any)
+				if flt["name"] != "envoy.filters.network.http_connection_manager" {
+					continue
+				}
+				rc, _ := flt["typed_config"].(map[string]any)["route_config"].(map[string]any)
+				if rc == nil {
+					continue
+				}
+				for _, vh := range rc["virtual_hosts"].([]any) {
+					vhost := vh.(map[string]any)
+					domains, _ := vhost["domains"].([]any)
+					for _, d := range domains {
+						if s, ok := d.(string); ok && s == domain {
+							for _, r := range vhost["routes"].([]any) {
+								routes = append(routes, r.(map[string]any))
+							}
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	return routes
+}
+
 // TestGenerateEnvoyConfig_DenylistPathRules_InferAllowDefault locks in the
 // fix for the inverse path-rule bug: a rule with only deny path_rules and
 // no explicit PathDefault must catch unmatched paths through to upstream
@@ -273,62 +311,76 @@ func TestGenerateEnvoyConfig_DenylistPathRules_InferAllowDefault(t *testing.T) {
 
 	var catchAllAction, adminAction string
 	catchAllSeen, adminSeen := false, false
-	listeners := cfg["static_resources"].(map[string]any)["listeners"].([]any)
-	for _, l := range listeners {
-		lis := l.(map[string]any)
-		for _, c := range lis["filter_chains"].([]any) {
-			ch := c.(map[string]any)
-			for _, f := range ch["filters"].([]any) {
-				flt := f.(map[string]any)
-				if flt["name"] != "envoy.filters.network.http_connection_manager" {
-					continue
-				}
-				tc := flt["typed_config"].(map[string]any)
-				rc, _ := tc["route_config"].(map[string]any)
-				if rc == nil {
-					continue
-				}
-				for _, vh := range rc["virtual_hosts"].([]any) {
-					vhost := vh.(map[string]any)
-					// Only inspect the docs.example.com virtual host —
-					// other virtual hosts (e.g. deny_all SNI catch-all)
-					// carry their own denied catch-all by design.
-					domains, _ := vhost["domains"].([]any)
-					isTarget := false
-					for _, d := range domains {
-						if s, ok := d.(string); ok && s == "docs.example.com" {
-							isTarget = true
-							break
-						}
-					}
-					if !isTarget {
-						continue
-					}
-					for _, r := range vhost["routes"].([]any) {
-						route := r.(map[string]any)
-						match, _ := route["match"].(map[string]any)
-						prefix, _ := match["prefix"].(string)
-						md := route["metadata"].(map[string]any)
-						fm := md["filter_metadata"].(map[string]any)
-						clw := fm["clawker"].(map[string]any)
-						action := clw["action"].(string)
-						switch prefix {
-						case "/":
-							catchAllAction = action
-							catchAllSeen = true
-						case "/admin":
-							adminAction = action
-							adminSeen = true
-						}
-					}
-				}
-			}
+	for _, route := range routesForDomain(t, cfg, "docs.example.com") {
+		match, _ := route["match"].(map[string]any)
+		prefix, _ := match["prefix"].(string)
+		md := route["metadata"].(map[string]any)
+		fm := md["filter_metadata"].(map[string]any)
+		clw := fm["clawker"].(map[string]any)
+		action := clw["action"].(string)
+		switch prefix {
+		case "/":
+			catchAllAction = action
+			catchAllSeen = true
+		case "/admin":
+			adminAction = action
+			adminSeen = true
 		}
 	}
 	require.True(t, adminSeen, "/admin path-rule route not found in docs.example.com virtual host")
 	require.True(t, catchAllSeen, `catch-all "/" route not found in docs.example.com virtual host`)
 	assert.Equal(t, "denied", adminAction, "/admin path rule must carry denied verdict")
 	assert.Equal(t, "allowed", catchAllAction, `catch-all "/" must carry allowed verdict — inferred PathDefault for denylist-only rule`)
+}
+
+// TestGenerateEnvoyConfig_PathRulesEmitLongestPrefixFirst asserts that
+// buildHTTPRoutes emits path-rule routes ordered longest-prefix-first so
+// Envoy's first-match-wins prefix matching resolves to the most specific
+// rule. Without this, a narrower override (e.g. an allow on /public/sub/) is
+// unreachable when a broader rule (a deny on /public/) is emitted first —
+// Envoy stops at the broad prefix and the specific rule never runs.
+func TestGenerateEnvoyConfig_PathRulesEmitLongestPrefixFirst(t *testing.T) {
+	t.Parallel()
+
+	// Mixed prefix lengths in non-sorted insertion order to prove the sort
+	// — not the insertion order — drives emission. The final emitted order
+	// must be longest-first regardless of how they appeared in the slice.
+	rules := []config.EgressRule{
+		{
+			Dst:    "api.example.com",
+			Proto:  "https",
+			Port:   443,
+			Action: "allow",
+			PathRules: []config.PathRule{
+				{Path: "/api/", Action: "allow"},
+				{Path: "/api/v1/internal/", Action: "deny"},
+				{Path: "/admin/", Action: "deny"},
+			},
+		},
+	}
+	ports := EnvoyPorts{EgressPort: 10000, TCPPortBase: 10001, HealthPort: 18901}
+
+	yamlBytes, warnings, err := GenerateEnvoyConfig(rules, ports, ALSConfig{})
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(yamlBytes, &cfg))
+
+	// Collect every route prefix in the order Envoy will evaluate them.
+	var prefixes []string
+	for _, route := range routesForDomain(t, cfg, "api.example.com") {
+		match, _ := route["match"].(map[string]any)
+		if p, ok := match["prefix"].(string); ok {
+			prefixes = append(prefixes, p)
+		}
+	}
+
+	// Expected emission order: longest path rule first, then shorter, then
+	// the catch-all "/" emitted by EffectivePathDefault. Equal-length
+	// prefixes (none here) would preserve insertion order via stable sort.
+	want := []string{"/api/v1/internal/", "/admin/", "/api/", "/"}
+	assert.Equal(t, want, prefixes, "path-rule routes must be emitted longest-prefix-first so Envoy first-match-wins resolves to the most specific rule")
 }
 
 func TestGenerateEnvoyConfig_ZeroPortTLSDefaults443(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #316. Two coupled changes — the ordering fix must land for the default deny to be overridable.

- **`internal/config/defaults.go`** — scope the default `.claude.ai` allow rule with deny `PathRules` for `/public/` and `/share/`. Public artifacts render attacker-authored HTML/JS and shared chats are UGC; both are reachable from a *trusted* origin today, so a prompt-injection payload can pivot an agent into fetching attacker content that the firewall sees as same-origin as the OAuth surface. `PathDefault` left empty → `EffectivePathDefault` infers `allow` (denylist mode), so OAuth/login under `/` and `/login` keep working.
- **`internal/controlplane/firewall/envoy_config.go`** — `buildHTTPRoutes` now sorts `PathRules` longest-prefix-first (stable) before emission. Envoy route matching is first-match-wins on prefix; emitting in slice order let a broad default (deny `/public/`) shadow a narrower user override (allow `/public/sub/`), leaving the override unreachable. This matches the "most specific rule wins" model (Cloudflare WAF, nginx `location`, API Gateway path policies). Stable sort preserves insertion order for equal-length prefixes, so `MergeRule`'s caller-wins semantics on identical-path collisions are untouched.

### Path-set rationale (grounded against live data)

Only `/public/` + `/share/` — kept tight to avoid brittle paths:
- `claude.ai/robots.txt` Disallows `/share/*`, `/chat/*`, `/api/*`, `/new?*`, `/magic-link*`, `/onboarding*`, `/upgrade*`, `/lti/*`, `/settings*`, `/task*`; only `/$` and `/login` are Allowed.
- `/public/artifacts/<uuid>` is the documented public-artifact surface (the issue's exact attack vector).
- `/chat/*` is owner-scoped (cross-user UGC goes through `/share/`); `/api/*` etc. are app routes, not UGC.

## Test plan

- [x] Unit: `TestGenerateEnvoyConfig_PathRulesEmitLongestPrefixFirst` — asserts emission order `[/api/v1/internal/, /admin/, /api/, /]` from non-sorted input; fails if the sort is removed.
- [x] Unit: existing `TestGenerateEnvoyConfig_DenylistPathRules_InferAllowDefault` still green (refactored both onto a shared `routesForDomain` walker).
- [x] Full `internal/controlplane/firewall/` + `internal/config/` suites pass; `go vet` clean; pre-commit (gitleaks/semgrep/golangci-lint/govulncheck/unit) pass.
- [x] UAT in a live agent container:
  - `/public/artifacts/<uuid>` → 403 (`Forbidden`, clawker block); `/share/abc` → 403; `/login` → passes through to upstream (CF challenge, not clawker).
  - Narrower override (`firewall add claude.ai --path /public/artifacts/<uuid> --action allow`) → whitelisted path returns 200 upstream content while siblings stay denied — confirms the longest-prefix route is reachable.

## Notes

- Seed path: new required-rule defaults only enter the egress-rules store at agent `BootstrapServicesPreStart` (`container_start.go`). `clawker firewall up` / CP boot do **not** re-seed. Existing deployments pick up the deny on next agent (re)start. Propagating shipped default-rule changes to already-running deployments without an agent restart is a separate gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)