### PR TITLE
fix(docker): resolve global built image for @ outside a project

### DIFF
--- a/.claude/rules/container-commands.md
+++ b/.claude/rules/container-commands.md
@@ -5,7 +5,7 @@ paths: ["internal/cmd/container/**"]
 
 # Container Command Rules
 
-- `@` symbol triggers `client.ResolveImageWithSource(ctx, projectName)` for automatic image resolution (Docker labels → `cfg.Project().Build.Image` config fallback); project name resolved via `project.ProjectManager.CurrentProject(ctx).Name()`
+- `@` symbol triggers `client.ResolveImageWithSource(ctx, projectName)` for automatic image resolution — scope-keyed: project-label image in project scope, global image (`ImageTag("")`) when no project; no `build.image` config fallback; project name resolved via `project.ProjectManager.CurrentProject(ctx).Name()`
 - Shared container flags and domain logic live in `internal/cmd/container/shared/` package
 - Always use `f.Client(ctx)` from Factory — never `docker.NewClient()` directly
 - Do NOT `defer client.Close()` — Factory manages client lifecycle

--- a/docs/cli-reference/clawker_container_create.md
+++ b/docs/cli-reference/clawker_container_create.md
@@ -16,7 +16,9 @@ Container names follow clawker conventions: clawker.project.agent
 When --agent is provided, the container is named clawker.`<project>`.`<agent>` where
 project is resolved from the current directory. When --name is provided, it overrides this.
 
-If IMAGE is "@", clawker will resolve the project's built image with :latest tag.
+If IMAGE is "@", clawker resolves the built image for the current scope: the
+project image inside a registered project, or the global image (built with
+"clawker build" outside any project) elsewhere.
 
 ```
 clawker container create [OPTIONS] IMAGE [COMMAND] [ARG...] [flags]

--- a/docs/cli-reference/clawker_container_run.md
+++ b/docs/cli-reference/clawker_container_run.md
@@ -15,7 +15,9 @@ Container names follow clawker conventions: clawker.project.agent
 When --agent is provided, the container is named clawker.`<project>`.`<agent>` where
 project is resolved from the current directory.
 
-If IMAGE is "@", clawker will resolve the project's built image with :latest tag.
+If IMAGE is "@", clawker resolves the built image for the current scope: the
+project image inside a registered project, or the global image (built with
+"clawker build" outside any project) elsewhere.
 
 ```
 clawker container run [OPTIONS] IMAGE [COMMAND] [ARG...] [flags]

--- a/docs/cli-reference/clawker_create.md
+++ b/docs/cli-reference/clawker_create.md
@@ -16,7 +16,9 @@ Container names follow clawker conventions: clawker.project.agent
 When --agent is provided, the container is named clawker.`<project>`.`<agent>` where
 project is resolved from the current directory. When --name is provided, it overrides this.
 
-If IMAGE is "@", clawker will resolve the project's built image with :latest tag.
+If IMAGE is "@", clawker resolves the built image for the current scope: the
+project image inside a registered project, or the global image (built with
+"clawker build" outside any project) elsewhere.
 
 ```
 clawker create [OPTIONS] IMAGE [COMMAND] [ARG...] [flags]

--- a/docs/cli-reference/clawker_run.md
+++ b/docs/cli-reference/clawker_run.md
@@ -15,7 +15,9 @@ Container names follow clawker conventions: clawker.project.agent
 When --agent is provided, the container is named clawker.`<project>`.`<agent>` where
 project is resolved from the current directory.
 
-If IMAGE is "@", clawker will resolve the project's built image with :latest tag.
+If IMAGE is "@", clawker resolves the built image for the current scope: the
+project image inside a registered project, or the global image (built with
+"clawker build" outside any project) elsewhere.
 
 ```
 clawker run [OPTIONS] IMAGE [COMMAND] [ARG...] [flags]

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -89,7 +89,7 @@ clawker run -it --rm --agent dev @ --dangerously-skip-permissions
 - `-it` — interactive mode with a terminal attached
 - `--rm` — removes the container when it finishes (recommended, volumes are preserved)
 - `--agent dev` — names this container `clawker.<project>.dev`
-- `@` — shortcut that resolves to your project's built image
+- `@` — shortcut that resolves to your built image (the project image here; outside a project it resolves to the global image from a global `clawker build`)
 
 You're now inside a containerized Claude Code session. Your project code is bind-mounted (live sync), your Git credentials are forwarded, and the network firewall is active. Arguments after the image (`@`) are passed directly to Claude Code inside the container.
 

--- a/internal/cmd/container/CLAUDE.md
+++ b/internal/cmd/container/CLAUDE.md
@@ -116,7 +116,7 @@ Single entry point for container creation, shared by `run` and `create`. Perform
 
 ## Image Resolution (@ Symbol)
 
-`opts.Image == "@"` → `client.ResolveImageWithSource(ctx, projectName)`. Source types: `ImageSourceExplicit`, `ImageSourceProject`, `ImageSourceConfig`. Resolution chain: Docker label lookup → `cfg.Project().Build.Image` fallback. Project name resolved via `project.ProjectManager.CurrentProject(ctx).Name()`. Returns `nil` when neither source yields an image (caller decides next action).
+`opts.Image == "@"` → `client.ResolveImageWithSource(ctx, projectName)`. Source types: `ImageSourceProject`, `ImageSourceGlobal`. Resolution is scope-keyed: project scope (non-empty `projectName`) → project-label image lookup; global scope (empty `projectName`) → global image lookup (`ImageTag("")`). Scopes do not ladder, and there is no `build.image` config fallback — that is a bare base image, never runnable as an agent. Project name resolved via `project.ProjectManager.CurrentProject(ctx).Name()`. Returns `nil` when no built image exists for the scope (caller prints next-steps guidance pointing at `clawker build`).
 
 ## Home Directory Safety
 

--- a/internal/cmd/container/create/create.go
+++ b/internal/cmd/container/create/create.go
@@ -68,7 +68,9 @@ Container names follow clawker conventions: clawker.project.agent
 When --agent is provided, the container is named clawker.<project>.<agent> where
 project is resolved from the current directory. When --name is provided, it overrides this.
 
-If IMAGE is "@", clawker will resolve the project's built image with :latest tag.`,
+If IMAGE is "@", clawker resolves the built image for the current scope: the
+project image inside a registered project, or the global image (built with
+"clawker build" outside any project) elsewhere.`,
 		Example: `  # Create a container with a specific agent name and interactive TTY
   clawker container create -it --agent ralph @ 
 
@@ -138,10 +140,10 @@ func createRun(ctx context.Context, opts *CreateOptions) error {
 		}
 		if resolvedImage == nil {
 			cs := ios.ColorScheme()
-			fmt.Fprintf(ios.ErrOut, "%s No image specified and no project image found\n", cs.FailureIcon())
+			fmt.Fprintf(ios.ErrOut, "%s No built image found for \"@\"\n", cs.FailureIcon())
 			fmt.Fprintf(ios.ErrOut, "\n%s Next steps:\n", cs.InfoIcon())
-			fmt.Fprintln(ios.ErrOut, "  1. Specify an image: clawker container create IMAGE")
-			fmt.Fprintln(ios.ErrOut, "  2. Build a project image: clawker build")
+			fmt.Fprintln(ios.ErrOut, "  1. Build an image first: clawker build")
+			fmt.Fprintln(ios.ErrOut, "  2. Or specify an image: clawker container create IMAGE")
 			return cmdutil.SilentError
 		}
 

--- a/internal/cmd/container/run/run.go
+++ b/internal/cmd/container/run/run.go
@@ -86,7 +86,9 @@ Container names follow clawker conventions: clawker.project.agent
 When --agent is provided, the container is named clawker.<project>.<agent> where
 project is resolved from the current directory.
 
-If IMAGE is "@", clawker will resolve the project's built image with :latest tag.`,
+If IMAGE is "@", clawker resolves the built image for the current scope: the
+project image inside a registered project, or the global image (built with
+"clawker build" outside any project) elsewhere.`,
 		Example: `  # Run an interactive shell
   clawker container run -it --agent ralph @ 
 
@@ -194,10 +196,10 @@ func runRun(ctx context.Context, opts *RunOptions) error {
 		}
 		if resolvedImage == nil {
 			cs := ios.ColorScheme()
-			fmt.Fprintf(ios.ErrOut, "%s No image specified and no project image found\n", cs.FailureIcon())
+			fmt.Fprintf(ios.ErrOut, "%s No built image found for \"@\"\n", cs.FailureIcon())
 			fmt.Fprintf(ios.ErrOut, "\n%s Next steps:\n", cs.InfoIcon())
-			fmt.Fprintln(ios.ErrOut, "  1. Specify an image: clawker container run IMAGE")
-			fmt.Fprintln(ios.ErrOut, "  2. Build a project image: clawker build")
+			fmt.Fprintln(ios.ErrOut, "  1. Build an image first: clawker build")
+			fmt.Fprintln(ios.ErrOut, "  2. Or specify an image: clawker container run IMAGE")
 			return cmdutil.SilentError
 		}
 

--- a/internal/cmd/container/run/run_test.go
+++ b/internal/cmd/container/run/run_test.go
@@ -610,84 +610,33 @@ func requireSliceEqual(t *testing.T, expected, actual []string) {
 // TestImageArg tests image argument handling for the run command.
 // Tests @ symbol resolution (using mock Docker client) and explicit image pass-through.
 func TestImageArg(t *testing.T) {
-	// Tests for @ symbol resolution (uses mocks.FakeClient)
-	// ResolveImageWithSource resolves project images only (no default image fallback).
-	// Returns nil when no project image with :latest tag is found.
-	t.Run("@ symbol resolution", func(t *testing.T) {
-		tests := []struct {
-			name          string
-			projectName   string
-			fakeImages    []string // Images to return from fake ImageList
-			wantReference string
-			wantSource    docker.ImageSource
-			wantNil       bool // Expect nil result (no resolution)
-		}{
-			{
-				name:          "@ resolves to project image when exists",
-				projectName:   "myproject",
-				fakeImages:    []string{"clawker-myproject:latest"},
-				wantReference: "clawker-myproject:latest",
-				wantSource:    docker.ImageSourceProject,
-			},
-			{
-				name:        "@ returns nil when no project image",
-				projectName: "myproject",
-				fakeImages:  []string{}, // No project images
-				wantNil:     true,
-			},
-			{
-				name:        "@ returns nil for empty project",
-				projectName: "",
-				fakeImages:  []string{},
-				wantNil:     true,
-			},
-			{
-				name:          "@ prefers latest-tagged project image",
-				projectName:   "myproject",
-				fakeImages:    []string{"clawker-myproject:latest", "other:tag"},
-				wantReference: "clawker-myproject:latest",
-				wantSource:    docker.ImageSourceProject,
-			},
-			{
-				name:        "@ ignores non-latest project images",
-				projectName: "myproject",
-				fakeImages:  []string{"clawker-myproject:v1.0"}, // No :latest tag
-				wantNil:     true,
-			},
+	// Command-level @ wiring: runRun resolves @ via ResolveImageWithSource and
+	// hands the resolved reference to container create. Resolution semantics
+	// themselves (scope keying, no ladder, no config fallback) are locked in
+	// internal/docker/image_resolve_test.go with a filter-emulating fake.
+	t.Run("@ resolves built image and creates container with it", func(t *testing.T) {
+		fake := mocks.NewFakeClient(configmocks.NewBlankConfig())
+		// No ProjectManager on the factory → global scope → global image.
+		fake.SetupImageList(whail.ImageSummary{RepoTags: []string{docker.ImageTag("")}})
+		var gotCreate moby.ContainerCreateOptions
+		fake.FakeAPI.ContainerCreateFn = func(_ context.Context, opts moby.ContainerCreateOptions) (moby.ContainerCreateResult, error) {
+			gotCreate = opts
+			return moby.ContainerCreateResult{ID: "abcdef123456789"}, nil
 		}
+		fake.SetupCopyToContainer()
+		fake.SetupContainerStart()
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				ctx := context.Background()
+		f, in, out, errOut := testFactory(t, fake)
+		cmd := NewCmdRun(f, nil)
+		cmd.SetArgs([]string{"--detach", "@"})
+		cmd.SetIn(in)
+		cmd.SetOut(out)
+		cmd.SetErr(errOut)
 
-				testCfg := configmocks.NewBlankConfig()
-
-				// Create fake Docker client with the config
-				fake := mocks.NewFakeClient(testCfg)
-
-				// Build image summaries and configure fake
-				var summaries []whail.ImageSummary
-				for _, ref := range tt.fakeImages {
-					summaries = append(summaries, whail.ImageSummary{
-						RepoTags: []string{ref},
-					})
-				}
-				fake.SetupImageList(summaries...)
-
-				// Call the resolution method on the client with projectName
-				result, err := fake.Client.ResolveImageWithSource(ctx, tt.projectName)
-				require.NoError(t, err)
-
-				if tt.wantNil {
-					require.Nil(t, result, "expected nil result")
-					return
-				}
-
-				require.NotNil(t, result, "expected non-nil result")
-				require.Equal(t, tt.wantReference, result.Reference)
-				require.Equal(t, tt.wantSource, result.Source)
-			})
-		}
+		err := cmd.Execute()
+		require.NoError(t, err)
+		require.NotNil(t, gotCreate.Config)
+		require.Equal(t, docker.ImageTag(""), gotCreate.Config.Image)
 	})
 
 	// Tests for explicit image pass-through (no resolution, no mock needed)
@@ -945,8 +894,8 @@ agent:
 		require.ErrorIs(t, err, cmdutil.SilentError)
 
 		errOutput := errOut.String()
-		require.Contains(t, errOutput, "No image specified")
-		require.Contains(t, errOutput, "no project image found")
+		require.Contains(t, errOutput, "No built image found")
+		require.Contains(t, errOutput, "clawker build")
 
 		fake.AssertNotCalled(t, "ContainerCreate")
 	})

--- a/internal/docker/CLAUDE.md
+++ b/internal/docker/CLAUDE.md
@@ -45,7 +45,7 @@ type ClientOption func(*clientOptions)    // WithLabels(whail.LabelConfig)
 
 `Client` embeds `*whail.Engine`. Fields: `cfg config.Config` (interface, always set), `BuildDefaultImageFunc BuildDefaultImageFn`, `ChownImage string`.
 
-**Image methods**: `Close()`, `ResolveImage(ctx, projectName)`, `ResolveImageWithSource(ctx, projectName)`, `BuildImage(ctx, reader, opts)`, `ImageExists(ctx, ref)`.
+**Image methods**: `Close()`, `ResolveImageWithSource(ctx, projectName)`, `BuildImage(ctx, reader, opts)`, `ImageExists(ctx, ref)`.
 
 ### Container type
 
@@ -65,7 +65,7 @@ type Container struct {
 | `FindContainerByAgent` | `(ctx context.Context, project, agent string) (string, *container.Summary, error)` — returns (name, summary, err); not-found = `(name, nil, nil)` |
 | `RemoveContainerWithVolumes` | `(ctx context.Context, containerID string, force bool) error` — stops + removes container + associated volumes |
 
-**Image resolution**: `ImageSource` enum (`Explicit`/`Project`/`Config`). `ResolvedImage` struct (Reference + Source). `ResolveImageWithSource(ctx, projectName)` resolves via a two-step chain: (1) Docker images matching the project label with `:latest` tag → `ImageSourceProject`, (2) fallback to `cfg.Project().Build.Image` → `ImageSourceConfig`. Returns `nil, nil` when neither source yields an image. `ResolveImage(ctx, projectName)` is a convenience wrapper returning just the reference string. `projectName` is the resolved project identity (from `project.ProjectManager.CurrentProject(ctx).Name()` at the command layer); empty string means no registered project.
+**Image resolution**: `ImageSource` enum (`Project`/`Global`). `ResolvedImage` struct (Reference + Source). `ResolveImageWithSource(ctx, projectName)` is scope-keyed: project scope (non-empty `projectName`) looks up Docker images matching the project label with `:latest` tag → `ImageSourceProject`; global scope (empty `projectName`) looks up the clawker-managed global image (`ImageTag("")`, managed filter + reference match — global images intentionally carry no project label) → `ImageSourceGlobal`. Returns `nil, nil` when no built image exists for the scope. Scopes do not ladder (a project with no built image never resolves the global image), and there is deliberately no fallback to `cfg.Project().Build.Image` — that is a bare base image, never runnable as an agent. `projectName` is the resolved project identity (from `project.ProjectManager.CurrentProject(ctx).Name()` at the command layer); empty string means no registered project.
 
 ## Builder (`builder.go`)
 

--- a/internal/docker/image_resolve.go
+++ b/internal/docker/image_resolve.go
@@ -10,9 +10,8 @@ import (
 type ImageSource string
 
 const (
-	ImageSourceExplicit ImageSource = "explicit" // User specified via CLI or args
-	ImageSourceProject  ImageSource = "project"  // Found via project label search
-	ImageSourceConfig   ImageSource = "config"   // From merged config (build.image)
+	ImageSourceProject ImageSource = "project" // Found via project label search
+	ImageSourceGlobal  ImageSource = "global"  // Globally built image (built outside any project)
 )
 
 // ResolvedImage contains the result of image resolution with source tracking.
@@ -51,39 +50,65 @@ func (c *Client) findProjectImage(ctx context.Context, projectName string) (stri
 	return "", nil
 }
 
-// ResolveImage resolves the image reference to use.
-// projectName is the resolved project identity (from ProjectManager); empty for unregistered projects.
-// Returns empty string if no image could be resolved.
-func (c *Client) ResolveImage(ctx context.Context, projectName string) (string, error) {
-	result, err := c.ResolveImageWithSource(ctx, projectName)
+// findGlobalImage searches for the clawker-managed global image — the image
+// `clawker build` produces outside any registered project, tagged ImageTag("").
+// Global-scope images intentionally omit the project label, so the lookup is
+// the managed filter plus a reference match on the global tag. Returns the
+// image reference if found, or empty string if not found.
+func (c *Client) findGlobalImage(ctx context.Context) (string, error) {
+	globalRef := ImageTag("")
+	f := c.ClawkerFilter().
+		Add("reference", globalRef)
+
+	result, err := c.ImageList(ctx, ImageListOptions{
+		Filters: f,
+	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to list images: %w", err)
 	}
-	if result == nil {
-		return "", nil
+
+	for _, img := range result.Items {
+		for _, tag := range img.RepoTags {
+			if tag == globalRef {
+				return tag, nil
+			}
+		}
 	}
-	return result.Reference, nil
+
+	return "", nil
 }
 
 // ResolveImageWithSource resolves the image to use for container operations.
-// projectName is the resolved project identity (from ProjectManager); empty for unregistered projects.
+// projectName is the resolved project identity (from ProjectManager); empty
+// for global scope (no registered project).
 //
-// Resolution order:
-//  1. Docker label lookup — clawker-managed image matching project label with :latest tag
-//  2. Config fallback — merged build.image from all config layers (project, user, defaults)
+// Resolution is scope-keyed:
+//   - project scope: clawker-managed image matching the project label with :latest tag
+//   - global scope: the clawker-managed global image (ImageTag(""))
 //
-// Returns nil if no image could be resolved (caller decides what to do).
+// Returns nil if no built image exists for the scope — the caller decides what
+// to do. There is deliberately no fallback to the configured build.image: that
+// is a bare base image (no Claude Code, no clawkerd) and is never runnable as
+// an agent. Scopes do not ladder: inside a project, a missing project image
+// resolves to nil rather than silently running the global image.
 func (c *Client) ResolveImageWithSource(ctx context.Context, projectName string) (*ResolvedImage, error) {
+	if projectName == "" {
+		globalImage, err := c.findGlobalImage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("auto-detect global image: %w", err)
+		}
+		if globalImage != "" {
+			return &ResolvedImage{Reference: globalImage, Source: ImageSourceGlobal}, nil
+		}
+		return nil, nil
+	}
+
 	projectImage, err := c.findProjectImage(ctx, projectName)
 	if err != nil {
 		return nil, fmt.Errorf("auto-detect project image: %w", err)
 	}
 	if projectImage != "" {
 		return &ResolvedImage{Reference: projectImage, Source: ImageSourceProject}, nil
-	}
-
-	if configImage := c.cfg.Project().Build.Image; configImage != "" {
-		return &ResolvedImage{Reference: configImage, Source: ImageSourceConfig}, nil
 	}
 
 	return nil, nil

--- a/internal/docker/image_resolve_test.go
+++ b/internal/docker/image_resolve_test.go
@@ -2,114 +2,94 @@ package docker
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	moby "github.com/moby/moby/client"
 )
 
-func TestFindProjectImage_EmptyProject(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig(t, `{}`)
-	client, _ := newTestClientWithConfig(cfg)
-
-	// Empty projectName returns empty string immediately (no Docker call)
-	result, err := client.findProjectImage(ctx, "")
-	if err != nil {
-		t.Errorf("findProjectImage() unexpected error = %v", err)
-	}
-	if result != "" {
-		t.Errorf("findProjectImage() = %q, want empty string", result)
-	}
-}
-
-func TestResolveImageWithSource_ProjectOnly(t *testing.T) {
+func TestFindGlobalImage(t *testing.T) {
 	ctx := context.Background()
 
-	tests := []struct {
-		name        string
-		projectName string
-		wantNil     bool
-	}{
-		{
-			name:        "returns nil for empty project name",
-			projectName: "",
-			wantNil:     true,
-		},
-		{
-			name:        "returns nil when no project image found",
-			projectName: "myproject",
-			wantNil:     true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := testConfig(t, `{}`)
-			client, fakeAPI := newTestClientWithConfig(cfg)
-
-			// Wire ImageList to return empty results
-			fakeAPI.ImageListFn = func(_ context.Context, _ moby.ImageListOptions) (moby.ImageListResult, error) {
-				return moby.ImageListResult{}, nil
-			}
-
-			result, err := client.ResolveImageWithSource(ctx, tt.projectName)
-			if err != nil {
-				t.Fatalf("ResolveImageWithSource() unexpected error: %v", err)
-			}
-
-			if tt.wantNil {
-				if result != nil {
-					t.Errorf("ResolveImageWithSource() = %+v, want nil", result)
-				}
-				return
-			}
-
-			if result == nil {
-				t.Fatal("ResolveImageWithSource() returned nil, want non-nil")
-			}
-		})
-	}
-}
-
-func TestResolveImageWithSource_ConfigFallback(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("falls back to build.image from config", func(t *testing.T) {
-		cfg := testConfig(t, `build:
-  image: "clawker-default:latest"`)
+	t.Run("finds global image and filters by managed label + global reference", func(t *testing.T) {
+		cfg := testConfig(t, `{}`)
 		client, fakeAPI := newTestClientWithConfig(cfg)
 
-		fakeAPI.ImageListFn = func(_ context.Context, _ moby.ImageListOptions) (moby.ImageListResult, error) {
-			return moby.ImageListResult{}, nil
+		var gotOpts moby.ImageListOptions
+		fakeAPI.ImageListFn = func(_ context.Context, opts moby.ImageListOptions) (moby.ImageListResult, error) {
+			gotOpts = opts
+			return moby.ImageListResult{
+				Items: []ImageSummary{
+					{RepoTags: []string{ImageTag("")}},
+				},
+			}, nil
 		}
 
-		result, err := client.ResolveImageWithSource(ctx, "")
+		result, err := client.findGlobalImage(ctx)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("findGlobalImage() unexpected error: %v", err)
 		}
-		if result == nil {
-			t.Fatal("expected non-nil result from config fallback")
+		if result != ImageTag("") {
+			t.Errorf("findGlobalImage() = %q, want %q", result, ImageTag(""))
 		}
-		if result.Reference != "clawker-default:latest" {
-			t.Errorf("Reference = %q, want %q", result.Reference, "clawker-default:latest")
+
+		labelFilters := gotOpts.Filters["label"]
+		if _, ok := labelFilters[cfg.LabelManaged()+"="+cfg.ManagedLabelValue()]; !ok {
+			t.Errorf("ImageList filters missing managed label, got %v", labelFilters)
 		}
-		if result.Source != ImageSourceConfig {
-			t.Errorf("Source = %q, want %q", result.Source, ImageSourceConfig)
+		refFilters := gotOpts.Filters["reference"]
+		if _, ok := refFilters[ImageTag("")]; !ok {
+			t.Errorf("ImageList filters missing global reference %q, got %v", ImageTag(""), refFilters)
 		}
 	})
 
-	t.Run("project image wins over config", func(t *testing.T) {
-		cfg := testConfig(t, `build:
-  image: "clawker-default:latest"`)
+	t.Run("ignores images without the exact global tag", func(t *testing.T) {
+		cfg := testConfig(t, `{}`)
 		client, fakeAPI := newTestClientWithConfig(cfg)
 
 		fakeAPI.ImageListFn = func(_ context.Context, _ moby.ImageListOptions) (moby.ImageListResult, error) {
 			return moby.ImageListResult{
 				Items: []ImageSummary{
-					{RepoTags: []string{"myproject:latest"}},
+					{RepoTags: []string{"clawker:v1.0", "clawker-myproject:latest"}},
 				},
 			}, nil
 		}
+
+		result, err := client.findGlobalImage(ctx)
+		if err != nil {
+			t.Fatalf("findGlobalImage() unexpected error: %v", err)
+		}
+		if result != "" {
+			t.Errorf("findGlobalImage() = %q, want empty string", result)
+		}
+	})
+}
+
+func TestResolveImageWithSource(t *testing.T) {
+	ctx := context.Background()
+
+	// imageListByFilter emulates daemon-side filtering: project-label queries
+	// return projectItems, global-reference queries return globalItems.
+	imageListByFilter := func(projectLabel string, projectItems, globalItems []ImageSummary) func(context.Context, moby.ImageListOptions) (moby.ImageListResult, error) {
+		return func(_ context.Context, opts moby.ImageListOptions) (moby.ImageListResult, error) {
+			if _, ok := opts.Filters["reference"][ImageTag("")]; ok {
+				return moby.ImageListResult{Items: globalItems}, nil
+			}
+			for key := range opts.Filters["label"] {
+				if strings.HasPrefix(key, projectLabel+"=") {
+					return moby.ImageListResult{Items: projectItems}, nil
+				}
+			}
+			return moby.ImageListResult{}, nil
+		}
+	}
+
+	t.Run("project scope resolves project image", func(t *testing.T) {
+		cfg := testConfig(t, `{}`)
+		client, fakeAPI := newTestClientWithConfig(cfg)
+		fakeAPI.ImageListFn = imageListByFilter(cfg.LabelProject(),
+			[]ImageSummary{{RepoTags: []string{"clawker-myproject:latest"}}}, nil)
 
 		result, err := client.ResolveImageWithSource(ctx, "myproject")
 		if err != nil {
@@ -118,47 +98,95 @@ func TestResolveImageWithSource_ConfigFallback(t *testing.T) {
 		if result == nil {
 			t.Fatal("expected non-nil result")
 		}
-		if result.Reference != "myproject:latest" {
-			t.Errorf("Reference = %q, want %q", result.Reference, "myproject:latest")
+		if result.Reference != "clawker-myproject:latest" {
+			t.Errorf("Reference = %q, want %q", result.Reference, "clawker-myproject:latest")
 		}
 		if result.Source != ImageSourceProject {
 			t.Errorf("Source = %q, want %q", result.Source, ImageSourceProject)
 		}
 	})
 
-	t.Run("returns nil when no project image and no config image", func(t *testing.T) {
+	t.Run("project scope does not ladder to global image", func(t *testing.T) {
 		cfg := testConfig(t, `{}`)
 		client, fakeAPI := newTestClientWithConfig(cfg)
+		fakeAPI.ImageListFn = imageListByFilter(cfg.LabelProject(),
+			nil, []ImageSummary{{RepoTags: []string{ImageTag("")}}})
 
-		fakeAPI.ImageListFn = func(_ context.Context, _ moby.ImageListOptions) (moby.ImageListResult, error) {
-			return moby.ImageListResult{}, nil
+		result, err := client.ResolveImageWithSource(ctx, "myproject")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+		if result != nil {
+			t.Errorf("expected nil (no project image, global must not leak into project scope), got %+v", result)
+		}
+	})
+
+	t.Run("global scope resolves global image", func(t *testing.T) {
+		cfg := testConfig(t, `{}`)
+		client, fakeAPI := newTestClientWithConfig(cfg)
+		fakeAPI.ImageListFn = imageListByFilter(cfg.LabelProject(),
+			nil, []ImageSummary{{RepoTags: []string{ImageTag("")}}})
+
+		result, err := client.ResolveImageWithSource(ctx, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result for global image")
+		}
+		if result.Reference != ImageTag("") {
+			t.Errorf("Reference = %q, want %q", result.Reference, ImageTag(""))
+		}
+		if result.Source != ImageSourceGlobal {
+			t.Errorf("Source = %q, want %q", result.Source, ImageSourceGlobal)
+		}
+	})
+
+	t.Run("global scope never falls back to config build.image", func(t *testing.T) {
+		// build.image is a bare base image (no Claude Code, no clawkerd) —
+		// handing it to run/create is never right. Locks the removal of the
+		// config fallback arm.
+		cfg := testConfig(t, `build:
+  image: "buildpack-deps:bookworm-scm"`)
+		client, fakeAPI := newTestClientWithConfig(cfg)
+		fakeAPI.ImageListFn = imageListByFilter(cfg.LabelProject(), nil, nil)
 
 		result, err := client.ResolveImageWithSource(ctx, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if result != nil {
-			t.Errorf("expected nil, got %+v", result)
+			t.Errorf("expected nil (config build.image must not resolve), got %+v", result)
 		}
 	})
-}
 
-func TestResolveImage_EmptyProject(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig(t, `{}`)
-	client, fakeAPI := newTestClientWithConfig(cfg)
+	t.Run("project scope never falls back to config build.image", func(t *testing.T) {
+		cfg := testConfig(t, `build:
+  image: "buildpack-deps:bookworm-scm"`)
+		client, fakeAPI := newTestClientWithConfig(cfg)
+		fakeAPI.ImageListFn = imageListByFilter(cfg.LabelProject(), nil, nil)
 
-	// Wire ImageList to return empty results
-	fakeAPI.ImageListFn = func(_ context.Context, _ moby.ImageListOptions) (moby.ImageListResult, error) {
-		return moby.ImageListResult{}, nil
-	}
+		result, err := client.ResolveImageWithSource(ctx, "myproject")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil (config build.image must not resolve), got %+v", result)
+		}
+	})
 
-	got, err := client.ResolveImage(ctx, "")
-	if err != nil {
-		t.Fatalf("ResolveImage() returned unexpected error: %v", err)
-	}
-	if got != "" {
-		t.Errorf("ResolveImage() = %q, want empty string", got)
-	}
+	t.Run("global scope wraps lookup errors", func(t *testing.T) {
+		cfg := testConfig(t, `{}`)
+		client, fakeAPI := newTestClientWithConfig(cfg)
+
+		listErr := errors.New("daemon unavailable")
+		fakeAPI.ImageListFn = func(_ context.Context, _ moby.ImageListOptions) (moby.ImageListResult, error) {
+			return moby.ImageListResult{}, listErr
+		}
+
+		_, err := client.ResolveImageWithSource(ctx, "")
+		if !errors.Is(err, listErr) {
+			t.Errorf("error = %v, want wrapped %v", err, listErr)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #359.

## Problem

`clawker run -it --rm --agent dev @` in a directory with **no registered project** failed with:

```
Error: Failed to create container
  Details: Error response from daemon: No such image: buildpack-deps:bookworm-scm
```

`@` resolution had two arms: project-label lookup (short-circuits when `projectName == ""`) and a fallback to the merged `build.image` config value — a bare base image (no Claude Code, no clawkerd) that is never runnable as an agent. The globally built image (`clawker:latest`, produced by `clawker build` outside a project) was never consulted: global *naming* support landed without a matching *lookup* arm, and the `default_image` setting that papered over it was later removed, silently converting the runnable-default fallback into a non-runnable base-image fallback.

## Fix

Image resolution is now **scope-keyed** (`internal/docker/image_resolve.go`):

- **New `findGlobalImage`** — clawker-managed filter + `reference` match on `ImageTag("")`, with an exact-tag gate; new `ImageSourceGlobal` source.
- **`ResolveImageWithSource`** — empty `projectName` resolves the global image; non-empty resolves the project-label image. **Scopes do not ladder**: inside a project with no built image, `@` does not silently run the global image (conservative, per issue design decision 1).
- **`build.image` config fallback removed** (issue design decision 2): handing a bare base to run/create is never right. `@` with no built image now hits the friendly nil-path guidance — "No built image found for \"@\"", leading with `clawker build` — instead of a confusing daemon error.
- **Dead code deleted**: `ResolveImage` wrapper, `ImageSourceExplicit`, `ImageSourceConfig` (zero references).

## Tests

- `image_resolve_test.go` rewritten around a **filter-emulating fake** (project-label queries vs global-reference queries return distinct result sets), locking: scope isolation (no ladder), no config fallback in either scope, exact-tag matching, managed-label + reference filter construction, and error wrapping.
- Run package gains a **command-level `@` wiring test** (`NewCmdRun` → `runRun` → container create asserted with the resolved reference) — previously only the error path was covered at command level.

## Docs

- `@` help text in `run`/`create` covers project-or-global scope; CLI reference regenerated.
- `docs/quickstart.mdx` `@` bullet, `internal/docker/CLAUDE.md`, `internal/cmd/container/CLAUDE.md`, and `.claude/rules/container-commands.md` updated to the scope-keyed model.

## Verification

Full unit suite green (4998 tests). Review gates (code-reviewer, code-simplifier, test-hunter) run; findings applied — including two stale doc files and pruning of redundant direct-call tests in favor of the command-level wiring test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)