### PR TITLE
fix(keyring): inject expired-but-refreshable host Claude Code credentials

### DIFF
--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "0.16.1",
+  "version": "1.0.1",
   "author": {
     "name": "schmitthub"
   },

--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "schmitthub"
   },

--- a/claude-plugin/clawker-support/CLAUDE.md
+++ b/claude-plugin/clawker-support/CLAUDE.md
@@ -67,7 +67,7 @@ claude-plugin/clawker-support/
         ├── docker-hygiene.md     # Docker disk space diagnosis and cleanup
         ├── monitoring.md         # OTel + OpenSearch + Prometheus stack, Clawker workspace, telemetry env, troubleshooting
         ├── firewall-security.md  # Proactive VCS egress lockdown — git credential-exfil defense (HTTPS path-scoping, GitHub write surface, monitoring-discovery loop)
-        ├── claude-code-auth.md   # Claude Code host-auth credential model — create-time snapshot, volume self-heal, host↔container isolation, /login troubleshooting
+        ├── claude-code.md        # Claude Code integration — auth section: host-auth credential model, create-time snapshot, volume self-heal, one-way sync, /login troubleshooting
         └── known-issues.md       # Active bugs and workarounds
 ```
 

--- a/claude-plugin/clawker-support/CLAUDE.md
+++ b/claude-plugin/clawker-support/CLAUDE.md
@@ -67,6 +67,7 @@ claude-plugin/clawker-support/
         ├── docker-hygiene.md     # Docker disk space diagnosis and cleanup
         ├── monitoring.md         # OTel + OpenSearch + Prometheus stack, Clawker workspace, telemetry env, troubleshooting
         ├── firewall-security.md  # Proactive VCS egress lockdown — git credential-exfil defense (HTTPS path-scoping, GitHub write surface, monitoring-discovery loop)
+        ├── claude-code-auth.md   # Claude Code host-auth credential model — create-time snapshot, volume self-heal, host↔container isolation, /login troubleshooting
         └── known-issues.md       # Active bugs and workarounds
 ```
 
@@ -86,12 +87,18 @@ diagnostics (clawker not found, firewall, credentials, container won't start).
 
 ## Versioning
 
-Plugin version lives in `.claude-plugin/plugin.json`. Bump it for every
-release-worthy change:
+Plugin version lives in `.claude-plugin/plugin.json`. **Every change bumps the
+patch number (`1.0.Z` → `1.0.Z+1`). No exceptions.**
 
-- **Patch** (0.x.Y): Typo fixes, wording improvements
-- **Minor** (0.X.0): New reference files, workflow changes, structural refactors
-- **Major** (X.0.0): Breaking changes to skill behavior or methodology
+The version IS the delivery mechanism. This plugin is served from a separate
+repo, and the release pipeline only picks up a change when the version
+increments (the marketplace caches by version). A change with no bump stays in
+this repo and never reaches users — so "is this worth a bump?" is the wrong
+question: if you touched the plugin, bump it. A typo fix, a new reference file,
+and a workflow rewrite are each just the next patch.
+
+Keep it patch-only. Minor/major are reserved for a deliberate, announced change
+in how the plugin works, which effectively never happens here.
 
 ## Completion Gate
 
@@ -100,7 +107,8 @@ After making changes to the plugin:
 1. Check that `known-issues.md` is still accurate — remove entries for fixed bugs
 2. Verify reference file cross-references are consistent (troubleshooting routing
    table, SKILL.md research step references)
-3. Bump the version in `plugin.json` if the change is user-visible
+3. Bump the patch version in `plugin.json` (see Versioning — the release
+   pipeline requires an increment per change)
 
 ## Dockerfile Template Sync
 

--- a/claude-plugin/clawker-support/skills/clawker-support/SKILL.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/SKILL.md
@@ -350,9 +350,10 @@ integrates with.
 15. **Claude Code host auth (`/login` prompts in containers)** — When the user
     asks how `use_host_auth` shares their host login, or reports being prompted
     for `/login` inside containers despite host auth being on, read
-    `reference/claude-code-auth.md`. It covers the create-time credential
-    snapshot, why the config volume self-heals across restarts, and the one-way
-    host↔container isolation that explains why an expired host refresh token
+    `reference/claude-code.md` (Authentication section). It covers the
+    create-time credential snapshot, why the config volume self-heals across
+    restarts, and the one-way host↔container model that explains why an expired
+    host refresh token
     forces a one-time re-login (and why re-authenticating on the host fixes only
     future containers).
 

--- a/claude-plugin/clawker-support/skills/clawker-support/SKILL.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/SKILL.md
@@ -347,6 +347,15 @@ integrates with.
     abuses forwarded git credentials to exfil to an arbitrary repo (domain-only
     sandboxes can't stop this; clawker's HTTPS path allow/deny can).
 
+15. **Claude Code host auth (`/login` prompts in containers)** — When the user
+    asks how `use_host_auth` shares their host login, or reports being prompted
+    for `/login` inside containers despite host auth being on, read
+    `reference/claude-code-auth.md`. It covers the create-time credential
+    snapshot, why the config volume self-heals across restarts, and the one-way
+    host↔container isolation that explains why an expired host refresh token
+    forces a one-time re-login (and why re-authenticating on the host fixes only
+    future containers).
+
 ### Step 4: Analyze — classify and decide placement
 
 Cross-reference your research to classify every item. This is the most common

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/claude-code-auth.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/claude-code-auth.md
@@ -1,0 +1,105 @@
+# Claude Code Host Authentication
+
+How clawker shares the host's Claude Code login with agent containers, and why
+that sharing has limits. Read this when a user reports authentication prompts
+(`/login`) inside containers, or asks how `use_host_auth` works.
+
+`use_host_auth` (under `agent.claude_code`, default enabled) is the only knob.
+Fetch `https://docs.clawker.dev/configuration` for the current field path and
+schema — everything below is the stable model, not field syntax.
+
+## The credential model
+
+Claude Code authenticates with an OAuth credential pair:
+
+- an **access token** — short-lived, used for every request, carries an expiry
+- a **refresh token** — long-lived, used to mint a new access token (and a
+  newly rotated refresh token) when the access token expires
+
+On the **host**, Claude Code keeps this pair in the OS keychain (with a file
+fallback). When the access token expires, Claude Code silently refreshes it
+using the refresh token and writes the rotated pair back to the keychain. The
+user never sees a prompt as long as the refresh token is still valid. A prompt
+(`/login`) appears only when the refresh token itself is expired or revoked.
+
+## How clawker shares it with a container
+
+When `use_host_auth` is enabled, clawker reads the host's stored Claude
+credentials **once, at container create time**, and writes them into the
+container's config **named volume** (mounted at `~/.claude`, as
+`.credentials.json`). Three properties follow from this, and they explain almost
+every support question:
+
+1. **Create-only snapshot.** Injection happens when the container is *created*,
+   never on `start` or `restart`. A restarted container keeps whatever
+   credentials its volume already holds. Re-running `clawker` against an
+   existing container does not re-read the host.
+
+2. **The volume self-heals.** Claude Code on Linux stores credentials in an OS
+   Secret Service (libsecret / gnome-keyring over D-Bus) **when one is present**,
+   and falls back to the plaintext `.credentials.json` otherwise. Clawker's base
+   image ships no Secret Service, so Claude Code reads and writes
+   `.credentials.json` in the config volume directly. The first time the
+   in-container access token expires, Claude Code refreshes it against the OAuth
+   endpoint (allowlisted by default) and writes the rotated pair *back into the
+   volume*. Because the volume persists across restarts, that refreshed refresh
+   token sticks — the container keeps itself logged in on its own from then on.
+
+   This file fallback is *why* persistence works. If a user bakes a Secret
+   Service backend (e.g. `gnome-keyring` + `dbus`) into a custom image, Claude
+   Code may store refreshed credentials in the keyring instead — which does not
+   live under `~/.claude`, so it would not survive container recreation and
+   could defeat the self-heal. For shared-host-auth to behave as described, let
+   Claude Code use the file.
+
+3. **Isolation is one-way.** The container cannot write back to the host
+   keychain, and the host cannot reach an already-created container's volume.
+   Refreshing on one side never updates the other. This is by design — the
+   sandbox boundary — but it is the root of the `/login` confusion below.
+
+An expired *access* token at create time is harmless: clawker injects it
+anyway, because the refresh token (not the access token) is what lets Claude
+Code recover, and it refreshes on first use. Only the **refresh token's**
+validity matters for whether a fresh container starts authenticated.
+
+## Troubleshooting
+
+### Repeated `/login` in new containers despite `use_host_auth` enabled
+
+**Symptom.** Every new agent container prompts for `/login` even though
+`agent.claude_code.use_host_auth` is on.
+
+**Most likely cause.** The host's **refresh token was already expired or
+revoked** when the container was created. The snapshot clawker copied in could
+not be refreshed, so Claude Code falls back to an interactive login. Nothing is
+misconfigured — the shared credential was simply stale at copy time.
+
+There is deliberately **no way to check or refresh the host's refresh token
+from inside a container.** The credential blob doesn't even expose the refresh
+token's expiry (only the access token's), and the sandbox can't touch the host
+keychain. So this isn't diagnosed by inspecting the container — it's reasoned
+about from the model above.
+
+**For the container that already prompted: nothing more to do.** Once the user
+completes `/login` inside it, Claude Code writes the fresh, rotated credentials
+into that container's config volume. The volume persists across restarts and
+keeps refreshing itself, so the user won't be prompted again in that container.
+They do **not** need to recreate or restart it.
+
+**To stop *future* new containers from prompting: re-authenticate on the host.**
+Have the user start a Claude Code session on the **host** and log in (or run
+any host Claude Code command that triggers a refresh). That writes a fresh
+refresh token into the host keychain, which new containers will snapshot at
+create time. Caveat: only containers created *after* the host re-auth benefit —
+ones created earlier keep their own (now self-healed) volume credentials.
+
+**If it persists for brand-new containers created after a host re-login**, rule
+out the simpler causes:
+
+- `use_host_auth` is actually disabled for this project/agent (it defaults on,
+  but a config may set it off). Confirm against the live config schema.
+- The container was created in "fresh" mode, which intentionally skips copying
+  host config and credentials.
+- The user was never authenticated on the host at all — in that case container
+  creation fails with an explicit "no credentials found" error rather than a
+  silent `/login` prompt, so this is a different symptom.

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/claude-code.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/claude-code.md
@@ -1,14 +1,20 @@
-# Claude Code Host Authentication
+# Claude Code
 
-How clawker shares the host's Claude Code login with agent containers, and why
-that sharing has limits. Read this when a user reports authentication prompts
-(`/login`) inside containers, or asks how `use_host_auth` works.
+How clawker integrates with Claude Code inside agent containers. Today that
+means **authentication** — sharing the host login with containers and why that
+sharing has limits. (Other Claude Code topics get their own section here as they
+come up.)
+
+## Authentication
+
+Read this section when a user reports authentication prompts (`/login`) inside
+containers, or asks how `use_host_auth` works.
 
 `use_host_auth` (under `agent.claude_code`, default enabled) is the only knob.
 Fetch `https://docs.clawker.dev/configuration` for the current field path and
 schema — everything below is the stable model, not field syntax.
 
-## The credential model
+### The credential model
 
 Claude Code authenticates with an OAuth credential pair:
 
@@ -22,7 +28,7 @@ using the refresh token and writes the rotated pair back to the keychain. The
 user never sees a prompt as long as the refresh token is still valid. A prompt
 (`/login`) appears only when the refresh token itself is expired or revoked.
 
-## How clawker shares it with a container
+### How clawker shares it with a container
 
 When `use_host_auth` is enabled, clawker reads the host's stored Claude
 credentials **once, at container create time**, and writes them into the
@@ -52,19 +58,25 @@ every support question:
    could defeat the self-heal. For shared-host-auth to behave as described, let
    Claude Code use the file.
 
-3. **Isolation is one-way.** The container cannot write back to the host
-   keychain, and the host cannot reach an already-created container's volume.
-   Refreshing on one side never updates the other. This is by design — the
-   sandbox boundary — but it is the root of the `/login` confusion below.
+3. **The two sides never sync — by design.** clawker plants a byte-for-byte copy
+   of the credential at create time and nothing more. From then on the host and
+   the container refresh independently, and clawker propagates nothing between
+   them. That is deliberate on three counts: an agent must never write to the
+   host keychain (a hard security boundary); a single host login can back many
+   containers that each refresh their own volume on their own schedule, so there
+   is no coherent "sync" to perform; and Anthropic's terms reserve OAuth
+   credential handling — refresh, rotation, any mutation — to first-party Claude
+   Code. clawker only seeds the initial copy; it never takes part in a token
+   exchange. This one-way model is the root of the `/login` confusion below.
 
 An expired *access* token at create time is harmless: clawker injects it
 anyway, because the refresh token (not the access token) is what lets Claude
 Code recover, and it refreshes on first use. Only the **refresh token's**
 validity matters for whether a fresh container starts authenticated.
 
-## Troubleshooting
+### Troubleshooting
 
-### Repeated `/login` in new containers despite `use_host_auth` enabled
+#### Repeated `/login` in new containers despite `use_host_auth` enabled
 
 **Symptom.** Every new agent container prompts for `/login` even though
 `agent.claude_code.use_host_auth` is on.
@@ -74,11 +86,9 @@ revoked** when the container was created. The snapshot clawker copied in could
 not be refreshed, so Claude Code falls back to an interactive login. Nothing is
 misconfigured — the shared credential was simply stale at copy time.
 
-There is deliberately **no way to check or refresh the host's refresh token
-from inside a container.** The credential blob doesn't even expose the refresh
-token's expiry (only the access token's), and the sandbox can't touch the host
-keychain. So this isn't diagnosed by inspecting the container — it's reasoned
-about from the model above.
+This is reasoned about from the model above, not diagnosed from inside the
+container: the credential blob doesn't expose the refresh token's expiry, and
+the sandbox can't reach the host keychain.
 
 **For the container that already prompted: nothing more to do.** Once the user
 completes `/login` inside it, Claude Code writes the fresh, rotated credentials

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/troubleshooting.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/troubleshooting.md
@@ -16,7 +16,7 @@ reference files. Check these first if the issue matches:
 | Disk space, build cache, Docker cleanup | `reference/docker-hygiene.md` | Full reference |
 | Monitoring stack (OTel/OpenSearch/Prometheus, workspace, empty indices) | `reference/monitoring.md` | Troubleshooting |
 | Securing git/VCS egress, can the agent push to/leak via other repos, credential-exfil hardening | `reference/firewall-security.md` | Full reference |
-| Repeated `/login` in new containers despite `use_host_auth`, how host Claude Code auth is shared | `reference/claude-code-auth.md` | Troubleshooting |
+| Repeated `/login` in new containers despite `use_host_auth`, how host Claude Code auth is shared | `reference/claude-code.md` | Authentication › Troubleshooting |
 | Control plane down or unreachable | This file | Control plane down or unhealthy |
 | `Token used before issued` / token fetch timeout on container start | This file | Control plane down or unhealthy |
 | Agent missing from CP registry | This file | Agent appears in clawker ps but missing from CP |

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/troubleshooting.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/troubleshooting.md
@@ -16,6 +16,7 @@ reference files. Check these first if the issue matches:
 | Disk space, build cache, Docker cleanup | `reference/docker-hygiene.md` | Full reference |
 | Monitoring stack (OTel/OpenSearch/Prometheus, workspace, empty indices) | `reference/monitoring.md` | Troubleshooting |
 | Securing git/VCS egress, can the agent push to/leak via other repos, credential-exfil hardening | `reference/firewall-security.md` | Full reference |
+| Repeated `/login` in new containers despite `use_host_auth`, how host Claude Code auth is shared | `reference/claude-code-auth.md` | Troubleshooting |
 | Control plane down or unreachable | This file | Control plane down or unhealthy |
 | `Token used before issued` / token fetch timeout on container start | This file | Control plane down or unhealthy |
 | Agent missing from CP registry | This file | Agent appears in clawker ps but missing from CP |

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -224,7 +224,7 @@ agent:
     config:
       # How to initialize Claude Code config: copy syncs host settings/plugins, fresh starts clean
       strategy: <string>  # default: copy | required: false
-    # Let the container use your host API keys so you don't have to re-authenticate
+    # Let the container use your host Claude Code credentials so you don't have to re-authenticate. The credential will be copied in at creation and persisted in the container's volume, but the container will refresh its tokens independently. If new containers keep starting unauthenticated, log in on the host to rotate the refresh token seed.
     use_host_auth: <boolean>  # default: true | required: false
     # Bind mount host ~/.claude/projects/ into the container so auto-memory and sessions are shared across container runs and instances
     mount_projects: <boolean>  # default: true | required: false
@@ -345,7 +345,7 @@ The following tables are auto-generated from the schema struct tags in `internal
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `strategy` | string | `copy` | How to initialize Claude Code config: copy syncs host settings/plugins, fresh starts clean |
-| `use_host_auth` | boolean | `true` | Let the container use your host API keys so you don't have to re-authenticate |
+| `use_host_auth` | boolean | `true` | Let the container use your host Claude Code credentials so you don't have to re-authenticate. The credential will be copied in at creation and persisted in the container's volume, but the container will refresh its tokens independently. If new containers keep starting unauthenticated, log in on the host to rotate the refresh token seed. |
 | `mount_projects` | boolean | `true` | Bind mount host ~/.claude/projects/ into the container so auto-memory and sessions are shared across container runs and instances |
 
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -76,7 +76,7 @@ type ClaudeCodeConfigOptions struct {
 // ClaudeCodeConfig controls Claude Code settings and authentication in containers.
 type ClaudeCodeConfig struct {
 	Config        ClaudeCodeConfigOptions `yaml:"config"`
-	UseHostAuth   *bool                   `yaml:"use_host_auth,omitempty" label:"Use Host Auth" desc:"Let the container use your host API keys so you don't have to re-authenticate" default:"true"`
+	UseHostAuth   *bool                   `yaml:"use_host_auth,omitempty" label:"Use Host Auth" desc:"Let the container use your host Claude Code credentials so you don't have to re-authenticate. The credential will be copied in at creation and persisted in the container's volume, but the container will refresh its tokens independently. If new containers keep starting unauthenticated, log in on the host to rotate the refresh token seed." default:"true"`
 	MountProjects *bool                   `yaml:"mount_projects,omitempty" label:"Mount Host Projects" desc:"Bind mount host ~/.claude/projects/ into the container so auto-memory and sessions are shared across container runs and instances" default:"true"`
 }
 

--- a/internal/keyring/CLAUDE.md
+++ b/internal/keyring/CLAUDE.md
@@ -2,8 +2,9 @@
 
 OS keychain wrapper with a service-credential registry.
 
-**Status**: No production callers yet. This package is ready for integration when
-container authentication is wired up.
+**Status**: Used by `internal/containerfs.PrepareCredentials` to source host
+Claude Code credentials for injection into agent containers when
+`agent.claude_code.use_host_auth` is enabled.
 
 ## Architecture
 
@@ -20,13 +21,16 @@ claude_code.go   — ClaudeCodeCredentials types + GetClaudeCodeCredentials()
 | `ErrNotFound` | No keyring entry | `errors.Is(err, keyring.ErrNotFound)` |
 | `ErrEmptyCredential` | Entry exists but blank | `errors.Is(err, keyring.ErrEmptyCredential)` |
 | `ErrInvalidSchema` | Data doesn't match struct | `errors.Is(err, keyring.ErrInvalidSchema)` |
-| `ErrTokenExpired` | Credential past expiry | `errors.Is(err, keyring.ErrTokenExpired)` |
 | `*TimeoutError` | Keyring op timed out | `errors.As(err, &te)` |
+
+> No expiry validation. Credentials are injected into containers regardless of
+> `expiresAt` — the blob carries the `refreshToken` and Claude Code refreshes in
+> place at runtime. Gating on expiry would discard a refreshable credential.
 
 ## Adding a New Service
 
 1. Create `<service>.go` with the credential struct
-2. Define a `ServiceDef[T]` var using the reusable helpers (`currentOSUser`, `jsonParse[T]`, `isExpired`)
+2. Define a `ServiceDef[T]` var using the reusable helpers (`currentOSUser`, `jsonParse[T]`); set the optional `Validate` func only for service-specific invariants (not expiry — see note above)
 3. Export a single public function that calls `getCredential(def)`
 4. Add tests in `<service>_test.go` using `MockInit()` + `Set()` to seed data
 

--- a/internal/keyring/claude_code.go
+++ b/internal/keyring/claude_code.go
@@ -19,22 +19,21 @@ type ClaudeAiOauth struct {
 	RateLimitTier    string   `json:"rateLimitTier"`
 }
 
-// claudeCodeService defines the fetch → parse → validate pipeline for Claude Code
+// claudeCodeService defines the fetch → parse pipeline for Claude Code
 // credentials stored in the OS keychain.
+//
+// No expiry validation: an expired access token is still injected into the
+// container because the blob carries the refreshToken, which Claude Code uses
+// to refresh in place at runtime. Gating on expiry here would discard a
+// perfectly refreshable credential.
 var claudeCodeService = ServiceDef[ClaudeCodeCredentials]{
 	ServiceName: "Claude Code-credentials",
 	User:        currentOSUser,
 	Parse:       jsonParse[ClaudeCodeCredentials],
-	Validate: func(c *ClaudeCodeCredentials) error {
-		if isExpired(c.ClaudeAiOauth.ExpiresAt) {
-			return ErrTokenExpired
-		}
-		return nil
-	},
 }
 
-// GetClaudeCodeCredentials fetches, parses, and validates the current user's
-// Claude Code credentials from the OS keychain.
+// GetClaudeCodeCredentials fetches and parses the current user's Claude Code
+// credentials from the OS keychain.
 func GetClaudeCodeCredentials() (*ClaudeCodeCredentials, error) {
 	return getCredential(claudeCodeService)
 }

--- a/internal/keyring/claude_code_test.go
+++ b/internal/keyring/claude_code_test.go
@@ -87,16 +87,6 @@ func TestGetClaudeCodeCredentials(t *testing.T) {
 		"organizationUuid": "` + orgUUID + `"
 	}`
 
-	expiredJSON := `{
-		"claudeAiOauth": {
-			"accessToken":  "access",
-			"refreshToken": "refresh",
-			"expiresAt":    1000000000000,
-			"scopes":       ["scope1"]
-		},
-		"organizationUuid": "` + orgUUID + `"
-	}`
-
 	invalidUUIDJSON := `{
 		"claudeAiOauth": {
 			"accessToken":  "access",
@@ -146,11 +136,6 @@ func TestGetClaudeCodeCredentials(t *testing.T) {
 			name:    "invalid UUID",
 			raw:     invalidUUIDJSON,
 			wantErr: ErrInvalidSchema,
-		},
-		{
-			name:    "expired token",
-			raw:     expiredJSON,
-			wantErr: ErrTokenExpired,
 		},
 	}
 

--- a/internal/keyring/service.go
+++ b/internal/keyring/service.go
@@ -6,14 +6,10 @@ import (
 	"fmt"
 	"os/user"
 	"strings"
-	"time"
 )
 
 // Sentinel errors returned by the service-credential pipeline.
 var (
-	// ErrTokenExpired indicates the credential's expiry timestamp is in the past.
-	ErrTokenExpired = errors.New("token has expired")
-
 	// ErrInvalidSchema indicates the raw keyring value could not be parsed into the
 	// expected credential struct (e.g. malformed JSON).
 	ErrInvalidSchema = errors.New("credential data does not match expected schema")
@@ -50,7 +46,7 @@ type ServiceDef[T any] struct {
 //  2. Get() fails       → ErrNotFound (no entry) or *TimeoutError
 //  3. raw == ""         → ErrEmptyCredential (entry exists but blank)
 //  4. Parse() fails     → ErrInvalidSchema wrapping the parse error
-//  5. Validate() fails  → returns validation error directly (e.g. ErrTokenExpired)
+//  5. Validate() fails  → returns the validation error directly (when set)
 func getCredential[T any](def ServiceDef[T]) (*T, error) {
 	u, err := def.User()
 	if err != nil {
@@ -100,10 +96,4 @@ func jsonParse[T any](raw string) (*T, error) {
 		return nil, err
 	}
 	return &v, nil
-}
-
-// isExpired reports whether a unix-millisecond timestamp is in the past.
-// A zero or negative value is treated as "no expiry" and returns false.
-func isExpired(unixMillis int64) bool {
-	return unixMillis > 0 && time.Now().After(time.UnixMilli(unixMillis))
 }


### PR DESCRIPTION
## Summary

Fixes agent containers failing to start (or repeatedly prompting `/login`) under `use_host_auth` when the host's Claude Code **access token** is expired.

The keyring credential pipeline rejected an expired access token via a `Validate` gate returning `ErrTokenExpired`. On macOS (keychain-only credential storage) that made `GetClaudeCodeCredentials` fail, so `PrepareCredentials` fell through to a nonexistent `.credentials.json` file fallback and container creation failed — **even though the credential blob carries a valid `refreshToken`** that Claude Code refreshes in place inside the container.

The injection path has no business validating expiry: an expired access token is still useful because the refresh token recovers it.

## Changes

- **`internal/keyring`** — drop the `Validate` expiry gate on `claudeCodeService`, the now-dead `ErrTokenExpired` sentinel, and the `isExpired` helper. Remove the matching `expired token` test case. Refresh the package `CLAUDE.md` (it had a stale "no production callers" note — `containerfs.PrepareCredentials` is the real caller).
- **`internal/config/schema.go` + `docs/configuration.mdx`** — document the inherent, one-way host→container refresh-token drift on the `use_host_auth` field. The full credential is seeded once at create time into the container's named volume; the container then refreshes its own copy independently, and that rotation can't propagate back to the host. The host's opaque refresh token goes stale on its own, so a host re-login is what reseeds future containers.
- **`claude-plugin/clawker-support`** — new `reference/claude-code-auth.md` covering the host-auth credential model + the "repeated `/login` in new containers" troubleshooting flow, wired into the troubleshooting routing table and `SKILL.md`. Switch the support plugin to patch-only versioning and bump to `1.0.1`.

## Behavioral note

Empirically confirmed: a newly created container with an expired-but-refreshable host token now refreshes successfully on first use. Probed a live agent container to verify the image ships no Secret Service backend, so Claude Code uses the plaintext `.credentials.json` in the config volume (which is what makes the volume self-heal across restarts).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/keyring/... ./internal/config/...` pass
- [x] pre-commit suite green (gitleaks, semgrep, golangci-lint, govulncheck, unit tests, generated-docs freshness)
- [x] `docs/configuration.mdx` regenerated from schema (no hand-edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)