### PR TITLE
fix(worktree): upsert stale branch config + thread ctx in worktree add

### DIFF
--- a/docs/worktrees.mdx
+++ b/docs/worktrees.mdx
@@ -63,7 +63,7 @@ The table shows:
 
 | Column | Description |
 |--------|-------------|
-| BRANCH | Branch name (or "(detached)" for detached HEAD) |
+| BRANCH | Branch name ("(detached)" if HEAD was manually detached inside the worktree after creation) |
 | PATH | Filesystem path to worktree |
 | HEAD | Short commit hash |
 | MODIFIED | Relative time since last change |

--- a/internal/cmd/worktree/add/add.go
+++ b/internal/cmd/worktree/add/add.go
@@ -66,13 +66,13 @@ Otherwise the branch is created from the base ref (default: HEAD).`,
 	return cmd
 }
 
-func addRun(_ context.Context, opts *AddOptions) error {
+func addRun(ctx context.Context, opts *AddOptions) error {
 	projectManager, err := opts.ProjectManager()
 	if err != nil {
 		return fmt.Errorf("loading project manager: %w", err)
 	}
 
-	proj, err := projectManager.CurrentProject(context.Background())
+	proj, err := projectManager.CurrentProject(ctx)
 	if err != nil {
 		if errors.Is(err, project.ErrProjectNotFound) {
 			return fmt.Errorf("not in a registered project directory")
@@ -80,7 +80,7 @@ func addRun(_ context.Context, opts *AddOptions) error {
 		return err
 	}
 
-	wtPath, err := proj.CreateWorktree(context.Background(), opts.Branch, opts.Base, opts.NoTrack)
+	wtPath, err := proj.CreateWorktree(ctx, opts.Branch, opts.Base, opts.NoTrack)
 	if err != nil {
 		if errors.Is(err, project.ErrNotInProjectPath) || errors.Is(err, project.ErrProjectNotRegistered) {
 			return fmt.Errorf("not in a registered project directory")

--- a/internal/git/CLAUDE.md
+++ b/internal/git/CLAUDE.md
@@ -84,7 +84,9 @@ err = mgr.SetBranchUpstream(localBranch, remote, remoteBranch)      // branch.<l
 the branch; `ErrAmbiguousRemoteBranch` when multiple remotes match and
 `checkout.defaultRemote` does not disambiguate. `SetBranchUpstream`'s `remoteBranch`
 is the branch name on the remote (may differ from `localBranch`, e.g. a local
-`mybranch` tracking `origin/foo`).
+`mybranch` tracking `origin/foo`). Like `git branch --set-upstream-to`, it upserts:
+a pre-existing `branch.<local>` config section is updated in place (unrelated keys
+preserved), never rejected.
 
 `DeleteBranch` is equivalent to safe `git branch -d` semantics:
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -577,13 +577,42 @@ func (g *GitManager) ResolveRemoteTrackingBranch(branch string) (remote string, 
 // <remote>/<remoteBranch> (branch.<localBranch>.remote / .merge), matching
 // `git branch --set-upstream-to`. remoteBranch is the branch name on the remote,
 // which may differ from localBranch (e.g. `mybranch` tracking `origin/foo`).
+//
+// Like git, this is an upsert: a pre-existing branch.<localBranch> config
+// section (e.g. left behind by a plumbing-level branch deletion, or user-set
+// keys such as branch.<name>.rebase for a branch that doesn't exist yet) is
+// updated in place, preserving its unrelated keys, rather than rejected.
 func (g *GitManager) SetBranchUpstream(localBranch, remote, remoteBranch string) error {
-	if err := g.repo.CreateBranch(&gogitconfig.Branch{
+	merge := plumbing.NewBranchReferenceName(remoteBranch)
+	err := g.repo.CreateBranch(&gogitconfig.Branch{
 		Name:   localBranch,
 		Remote: remote,
-		Merge:  plumbing.NewBranchReferenceName(remoteBranch),
-	}); err != nil {
+		Merge:  merge,
+	})
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, gogit.ErrBranchExists) {
 		return fmt.Errorf("writing tracking config for %q: %w", localBranch, err)
+	}
+
+	// A branch.<localBranch> config section already exists. go-git's
+	// CreateBranch is create-only, but `git branch --set-upstream-to` updates
+	// the section in place — do the same. config.Branch retains unknown keys
+	// in its raw subsection, so only remote/merge change.
+	cfg, err := g.repo.Config()
+	if err != nil {
+		return fmt.Errorf("reading config to update tracking for %q: %w", localBranch, err)
+	}
+	b, ok := cfg.Branches[localBranch]
+	if !ok {
+		b = &gogitconfig.Branch{Name: localBranch}
+		cfg.Branches[localBranch] = b
+	}
+	b.Remote = remote
+	b.Merge = merge
+	if err := g.repo.SetConfig(cfg); err != nil {
+		return fmt.Errorf("updating tracking config for %q: %w", localBranch, err)
 	}
 	return nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1568,23 +1569,24 @@ func TestGitManager_SetupWorktree_RejectsExplicitRemoteRef(t *testing.T) {
 // created, the leaked branch ref must be removed. Otherwise a retry takes the
 // branch-exists path and silently skips tracking, masking the original failure.
 func TestGitManager_SetupWorktree_UpstreamFailureRollsBackBranch(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("fault injection relies on file permissions, which root bypasses")
+	}
+
 	fx := newRepoWithRemote(t)
 	provider := newFakeWorktreeDirProvider(t)
 
-	// Pre-seed a branch.<name> config section so go-git's CreateBranch (inside
-	// SetBranchUpstream) fails with ErrBranchExists — the worktree+branch ref
-	// are created first, then upstream config errors, triggering rollback.
-	cfg, err := fx.mgr.repo.Config()
-	require.NoError(t, err)
-	cfg.Branches[fx.remoteBranch] = &config.Branch{
-		Name:   fx.remoteBranch,
-		Remote: "origin",
-		Merge:  plumbing.NewBranchReferenceName(fx.remoteBranch),
-	}
-	require.NoError(t, fx.mgr.repo.SetConfig(cfg))
+	// Make .git/config unwritable so the tracking-config write inside
+	// SetBranchUpstream fails — the worktree+branch ref are created first,
+	// then upstream config errors, triggering rollback. (Reads still succeed,
+	// so everything up to the config write proceeds normally.)
+	cfgPath := filepath.Join(fx.mgr.repoRoot, ".git", "config")
+	require.NoError(t, os.Chmod(cfgPath, 0o444))
+	// Restore perms so TempDir cleanup can proceed; failure is unactionable.
+	t.Cleanup(func() { _ = os.Chmod(cfgPath, 0o644) })
 
-	_, err = fx.mgr.SetupWorktree(provider, fx.remoteBranch, "", false)
-	require.Error(t, err, "upstream config must fail on the pre-seeded branch section")
+	_, err := fx.mgr.SetupWorktree(provider, fx.remoteBranch, "", false)
+	require.Error(t, err, "upstream config must fail on the read-only config file")
 	assert.Contains(t, err.Error(), "configuring upstream")
 
 	// The branch ref created before the failure must be rolled back, so a retry
@@ -1592,6 +1594,41 @@ func TestGitManager_SetupWorktree_UpstreamFailureRollsBackBranch(t *testing.T) {
 	exists, bErr := fx.mgr.BranchExists(fx.remoteBranch)
 	require.NoError(t, bErr)
 	assert.False(t, exists, "leaked branch ref must be removed on upstream-config rollback")
+}
+
+// TestGitManager_SetupWorktree_StaleBranchConfigSectionIsUpserted pins
+// SetBranchUpstream's git parity: a pre-existing branch.<name> config section
+// (no local ref — e.g. left behind by a plumbing-level branch deletion, or
+// user-set keys for a branch that doesn't exist yet) must be updated in place
+// like `git branch --set-upstream-to`, not rejected — and unrelated keys in
+// the section must survive the update.
+func TestGitManager_SetupWorktree_StaleBranchConfigSectionIsUpserted(t *testing.T) {
+	fx := newRepoWithRemote(t)
+	provider := newFakeWorktreeDirProvider(t)
+
+	// Stale section: wrong remote/merge plus an unrelated user key, with no
+	// matching local branch ref. Seeded by editing .git/config directly —
+	// go-git's SetConfig rebuilds the branch section from typed fields and
+	// would drop a raw-only key, but keys parsed from the file are retained.
+	cfgPath := filepath.Join(fx.mgr.repoRoot, ".git", "config")
+	raw, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	stale := fmt.Sprintf("[branch %q]\n\tremote = stale-remote\n\tmerge = refs/heads/stale-branch\n\trebase = true\n", fx.remoteBranch)
+	require.NoError(t, os.WriteFile(cfgPath, append(raw, stale...), 0o644))
+
+	path, err := fx.mgr.SetupWorktree(provider, fx.remoteBranch, "", false)
+	require.NoError(t, err, "a stale branch config section must not fail worktree creation")
+	require.NotEmpty(t, path)
+
+	// remote/merge were re-pointed at the dwim-resolved remote…
+	assertUpstream(t, fx.mgr, fx.remoteBranch, "origin", fx.remoteBranch)
+
+	// …and the unrelated key survived the upsert.
+	cfg, err := fx.mgr.repo.Config()
+	require.NoError(t, err)
+	assert.Equal(t, "true",
+		cfg.Raw.Section("branch").Subsection(fx.remoteBranch).Option("rebase"),
+		"unrelated branch config keys must be preserved")
 }
 
 func TestGitManager_SetupWorktree_AmbiguousRemoteBranch(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #354, addressing the Copilot review comments that landed after merge. All three were triaged with multi-agent validation; two were applied as-assessed, one (the doc wording Copilot suggested) was corrected against actual code behavior before applying.

- **`SetBranchUpstream` upserts like `git branch --set-upstream-to`** (`internal/git/git.go`): go-git's `CreateBranch` is create-only and errors with `ErrBranchExists` when a `branch.<name>` config section already exists — even with no matching ref (plumbing-level branch deletion leftovers, user-set keys like `branch.<name>.rebase` for a not-yet-existing branch). Previously that state made `worktree add` fail permanently (rollback destroys the worktree, retry hits the same stale section) until the user hand-edited `.git/config`. Now the section is updated in place, preserving unrelated keys — matching native git.
- **`addRun` threads the command context** (`internal/cmd/worktree/add/add.go`) instead of `context.Background()`, matching the list/remove/prune siblings. No behavior change today (downstream layers don't honor ctx yet); consistency + future-proofing.
- **Docs**: the worktree list table's `(detached)` value is clarified — it appears only when HEAD is manually detached inside a clawker-managed worktree after creation. (Copilot's suggested wording — that externally-created detached worktrees appear in listings — was factually wrong: listing is registry-driven and external worktrees never appear.)

## Tests

- Rollback-contract test's fault injector reworked: the pre-seeded config section it relied on now succeeds via the upsert, so it injects via read-only `.git/config` instead (root-skip guarded).
- New `TestGitManager_SetupWorktree_StaleBranchConfigSectionIsUpserted` pins the upsert, including unrelated-key preservation (seeded by editing `.git/config` directly — go-git's `SetConfig` drops raw-only keys set in memory, file-parsed keys round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)