### PR TITLE
feat(statusline): uncommitted-file count next to git branch

### DIFF
--- a/internal/bundler/assets/statusline.sh
+++ b/internal/bundler/assets/statusline.sh
@@ -242,6 +242,19 @@ VERSION=$(get_version)
 cd "$DIR" 2>/dev/null
 branch=$(git --no-optional-locks rev-parse --abbrev-ref HEAD 2>/dev/null)
 
+# Uncommitted file count: staged, unstaged, and untracked changes collapsed
+# into one red counter. Any non-zero = work that is lost if this worktree
+# directory is deleted without committing — the one thing a worktree agent,
+# flying blind without an IDE, most needs to catch before closing. One
+# --porcelain line per path, so the line count is a deduped file count.
+git_status=""
+if [ -n "$branch" ]; then
+    dirty=$(git --no-optional-locks status --porcelain 2>/dev/null | grep -c .)
+    if [ "$dirty" -gt 0 ]; then
+        git_status=$(printf "${RED}✗%d${NC}" "$dirty")
+    fi
+fi
+
 # Worktree detection: .git file = worktree, .git dir = regular repo
 is_worktree=false
 if [ -f "${DIR}/.git" ]; then
@@ -280,6 +293,8 @@ if [ -n "$branch" ]; then
     else
         line1+=$(printf " ${GRAY}%s${NC}" "${GIT}$branch")
     fi
+    # Uncommitted file counter after the branch (e.g. ✗3)
+    [ -n "$git_status" ] && line1+=" $git_status"
 fi
 
 # Pipe before host mount


### PR DESCRIPTION
## Summary

Adds a red `✗N` counter immediately after the git branch on the Clawker statusline (`internal/bundler/assets/statusline.sh`), where `N` is the number of uncommitted files — staged, unstaged, and untracked — collapsed into one deduped count.

Render: ` …@agent  branch(wt) ✗3 | 📁 …` (the `✗3` in red).

## Why

Worktree agents run without an IDE and are otherwise blind to git state. The single most important thing such an agent (or its operator) needs to catch before closing a session is **work that would be lost if the worktree directory is deleted without committing**. A non-zero `✗N` is that signal; a clean tree shows nothing.

The count intentionally folds *staged* changes in too. For a worktree, `git add` is **not** a durable safety line — staged blobs become dangling and get GC'd once the worktree's admin entry is pruned. Only a commit (whose branch ref lives in the shared `.git` and survives worktree removal) is safe. So every uncommitted file is at risk and belongs in the count.

## Implementation

- One `git --no-optional-locks status --porcelain` call (lock-safe).
- `grep -c .` counts lines; `--porcelain` emits one line per path, so the line count is an inherent dedupe (a partially-staged `MM`/`AM` file counts once).
- `✗` marker = oh-my-zsh's canonical "dirty working tree" convention; rendered in the script's existing `RED`. Reliably monochrome, so the color holds.
- Appended after the branch on line 1 — the existing branch/worktree rendering is untouched.

## Adaptation note

Adapted from the Python reference in #342, but rethought for the worktree-loss use case rather than copied: collapses the ref's separate staged/modified counters into a single "files you'll lose if you don't commit" signal.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)