### PR TITLE
docs: sweep + fix statusline worktree detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-<code>clawker</code> is a cli for orchestrating, monitoring, and automating portable <code>devcontainers</code> for <code>Claude Code</code> agents. It works on any MacOS/Linux host with docker installed. I wrote this because I didn't want to have to pay someone to run claude code agents with <code>--dangerously-skip-permissions</code> when containers have been around for a decade, and claude code's sandbox mode is the temu version of a container. <code>clawker</code> offers many convenience features beyond just building and running claude code in a container using a Dockerfile (you don't even have to write a Dockerfile it's got you covered).
+<code>clawker</code> is a cli for orchestrating, monitoring, and automating portable <code>devcontainers</code> for <code>Claude Code</code> agents — a security-first AI container sandbox for Anthropic's models, including the latest mythos-class <code>Fable 5</code>. It works on any MacOS/Linux host with docker installed. I wrote this because I didn't want to have to pay someone to run claude code agents with <code>--dangerously-skip-permissions</code> when containers have been around for a decade, and claude code's sandbox mode is the temu version of a container. <code>clawker</code> offers many convenience features beyond just building and running claude code in a container using a Dockerfile (you don't even have to write a Dockerfile it's got you covered).
 </p>
 
 <div align="center">

--- a/cmd/gen-docs/configuration.mdx.tmpl
+++ b/cmd/gen-docs/configuration.mdx.tmpl
@@ -2,6 +2,7 @@
 title: "Configuration"
 description: "Reference for .clawker.yaml project configuration"
 icon: "gear"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "clawker.yaml", "agent configuration"]
 ---
 
 {/* AUTO-GENERATED from cmd/gen-docs/configuration.mdx.tmpl + schema struct tags. Do not edit directly. Run: make docs */}

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Architecture"
 description: "System layers, package DAG, CLI commands, and key abstractions"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "architecture", "Go CLI"]
 ---
 
 # Architecture

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -2,6 +2,7 @@
 title: "Configuration"
 description: "Reference for .clawker.yaml project configuration"
 icon: "gear"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "clawker.yaml", "agent configuration"]
 ---
 
 {/* AUTO-GENERATED from cmd/gen-docs/configuration.mdx.tmpl + schema struct tags. Do not edit directly. Run: make docs */}

--- a/docs/container-internals.mdx
+++ b/docs/container-internals.mdx
@@ -2,6 +2,7 @@
 title: "Container Internals"
 description: "How Clawker containers are built, initialized, and managed — workspace mounting, session persistence, git integration, and the container lifecycle"
 icon: "microchip"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "container lifecycle", "workspace mounting"]
 ---
 
 Clawker containers are more than a simple `docker run`. Every container goes through a multi-phase initialization that sets up workspace mirroring, git integration, session persistence, credential forwarding, and security controls. This page explains what happens under the hood and why.

--- a/docs/control-plane.mdx
+++ b/docs/control-plane.mdx
@@ -2,6 +2,7 @@
 title: "Control Plane"
 description: "The clawker control plane — what it is, what it does, and how to interact with it"
 icon: "tower-control"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "control plane", "mTLS", "agent registry"]
 ---
 
 The clawker **control plane** (CP) is a long-lived, privileged Go service that runs as `cmd/clawker-cp` (PID 1) inside the `clawker-controlplane` Docker container. It is the authoritative supervisor for every clawker-managed agent on the host — it owns the agent identity registry, the egress firewall lifecycle, the eBPF program lifetime, and the CP↔agent command channel.

--- a/docs/credentials.mdx
+++ b/docs/credentials.mdx
@@ -2,6 +2,7 @@
 title: "Credential Forwarding"
 description: "SSH, GPG, Git HTTPS, and Claude Code authentication forwarding into containers"
 icon: "key"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "credential forwarding", "SSH agent", "GPG signing"]
 ---
 
 Clawker forwards your host credentials into containers so agents can push to Git, sign commits, and authenticate with Claude Code without manual key copying. All credential forwarding is enabled by default.

--- a/docs/custom-images.mdx
+++ b/docs/custom-images.mdx
@@ -2,6 +2,7 @@
 title: "Custom Images"
 description: "Building custom Docker images with packages, Dockerfile instructions, and injection points"
 icon: "layer-group"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "Docker image", "Dockerfile", "devcontainer"]
 ---
 
 Clawker builds Docker images from a parameterized Dockerfile template. You configure the image through `.clawker.yaml` and Clawker generates an optimized Dockerfile with caching, security, and Claude Code pre-installed.

--- a/docs/design.mdx
+++ b/docs/design.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Design Philosophy"
 description: "Security model, core concepts, and key design decisions"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "design philosophy", "secure by default"]
 ---
 
 # Design Philosophy

--- a/docs/docker-hygiene.mdx
+++ b/docs/docker-hygiene.mdx
@@ -2,6 +2,7 @@
 title: Docker Hygiene
 description: Managing disk space with clawker's Docker resources
 icon: "broom"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "Docker resources", "disk space"]
 ---
 
 Clawker builds custom Docker images, creates config/history volumes, and spins up infrastructure containers (Envoy, CoreDNS, monitoring stack). Over time, these resources accumulate and can consume significant disk space — especially if you rebuild images frequently or work across many projects.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,7 +3,15 @@
   "theme": "maple",
   "name": "Clawker",
   "favicon": "/favicon.svg",
-  "description": "Claude Code agent-in-container orchestration and automation",
+  "description": "Clawker — a secure AI container sandbox for Anthropic Claude Code agents. Orchestrate, monitor, and automate mythos-class Fable 5 agents in isolated Docker containers.",
+  "seo": {
+    "metatags": {
+      "keywords": "mythos-class, security, AI container sandbox, Claude Code, Fable 5, Anthropic, agent sandbox, egress firewall, Docker, agent orchestration",
+      "og:site_name": "Clawker",
+      "og:description": "Secure AI container sandbox for Anthropic Claude Code agents — orchestration, egress firewall, and monitoring for mythos-class Fable 5 agents."
+    },
+    "indexing": "all"
+  },
   "appearance": {
     "default": "dark",
     "strict": true

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8,7 +8,11 @@
     "metatags": {
       "keywords": "mythos-class, security, AI container sandbox, Claude Code, Fable 5, Anthropic, agent sandbox, egress firewall, Docker, agent orchestration",
       "og:site_name": "Clawker",
-      "og:description": "Secure AI container sandbox for Anthropic Claude Code agents — orchestration, egress firewall, and monitoring for mythos-class Fable 5 agents."
+      "og:title": "Clawker — AI container sandbox for Claude Code agents",
+      "og:description": "Secure AI container sandbox for Anthropic Claude Code agents — orchestration, egress firewall, and monitoring for mythos-class Fable 5 agents.",
+      "og:image": "https://raw.githubusercontent.com/schmitthub/clawker/main/docs/assets/threat-model.png",
+      "twitter:card": "summary_large_image",
+      "twitter:image": "https://raw.githubusercontent.com/schmitthub/clawker/main/docs/assets/threat-model.png"
     },
     "indexing": "all"
   },

--- a/docs/firewall.mdx
+++ b/docs/firewall.mdx
@@ -2,6 +2,7 @@
 title: "Firewall Guide"
 description: "eBPF + CoreDNS + Envoy network firewall architecture, configuration, CLI commands, and troubleshooting"
 icon: "fire-flame-curved"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "egress firewall", "eBPF", "Envoy", "CoreDNS", "network isolation"]
 ---
 
 Clawker ships a **deny-by-default network firewall** that restricts all container egress to explicitly allowed domains. The firewall runs as a shared stack — an Envoy egress proxy, a custom CoreDNS resolver with a `dnsbpf` plugin, and a set of eBPF cgroup programs — managed automatically by clawker on an isolated Docker bridge network. One firewall stack serves all clawker-managed containers on the host (1:N). It provides DNS-level blocking, per-domain TCP routing, and TLS-level inspection without granting your agent containers any special privileges.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,7 +8,7 @@ keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "F
 
 The rise of Agentic AI has been meteoric, but in the rush to ship model harnesses, the industry is skipping the risks and responsibilities that come with them. They’re avoiding dependency pain by shipping bare-metal software, when the harness itself needs a harness. 
 
-Clawker solves this by running [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in isolated devcontainers — a security-first AI container sandbox for Anthropic's models, from the latest mythos-class Fable 5 down — with security controls, credential forwarding, and multi-agent orchestration built in.
+Clawker solves this by running [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in isolated devcontainers — a security-first AI container sandbox for Anthropic's models, including the latest mythos-class Fable 5 — with security controls, credential forwarding, and multi-agent orchestration built in.
 
 <CardGroup cols={2}>
   <Card title="Quick Start" icon="terminal" href="/quickstart">

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,13 +1,14 @@
 ---
 title: "Introduction"
 description: "Secure, isolated Docker environments for Claude Code agents"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "Claude Code sandbox", "AI agent isolation", "Docker", "agent orchestration"]
 ---
 
 # Clawker
 
 The rise of Agentic AI has been meteoric, but in the rush to ship model harnesses, the industry is skipping the risks and responsibilities that come with them. They’re avoiding dependency pain by shipping bare-metal software, when the harness itself needs a harness. 
 
-Clawker solves this by running [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in isolated devcontainers with security controls, credential forwarding, and multi-agent orchestration built in.
+Clawker solves this by running [Claude Code](https://docs.anthropic.com/en/docs/claude-code) agents in isolated devcontainers — a security-first AI container sandbox for Anthropic's models, from the latest mythos-class Fable 5 down — with security controls, credential forwarding, and multi-agent orchestration built in.
 
 <CardGroup cols={2}>
   <Card title="Quick Start" icon="terminal" href="/quickstart">

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -2,6 +2,7 @@
 title: "Installation"
 description: "All methods for installing Clawker"
 icon: "download"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "install clawker", "Homebrew", "macOS", "Linux"]
 ---
 
 ## Prerequisites

--- a/docs/monitoring.mdx
+++ b/docs/monitoring.mdx
@@ -2,6 +2,7 @@
 title: "Monitoring"
 description: "Set up the OpenSearch + OpenSearch Dashboards + Prometheus monitoring stack for agent observability"
 icon: "chart-mixed"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "OpenSearch", "Prometheus", "agent observability"]
 ---
 
 Clawker includes an optional monitoring stack that collects telemetry from Claude Code agents running in containers. It provides dashboards for logs and metrics — giving you visibility into what every agent is doing, how much it costs, what tools it's calling, and whether it's making progress.

--- a/docs/observability.mdx
+++ b/docs/observability.mdx
@@ -2,6 +2,7 @@
 title: "Egress Observability"
 description: "Per-decision-point eBPF egress event records — what netlogger emits, where it lands, and how to use it"
 icon: "binoculars"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "eBPF", "OpenTelemetry", "egress audit"]
 ---
 
 When the firewall is enabled, clawker's control plane runs **netlogger** — a userspace pipeline that drains an eBPF ringbuf populated by the cgroup/connect/sendmsg/sock_create programs and emits one OTLP log record per egress decision. Every connect, sendmsg, and socket-create call from a managed agent container produces a record carrying the kernel's verdict (`allowed` / `denied` / `bypassed`), the container's attribution (`agent`, `project`, `container_id`), the destination 4-tuple, and the resolved domain when DNS context is available.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -2,6 +2,7 @@
 title: "Quickstart"
 description: "Install clawker, initialize a project, and run your first containerized Claude Code agent"
 icon: "rocket"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "Claude Code container", "Docker", "agent sandbox setup"]
 ---
 
 ## Prerequisites

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -2,6 +2,7 @@
 title: "Security"
 description: "Container security controls: firewall overview, Docker socket access, Linux capabilities, host proxy, and credential forwarding"
 icon: "shield"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "container security", "egress firewall", "Linux capabilities"]
 ---
 
 Clawker runs every agent in an isolated Docker container with a default-on network firewall. This guide explains the container security controls and how to customize them.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,7 @@
 ---
 title: "Testing Guide"
 description: "Test strategy, how to run tests, golden files, and writing new tests"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "testing", "golden files"]
 ---
 
 # Testing Guide

--- a/docs/threat-model.mdx
+++ b/docs/threat-model.mdx
@@ -2,6 +2,7 @@
 title: "Threat Model"
 description: "Why AI agents need containment, what attack surfaces clawker mitigates, and what you're responsible for"
 icon: "crosshairs"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "threat model", "prompt injection", "AI agent security", "agent containment"]
 ---
 
 AI coding agents are not traditional CLI tools. They make autonomous decisions about what files to read and write, what commands to run, what network requests to make, and what credentials to use. They do this with full conviction — even when they're wrong. They hallucinate file paths, lose context mid-task, get tunnel vision on a broken approach, and can be coerced by adversarial content embedded in the data they fetch. Handing one of these agents unrestricted code execution, full filesystem access, and open network on your bare-metal host is reckless.

--- a/docs/worktrees.mdx
+++ b/docs/worktrees.mdx
@@ -2,6 +2,7 @@
 title: "Worktrees"
 description: "Git worktree integration for multi-branch agent workflows"
 icon: "code-branch"
+keywords: ["mythos-class", "security", "AI container sandbox", "Claude Code", "Fable 5", "Anthropic", "git worktree", "parallel agents", "multi-agent"]
 ---
 
 Clawker integrates with Git worktrees to let you run multiple agents on separate branches simultaneously without conflicts. Each worktree gets its own working directory, and Clawker tracks them in the project registry.

--- a/internal/bundler/assets/statusline.sh
+++ b/internal/bundler/assets/statusline.sh
@@ -255,22 +255,25 @@ if [ -n "$branch" ]; then
     fi
 fi
 
-# Worktree detection: ask git rather than stat'ing ${DIR}/.git — the .git
-# *file* only exists at the worktree root, so a path check silently fails the
-# moment the session cwd is a subdirectory. In a linked worktree the git-dir
-# (<main>/.git/worktrees/<name>) differs from the common dir (<main>/.git);
-# in a regular repo they are identical from any depth.
+# Worktree detection: the .git *file* exists only at the worktree root, so a
+# path check fails from any subdirectory. Instead compare git-dir
+# (<main>/.git/worktrees/<name> in a linked worktree) against the common dir
+# (<main>/.git) — they resolve to the same path only in a regular repo.
 is_worktree=false
 if [ -n "$branch" ]; then
-    # --path-format=absolute: both paths come back canonical, so the string
-    # compare can't false-positive on relative-vs-absolute (a regular repo at
-    # its root reports ".git" vs "/path/.git" without it).
+    # --path-format=absolute (git 2.31+) canonicalizes both paths so the
+    # compare can't false-positive on mixed formats: from a subdirectory of a
+    # regular repo, --git-dir is absolute while --git-common-dir is
+    # cwd-relative ("/repo/.git" vs "../.git"). Older git echoes the unknown
+    # flag to *stdout* with exit 0, polluting the first line — so only trust
+    # the compare when git_dir parsed as an absolute path; anything else
+    # degrades to no indicator.
     git_dirs=$(git --no-optional-locks rev-parse --path-format=absolute --git-dir --git-common-dir 2>/dev/null)
     git_dir=${git_dirs%%$'\n'*}
     git_common_dir=${git_dirs##*$'\n'}
-    if [ -n "$git_dir" ] && [ "$git_dir" != "$git_common_dir" ]; then
-        is_worktree=true
-    fi
+    case "$git_dir" in
+        /*) [ "$git_dir" != "$git_common_dir" ] && is_worktree=true ;;
+    esac
 fi
 
 # Vim mode

--- a/internal/bundler/assets/statusline.sh
+++ b/internal/bundler/assets/statusline.sh
@@ -255,10 +255,22 @@ if [ -n "$branch" ]; then
     fi
 fi
 
-# Worktree detection: .git file = worktree, .git dir = regular repo
+# Worktree detection: ask git rather than stat'ing ${DIR}/.git — the .git
+# *file* only exists at the worktree root, so a path check silently fails the
+# moment the session cwd is a subdirectory. In a linked worktree the git-dir
+# (<main>/.git/worktrees/<name>) differs from the common dir (<main>/.git);
+# in a regular repo they are identical from any depth.
 is_worktree=false
-if [ -f "${DIR}/.git" ]; then
-    is_worktree=true
+if [ -n "$branch" ]; then
+    # --path-format=absolute: both paths come back canonical, so the string
+    # compare can't false-positive on relative-vs-absolute (a regular repo at
+    # its root reports ".git" vs "/path/.git" without it).
+    git_dirs=$(git --no-optional-locks rev-parse --path-format=absolute --git-dir --git-common-dir 2>/dev/null)
+    git_dir=${git_dirs%%$'\n'*}
+    git_common_dir=${git_dirs##*$'\n'}
+    if [ -n "$git_dir" ] && [ "$git_dir" != "$git_common_dir" ]; then
+        is_worktree=true
+    fi
 fi
 
 # Vim mode


### PR DESCRIPTION
## Summary

Two changes on this branch:

### Docs SEO sweep
- `keywords` frontmatter on every hand-written docs page (Mintlify per-page SEO): mythos-class, security, AI container sandbox, Claude Code, Fable 5, Anthropic + page-specific terms
- `docs.json`: new `seo.metatags` block (keywords + og tags), `indexing: all`, richer site description
- Keyword copy woven into README and `index.mdx` intros
- GitHub repo topics updated to match (applied directly: +mythos-class, +security, +ai-container-sandbox, +fable-5, +anthropic; dropped 3 plural-dupe topics to fit the 20-topic cap)

### statusline.sh worktree detection fix

Fixes #363

The cyan `+<branch>(wt)` indicator was detected by `[ -f "${DIR}/.git" ]`, which is only true at the worktree root — `workspace.current_dir` tracks the session cwd, so the indicator silently vanished whenever the agent `cd`'d into a subdirectory. Now asks git directly: compares `rev-parse --git-dir` vs `--git-common-dir` with `--path-format=absolute` (a regular repo at its root reports relative `.git` vs absolute without it, which would false-positive).

## Test plan

- Verified all five cwd scenarios by piping synthetic status-line JSON through the script: worktree root ✓(wt), worktree subdir ✓(wt), regular repo root ✗, regular repo subdir ✗, non-repo ✗
- Pre-commit hooks (gitleaks, govulncheck) passed; go hooks skipped (no .go files changed)
- docs.json validates; Mintlify per-page `keywords` + `seo.metatags` schema confirmed against Mintlify docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)