### PR TITLE
fix(worktree): protect main .git, fix Go builds, and refuse double-checkout in worktree containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,12 @@ BINARY_NAME := clawker
 CLAWKER_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 CLAWKER_REVISION ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 GO ?= go
-GOFLAGS := -trimpath
+# Append to (not clobber) any inherited GOFLAGS: worktree containers set
+# GOFLAGS=-buildvcs=false because Go cannot stamp linked worktrees there
+# (the .git-file walk lands on the mounted main .git and exits 128).
+# (make re-exports the merged value to recipes only when GOFLAGS was already
+# in the environment; host builds without GOFLAGS are unchanged.)
+GOFLAGS := -trimpath $(GOFLAGS)
 # Dev builds leave build.Date empty; release goreleaser stamps it via
 # {{.CommitDate}} in .goreleaser.yaml.
 LDFLAGS := -s -w \

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
@@ -36,3 +36,23 @@ container: `export GOFLAGS=-buildvcs=false` (or add it to `agent.env` and
 recreate). Do **not** suggest `git config --global --add safe.directory` for
 the main repo path — git at that path sees the whole tree as deleted, and a
 `git add -A` there would stage mass deletions into the host's real index.
+
+## --worktree on a branch already checked out
+
+`clawker run --worktree <branch>` for a branch that is already checked out in
+the main repo (or another worktree) is refused:
+
+```
+branch is already checked out in another worktree: "<branch>" is checked out at <path>
+```
+
+This mirrors native `git worktree add` — one branch cannot be checked out in two
+places, or a commit in one moves the other's HEAD onto content it never checked
+out. Common trigger: `git switch -c <branch>` in the repo root, then
+`clawker run --worktree <branch>` on the same name.
+
+Fix: either switch the root checkout off the branch (`git switch <other>` there),
+or pass `--worktree <new-branch>` and let clawker create and own a fresh branch
+(don't pre-create it in root). If a worktree commit already slid root's HEAD,
+`git -C <root> switch <branch>` (or `git switch -f <branch>`) re-separates them;
+no commits are lost — they live on the branch ref.

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
@@ -15,3 +15,24 @@ FOO_API_KEY=sk-abc123
 # May break — quotes become part of the value
 FOO_API_KEY="sk-abc123"
 ```
+
+## go build VCS error in older worktree containers
+
+In worktree containers created before the `GOFLAGS=-buildvcs=false` default,
+any `go build` of a main package fails:
+
+```
+error obtaining VCS status: exit status 128
+	Use -buildvcs=false to disable VCS stamping.
+```
+
+Go skips the worktree's `.git` *file*, walks up to the mounted main `.git`
+directory, and trips git's `safe.directory` check on the root-owned mount
+scaffold dir. Plain git inside the worktree works, which makes this confusing.
+
+Fix: recreate the container (new worktree containers set
+`GOFLAGS=-buildvcs=false` automatically). In-place workaround for an existing
+container: `export GOFLAGS=-buildvcs=false` (or add it to `agent.env` and
+recreate). Do **not** suggest `git config --global --add safe.directory` for
+the main repo path — git at that path sees the whole tree as deleted, and a
+`git add -A` there would stage mass deletions into the host's real index.

--- a/docs/worktrees.mdx
+++ b/docs/worktrees.mdx
@@ -205,4 +205,17 @@ When a container is created with `--worktree`, two mounts are set up:
 
 By mounting both at their real host paths, git commands inside the container work correctly — the `.git` file's reference resolves, git finds the shared metadata, and operations like `git log`, `git status`, and `git commit` behave normally.
 
+### Protected `.git` paths
+
+The main `.git` mount is read-write (commits from the worktree write objects, refs, and per-worktree metadata there), but two paths inside it are masked with **read-only** binds:
+
+- `.git/hooks/` — a hook planted from inside the container would execute on the *host* the next time you run git in the main checkout.
+- `.git/config` — config keys like `core.hooksPath`, `core.fsmonitor`, or `filter.*` can execute arbitrary commands; from a worktree, `git config --local` writes to this shared file.
+
+This keeps worktree containers meaningfully more isolated than bind mode. The trade-off: `git config --local`, `git remote add`, and `git push -u` fail inside a worktree container (the config file is read-only). Upstream tracking is already configured on the host when the worktree is created, so a plain `git push` works without `-u`.
+
+### Go builds inside worktree containers
+
+Worktree containers set `GOFLAGS=-buildvcs=false`. Go's VCS stamping cannot work in a linked worktree: the `go` tool only recognizes a `.git` *directory* (a worktree has a `.git` file), so it walks up to the mounted main `.git`, where stamping would either fail (`error obtaining VCS status: exit status 128`) or record the wrong revision. Set `GOFLAGS` in `agent.env` to override.
+
 See [Container Internals](/container-internals) for the complete explanation of workspace mounting, git integration, and session persistence.

--- a/internal/cmd/container/shared/container_create.go
+++ b/internal/cmd/container/shared/container_create.go
@@ -1606,7 +1606,7 @@ func CreateContainer(ctx context.Context, opts *CreateContainerOptions, events c
 	workspaceMounts = append(workspaceMounts, gitSetup.Mounts...)
 	containerOpts.Env = append(containerOpts.Env, gitSetup.Env...)
 
-	runtimeEnv, envWarnings, err := buildCreateTimeEnv(ctx, opts, containerOpts, agentName, wd, log)
+	runtimeEnv, envWarnings, err := buildCreateTimeEnv(ctx, opts, containerOpts, agentName, wd, projectRootDir, log)
 	if err != nil {
 		return nil, err
 	}
@@ -1930,8 +1930,10 @@ func setupHostProxy(ctx context.Context, events chan<- CreateContainerEvent, cfg
 }
 
 // buildCreateTimeEnv constructs container runtime environment variables.
-// Returns env vars, warnings (e.g. unset from_env vars), and error.
-func buildCreateTimeEnv(ctx context.Context, opts *CreateContainerOptions, containerOpts *ContainerCreateOptions, agentName, wd string, log *logger.Logger) (env []string, warnings []string, retErr error) {
+// projectRootDir is the main repo root when the workspace is a git worktree
+// (empty otherwise) — the same signal workspace.SetupMounts keys the .git
+// mount on. Returns env vars, warnings (e.g. unset from_env vars), and error.
+func buildCreateTimeEnv(ctx context.Context, opts *CreateContainerOptions, containerOpts *ContainerCreateOptions, agentName, wd, projectRootDir string, log *logger.Logger) (env []string, warnings []string, retErr error) {
 	projectCfg := opts.Config.Project()
 	workspaceMode := containerOpts.Mode
 	if workspaceMode == "" {
@@ -1958,6 +1960,7 @@ func buildCreateTimeEnv(ctx context.Context, opts *CreateContainerOptions, conta
 		Agent:             agentName,
 		WorkspaceMode:     workspaceMode,
 		WorkspaceSource:   wd,
+		Worktree:          projectRootDir != "",
 		Editor:            projectCfg.Agent.Editor,
 		Visual:            projectCfg.Agent.Visual,
 		Is256Color:        opts.Is256Color,

--- a/internal/cmd/container/shared/container_create.go
+++ b/internal/cmd/container/shared/container_create.go
@@ -29,6 +29,7 @@ import (
 	"github.com/schmitthub/clawker/internal/config"
 	"github.com/schmitthub/clawker/internal/consts"
 	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/internal/git"
 
 	"github.com/schmitthub/clawker/internal/hostproxy"
 	"github.com/schmitthub/clawker/internal/logger"
@@ -1865,6 +1866,13 @@ func resolveWorkDir(ctx context.Context, containerOpts *ContainerCreateOptions, 
 		// (no --no-track surface here; use `clawker worktree add` for that).
 		wd, err = proj.CreateWorktree(ctx, wtSpec.Branch, wtSpec.Base, false)
 		if err != nil {
+			if errors.Is(err, git.ErrBranchAlreadyCheckedOut) {
+				// Branch is checked out elsewhere (the main repo or another
+				// worktree); git forbids a second checkout of one branch.
+				return "", "", fmt.Errorf(
+					"%w\nswitch the other checkout off the branch (e.g. `git switch <other-branch>` there), "+
+						"or pass `--worktree <new-branch>` to let clawker create and own a fresh branch", err)
+			}
 			if !errors.Is(err, project.ErrWorktreeExists) {
 				return "", "", fmt.Errorf("setting up worktree %q for agent %q: %w", wtSpec.Branch, agentName, err)
 			}

--- a/internal/docker/CLAUDE.md
+++ b/internal/docker/CLAUDE.md
@@ -81,7 +81,7 @@ type Container struct {
 
 ## Environment (`env.go`)
 
-`RuntimeEnv(opts RuntimeEnvOpts) ([]string, error)` — builds container env vars. Precedence: base → terminal → agent env → instruction env. Sorted by key.
+`RuntimeEnv(opts RuntimeEnvOpts) ([]string, error)` — builds container env vars. Precedence: base → terminal → agent env → instruction env. Sorted by key. `Worktree: true` (linked-worktree workspace) adds `GOFLAGS=-buildvcs=false` — Go cannot stamp linked worktrees (its VCS walk skips the `.git` file and lands on the mounted main `.git`); user env overrides.
 
 ## Volume Utilities (`volume.go`)
 

--- a/internal/docker/env.go
+++ b/internal/docker/env.go
@@ -19,6 +19,9 @@ type RuntimeEnvOpts struct {
 	Agent           string
 	WorkspaceMode   string // "bind" or "snapshot"
 	WorkspaceSource string // host path being mounted
+	// Worktree marks a workspace that is a linked git worktree, with the main
+	// repo's .git directory mounted separately (see workspace.SetupMounts).
+	Worktree bool
 
 	// Editor preferences
 	Editor string
@@ -174,6 +177,18 @@ func RuntimeEnv(opts RuntimeEnvOpts) ([]string, error) {
 			return nil, fmt.Errorf("failed to marshal remote sockets: %w", err)
 		}
 		m["CLAWKER_REMOTE_SOCKETS"] = string(socketsBytes)
+	}
+
+	// Worktree containers: disable Go VCS stamping. Go's VCS discovery only
+	// recognizes a .git *directory* — it skips a linked worktree's .git file
+	// and walks up to the bind-mounted main .git, where `git status` either
+	// fails with exit 128 (dubious ownership: the repo top-level is a
+	// root-owned Docker scaffold dir) or, if unblocked, would stamp the wrong
+	// revision (the main checkout's HEAD with the entire tree appearing
+	// deleted, since only .git is mounted). Stamping can never be correct in
+	// this topology, so default it off. agent.env / instruction env override.
+	if opts.Worktree {
+		m["GOFLAGS"] = "-buildvcs=false"
 	}
 
 	// Agent env vars (override base defaults and terminal)

--- a/internal/docker/env_test.go
+++ b/internal/docker/env_test.go
@@ -100,6 +100,35 @@ func TestRuntimeEnv_Precedence(t *testing.T) {
 	assert.Contains(t, env, "SHARED=from-instructions", "instruction env should override agent env")
 }
 
+func TestRuntimeEnv_WorktreeDisablesGoVCSStamping(t *testing.T) {
+	env, err := RuntimeEnv(RuntimeEnvOpts{Worktree: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, env, "GOFLAGS=-buildvcs=false",
+		"worktree containers must disable Go VCS stamping (go cannot stamp linked worktrees; the main .git mount makes it fail or stamp the wrong revision)")
+}
+
+func TestRuntimeEnv_NonWorktreeNoGoFlags(t *testing.T) {
+	env, err := RuntimeEnv(RuntimeEnvOpts{})
+	require.NoError(t, err)
+
+	for _, e := range env {
+		assert.False(t, strings.HasPrefix(e, "GOFLAGS="),
+			"should not set GOFLAGS for non-worktree containers")
+	}
+}
+
+func TestRuntimeEnv_WorktreeGoFlagsAgentEnvOverride(t *testing.T) {
+	env, err := RuntimeEnv(RuntimeEnvOpts{
+		Worktree: true,
+		AgentEnv: map[string]string{"GOFLAGS": "-buildvcs=auto"},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, env, "GOFLAGS=-buildvcs=auto", "agent env should override the worktree GOFLAGS default")
+	assert.NotContains(t, env, "GOFLAGS=-buildvcs=false")
+}
+
 func TestRuntimeEnv_256Color(t *testing.T) {
 	env, err := RuntimeEnv(RuntimeEnvOpts{
 		Is256Color: true,

--- a/internal/git/CLAUDE.md
+++ b/internal/git/CLAUDE.md
@@ -48,6 +48,14 @@ Behavior details:
 
 - `SetupWorktree` validates/reuses existing directories when possible.
 - `SetupWorktree` removes orphaned git metadata for a target worktree before fresh creation.
+- `SetupWorktree` refuses to create a worktree for an existing branch that is already
+  checked out elsewhere — the repo root checkout or another linked worktree —
+  returning `ErrBranchAlreadyCheckedOut` (path named in the wrapped message). This
+  is the interlock native `git worktree add` enforces; go-git's experimental
+  worktree package does not, so without it two checkouts could share one branch
+  ref and a commit in either would slide the other's HEAD. The guard fires only on
+  fresh creation; idempotent reuse of an already-established worktree returns
+  before it. New branches can't collide, so only the existing-branch path is gated.
 - `SetupWorktree` branch resolution mirrors native `git worktree add` (no network):
   - branch is a local head → check it out.
   - `base != ""` → create the branch at base; if base is a remote-tracking branch
@@ -164,6 +172,7 @@ These are composed by `GitManager.SetupWorktree`/`RemoveWorktree` for domain wor
 - `ErrBranchAlreadyExists`
 - `ErrAmbiguousRemoteBranch`
 - `ErrExplicitRemoteRef`
+- `ErrBranchAlreadyCheckedOut`
 
 Prefer `errors.Is` checks at command/service boundaries.
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -54,6 +54,12 @@ var (
 	// Native git would detach HEAD there, which clawker's branch-keyed worktrees
 	// do not support; the caller is steered to the bare name or colon-base form.
 	ErrExplicitRemoteRef = errors.New("branch name is a remote-tracking ref")
+
+	// ErrBranchAlreadyCheckedOut is returned when a worktree is requested for a
+	// branch that is already checked out elsewhere (the repo root checkout or
+	// another linked worktree). Native `git worktree add` refuses this; go-git's
+	// experimental worktree package does not, so SetupWorktree enforces it.
+	ErrBranchAlreadyCheckedOut = errors.New("branch is already checked out in another worktree")
 )
 
 // GitManager is the top-level facade for git operations.
@@ -245,6 +251,16 @@ func (g *GitManager) SetupWorktree(dirs WorktreeDirProvider, branch, base string
 	// Branch names like "a/foo" have slashes that go-git rejects in worktree names,
 	// but the directory basename contains no slashes. This matches native git behavior.
 	if branchExists {
+		// Refuse if the branch is already checked out elsewhere (root or another
+		// worktree). go-git would happily create a second checkout of one branch;
+		// a commit in either then slides the other's HEAD onto content it never
+		// materialized. Mirror native `git worktree add`'s interlock.
+		if loc, inUse, err := g.findBranchCheckout(branch); err != nil {
+			return "", fmt.Errorf("checking branch checkout state: %w", err)
+		} else if inUse {
+			return "", fmt.Errorf("%w: %q is checked out at %s", ErrBranchAlreadyCheckedOut, branch, loc)
+		}
+
 		// Branch exists - check it out without creating a new one
 		if err := wt.AddWithExistingBranch(wtPath, wtName, branchRef); err != nil {
 			// Clean up directory and git metadata on failure
@@ -463,6 +479,72 @@ func (g *GitManager) GetCurrentBranch() (string, error) {
 	}
 
 	return head.Name().Short(), nil
+}
+
+// findBranchCheckout reports the filesystem path of an existing checkout (the
+// repo root or a linked worktree) that currently has `branch` as its HEAD,
+// mirroring the interlock native `git worktree add` enforces. It returns
+// ("", false, nil) when the branch is checked out nowhere. Detached worktrees
+// never collide (no branch). In-memory repos have no on-disk worktree metadata,
+// so only the root checkout is consulted.
+func (g *GitManager) findBranchCheckout(branch string) (string, bool, error) {
+	// Root checkout (the main worktree).
+	current, err := g.GetCurrentBranch()
+	if err != nil {
+		return "", false, fmt.Errorf("resolving current branch: %w", err)
+	}
+	if current == branch {
+		return g.RepoRoot(), true, nil
+	}
+
+	gitDir := g.GitDir()
+	if gitDir == "" {
+		return "", false, nil // in-memory repo: no linked-worktree metadata
+	}
+	wt, err := g.Worktrees()
+	if err != nil {
+		return "", false, fmt.Errorf("initializing worktree manager: %w", err)
+	}
+	slugs, err := wt.List()
+	if err != nil {
+		return "", false, fmt.Errorf("listing worktrees: %w", err)
+	}
+
+	want := plumbing.NewBranchReferenceName(branch)
+	for _, slug := range slugs {
+		headPath := filepath.Join(gitDir, "worktrees", slug, "HEAD")
+		data, err := os.ReadFile(headPath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue // racing prune / partial metadata, not our collision
+			}
+			return "", false, fmt.Errorf("reading worktree HEAD %s: %w", headPath, err)
+		}
+		// A worktree on a branch records "ref: refs/heads/<branch>"; a detached
+		// worktree records a bare hash and never collides.
+		const symPrefix = "ref: "
+		line := strings.TrimSpace(string(data))
+		if !strings.HasPrefix(line, symPrefix) {
+			continue
+		}
+		if plumbing.ReferenceName(strings.TrimPrefix(line, symPrefix)) != want {
+			continue
+		}
+		return g.worktreePathFromSlug(gitDir, slug), true, nil
+	}
+	return "", false, nil
+}
+
+// worktreePathFromSlug resolves a linked worktree's checkout directory from its
+// gitdir pointer (best-effort, for the conflict message). The gitdir file holds
+// "<worktree>/.git"; its parent is the checkout. Falls back to the slug when the
+// pointer is unreadable — the collision is real regardless of the label.
+func (g *GitManager) worktreePathFromSlug(gitDir, slug string) string {
+	data, err := os.ReadFile(filepath.Join(gitDir, "worktrees", slug, "gitdir"))
+	if err != nil {
+		return slug
+	}
+	return filepath.Dir(strings.TrimSpace(string(data)))
 }
 
 // ResolveRef resolves a reference (branch, tag, commit) to a commit hash.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -772,32 +772,6 @@ func TestGitManager_ListWorktrees_OrphanedDirectory(t *testing.T) {
 	assert.Equal(t, orphanDir, orphanInfo.Path)
 }
 
-func TestGitManager_SetupWorktree_SucceedsWithExistingBranch(t *testing.T) {
-	// After the fix, SetupWorktree should succeed with an existing branch
-	// by using AddWithExistingBranch instead of AddWithNewBranch.
-	_, repoDir := newTestRepoOnDisk(t)
-	mgr, err := NewGitManager(repoDir)
-	require.NoError(t, err)
-
-	wt, err := mgr.Worktrees()
-	require.NoError(t, err)
-
-	provider := newFakeWorktreeDirProvider(t)
-
-	// Create a worktree for the existing master branch - should succeed now
-	path, err := mgr.SetupWorktree(provider, "master", "", false)
-	require.NoError(t, err)
-	assert.NotEmpty(t, path)
-
-	// Verify the worktree is on master
-	wtRepo, err := wt.Open(path)
-	require.NoError(t, err)
-
-	head, err := wtRepo.Head()
-	require.NoError(t, err)
-	assert.Equal(t, "master", head.Name().Short())
-}
-
 func TestGitManager_SetupWorktree_CleanupOnInvalidBase(t *testing.T) {
 	_, repoDir := newTestRepoOnDisk(t)
 	mgr, err := NewGitManager(repoDir)
@@ -1028,10 +1002,18 @@ func TestGitManager_SetupWorktree_CleansUpGitMetadataOnFailure(t *testing.T) {
 }
 
 func TestGitManager_SetupWorktree_ExistingBranchWorksCorrectly(t *testing.T) {
-	// This test verifies that SetupWorktree correctly uses AddWithExistingBranch
-	// for branches that already exist, instead of failing.
+	// This test verifies that SetupWorktree uses AddWithExistingBranch for a
+	// branch that already exists (instead of failing) and lands the worktree on
+	// that branch. The branch must NOT be checked out at root — that collision
+	// is refused (see TestSetupWorktree_RefusesBranchCheckedOutAtRoot).
 
-	_, repoDir := newTestRepoOnDisk(t)
+	repo, repoDir := newTestRepoOnDisk(t)
+	headRef, err := repo.Head()
+	require.NoError(t, err)
+	// Create an existing branch without checking it out at root (root stays on master).
+	require.NoError(t, repo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName("feature/existing"), headRef.Hash())))
+
 	mgr, err := NewGitManager(repoDir)
 	require.NoError(t, err)
 
@@ -1040,8 +1022,7 @@ func TestGitManager_SetupWorktree_ExistingBranchWorksCorrectly(t *testing.T) {
 
 	provider := newFakeWorktreeDirProvider(t)
 
-	// Setup worktree for master (which already exists)
-	path, err := mgr.SetupWorktree(provider, "master", "", false)
+	path, err := mgr.SetupWorktree(provider, "feature/existing", "", false)
 	require.NoError(t, err)
 	assert.NotEmpty(t, path)
 
@@ -1051,13 +1032,13 @@ func TestGitManager_SetupWorktree_ExistingBranchWorksCorrectly(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	// Verify the worktree is on master
+	// Verify the worktree is on the existing branch
 	wtRepo, err := wt.Open(path)
 	require.NoError(t, err)
 
 	head, err := wtRepo.Head()
 	require.NoError(t, err)
-	assert.Equal(t, "master", head.Name().Short())
+	assert.Equal(t, "feature/existing", head.Name().Short())
 }
 
 func TestWorktreeManager_AddWithNewBranch_NoSlugifiedBranch(t *testing.T) {
@@ -1671,4 +1652,60 @@ func TestGitManager_SetupWorktree_AmbiguousRemoteBranch(t *testing.T) {
 		assert.Equal(t, fx.remoteTip, head.Hash())
 		assertUpstream(t, fx.mgr, fx.remoteBranch, "upstream", fx.remoteBranch)
 	})
+}
+
+// checkoutNewBranchAtRoot creates and checks out a branch in the main worktree
+// (the repo root checkout), so the branch becomes root's HEAD.
+func checkoutNewBranchAtRoot(t *testing.T, repo *gogit.Repository, branch string) {
+	t.Helper()
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, wt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName(branch),
+		Create: true,
+	}))
+}
+
+// TestSetupWorktree_RefusesBranchCheckedOutAtRoot pins the interlock native
+// `git worktree add` enforces but go-git's experimental worktree package does
+// not: a branch already checked out at the repo root cannot be checked out
+// again in a worktree (the shared ref would let a worktree commit slide root's
+// HEAD onto a commit root never materialized).
+func TestSetupWorktree_RefusesBranchCheckedOutAtRoot(t *testing.T) {
+	repo, repoDir := newTestRepoOnDisk(t)
+	checkoutNewBranchAtRoot(t, repo, "feature/x")
+
+	mgr, err := NewGitManager(repoDir)
+	require.NoError(t, err)
+	provider := newFakeWorktreeDirProvider(t)
+
+	_, err = mgr.SetupWorktree(provider, "feature/x", "", false)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrBranchAlreadyCheckedOut)
+	assert.Contains(t, err.Error(), repoDir, "error must name the conflicting checkout path")
+	assert.Contains(t, err.Error(), "feature/x")
+}
+
+// TestFindBranchCheckout_DetectsLinkedWorktree exercises the linked-worktree
+// arm of the interlock: a branch held by another linked worktree is detected.
+// (The branch-keyed dir provider prevents two worktrees for one branch through
+// SetupWorktree itself, so the linked arm is verified on the helper directly.)
+func TestFindBranchCheckout_DetectsLinkedWorktree(t *testing.T) {
+	_, repoDir := newTestRepoOnDisk(t)
+	mgr, err := NewGitManager(repoDir)
+	require.NoError(t, err)
+	provider := newFakeWorktreeDirProvider(t)
+
+	wtPath, err := mgr.SetupWorktree(provider, "feature/z", "", false)
+	require.NoError(t, err)
+
+	loc, found, err := mgr.findBranchCheckout("feature/z")
+	require.NoError(t, err)
+	assert.True(t, found, "branch checked out in a linked worktree must be detected")
+	assert.NotEmpty(t, loc)
+	assert.Equal(t, filepath.Base(wtPath), filepath.Base(loc), "should resolve the conflicting worktree path")
+
+	_, found, err = mgr.findBranchCheckout("feature/not-checked-out")
+	require.NoError(t, err)
+	assert.False(t, found, "a branch checked out nowhere must not be flagged")
 }

--- a/internal/workspace/CLAUDE.md
+++ b/internal/workspace/CLAUDE.md
@@ -88,11 +88,15 @@ Failure handling:
 
 **Worktree support**: When using `--worktree`, the worktree directory is set as `WorkDir`. Additionally, `ProjectRootDir` must be set to the main repository root so that the `.git` directory can be mounted into the container. Git worktrees use a `.git` **file** (not directory) that references the main repo's `.git/worktrees/<name>/` metadata. By mounting the main `.git` directory at its original absolute path in the container, git commands work correctly inside the worktree.
 
-The `buildWorktreeGitMount(projectRootDir string) (*mount.Mount, error)` helper validates and creates the `.git` mount:
+The `buildWorktreeGitMounts(projectRootDir string) ([]mount.Mount, error)` helper validates and creates the `.git` mounts:
 - Resolves symlinks to match git's behavior (e.g., `/var` → `/private/var` on macOS)
 - Returns clear errors if `ProjectRootDir` doesn't exist or has permission issues
 - Validates `.git` exists and is a directory (not a worktree `.git` file)
-- Returns a bind mount with `Source == Target` (same absolute path) for worktree reference resolution
+- Returns three bind mounts, all with `Source == Target` (same absolute path) for worktree reference resolution:
+  1. `.git` read-write (worktree git ops write objects, refs, `.git/worktrees/<name>/`)
+  2. `.git/config` read-only and 3. `.git/hooks` read-only — masked over the RW mount because both are host-code-execution vectors (planted hooks / `core.hooksPath` / `core.fsmonitor` / `filter.*` run on the host's next git op in the main checkout). Missing `config`/`hooks` are created host-side first so the RO bind always has a source; skipping would let the agent create them in the RW region. Known in-worktree casualties (loud failures, not silent): `git config --local`, `git remote add`, `git push -u` — upstream tracking is configured host-side at worktree creation, so plain `git push` works.
+
+Worktree containers also get `GOFLAGS=-buildvcs=false` (see `docker.RuntimeEnvOpts.Worktree`): Go's VCS discovery only recognizes a `.git` directory, walks up past the worktree's `.git` file to the mounted main `.git`, and either fails exit 128 (dubious ownership on the root-owned mount-parent scaffold) or would stamp the wrong revision. Stamping can never be correct in this topology.
 
 ## Git Credentials
 

--- a/internal/workspace/setup.go
+++ b/internal/workspace/setup.go
@@ -146,14 +146,14 @@ func SetupMounts(ctx context.Context, client *docker.Client, cfg SetupMountsConf
 
 	// Mount main repo's .git directory for worktree support
 	if cfg.ProjectRootDir != "" {
-		gitMount, err := buildWorktreeGitMount(cfg.ProjectRootDir)
+		gitMounts, err := buildWorktreeGitMounts(cfg.ProjectRootDir)
 		if err != nil {
 			return nil, err
 		}
-		mounts = append(mounts, *gitMount)
+		mounts = append(mounts, gitMounts...)
 		cfg.Log.Debug().
-			Str("gitdir", gitMount.Source).
-			Msg("mounting main repo .git for worktree")
+			Str("gitdir", gitMounts[0].Source).
+			Msg("mounting main repo .git for worktree (hooks and config masked read-only)")
 	}
 
 	// Ensure config volumes (returns creation state for init orchestration)
@@ -220,11 +220,27 @@ func SetupMounts(ctx context.Context, client *docker.Client, cfg SetupMountsConf
 	}, nil
 }
 
-// buildWorktreeGitMount creates a bind mount for the main repository's .git directory.
-// This is needed for worktree support because worktrees use a .git file that references
-// the main repo's .git directory. By mounting at the same absolute path, git commands
-// work correctly inside the container.
-func buildWorktreeGitMount(projectRootDir string) (*mount.Mount, error) {
+// buildWorktreeGitMounts creates the bind mounts for the main repository's
+// .git directory required by a worktree workspace.
+//
+// The .git directory itself is mounted read-write at its original absolute
+// path (Source == Target) so the paths git recorded in the worktree's .git
+// file resolve, and so git inside the worktree can write objects, refs, and
+// its .git/worktrees/<name>/ metadata.
+//
+// .git/hooks and .git/config are masked with read-only binds stacked over the
+// RW mount: both are host-code-execution vectors — a hook planted from the
+// container, or config keys like core.hooksPath, core.fsmonitor, or
+// filter.*.smudge, execute on the HOST the next time the host user runs git
+// in the main checkout. Worktree mode promises more isolation than bind mode;
+// leaving these writable would silently grant bind-equivalent access to the
+// whole repo. Nothing in clawker's in-container flows writes either path
+// (in-container git config is --global only; the GPG override is env-based
+// for exactly this reason). The known in-worktree casualties are loud, not
+// silent: `git config --local`, `git remote add`, and `git push -u` fail on
+// the read-only config (upstream tracking is already configured host-side at
+// worktree creation, so plain `git push` works).
+func buildWorktreeGitMounts(projectRootDir string) ([]mount.Mount, error) {
 	// Resolve symlinks to match git's behavior. Git records absolute paths with
 	// symlinks resolved (e.g., on macOS /var -> /private/var). The mount target
 	// must match the path git wrote in the worktree's .git file.
@@ -246,10 +262,44 @@ func buildWorktreeGitMount(projectRootDir string) (*mount.Mount, error) {
 		return nil, fmt.Errorf(".git at %s is not a directory (expected main repository, got worktree)", gitDir)
 	}
 
-	return &mount.Mount{
-		Type:     mount.TypeBind,
-		Source:   gitDir,
-		Target:   gitDir, // Same absolute path preserves worktree references
-		ReadOnly: false,
+	// Ensure the protected paths exist on the host before binding them
+	// read-only. A missing source would fail the mount — and skipping the
+	// mount instead would let the agent create the path inside the RW .git
+	// region, reopening the vector.
+	hooksDir := filepath.Join(gitDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return nil, fmt.Errorf("cannot ensure .git/hooks at %s: %w", hooksDir, err)
+	}
+	configFile := filepath.Join(gitDir, "config")
+	cf, err := os.OpenFile(configFile, os.O_WRONLY|os.O_CREATE, 0o644) // no O_TRUNC: existing content untouched
+	if err != nil {
+		return nil, fmt.Errorf("cannot ensure .git/config at %s: %w", configFile, err)
+	}
+	if err := cf.Close(); err != nil {
+		return nil, fmt.Errorf("cannot ensure .git/config at %s: %w", configFile, err)
+	}
+
+	// Source == Target on all three: same absolute path preserves worktree
+	// references. Docker applies mounts ordered by destination depth, so the
+	// RO binds layer over the RW parent.
+	return []mount.Mount{
+		{
+			Type:     mount.TypeBind,
+			Source:   gitDir,
+			Target:   gitDir,
+			ReadOnly: false,
+		},
+		{
+			Type:     mount.TypeBind,
+			Source:   configFile,
+			Target:   configFile,
+			ReadOnly: true,
+		},
+		{
+			Type:     mount.TypeBind,
+			Source:   hooksDir,
+			Target:   hooksDir,
+			ReadOnly: true,
+		},
 	}, nil
 }

--- a/internal/workspace/setup.go
+++ b/internal/workspace/setup.go
@@ -270,13 +270,30 @@ func buildWorktreeGitMounts(projectRootDir string) ([]mount.Mount, error) {
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		return nil, fmt.Errorf("cannot ensure .git/hooks at %s: %w", hooksDir, err)
 	}
+	// Only create .git/config when missing — an existing config may
+	// legitimately be read-only, and it only needs to EXIST as the RO bind
+	// source below; opening it for write would fail EACCES for no reason.
 	configFile := filepath.Join(gitDir, "config")
-	cf, err := os.OpenFile(configFile, os.O_WRONLY|os.O_CREATE, 0o644) // no O_TRUNC: existing content untouched
-	if err != nil {
-		return nil, fmt.Errorf("cannot ensure .git/config at %s: %w", configFile, err)
-	}
-	if err := cf.Close(); err != nil {
-		return nil, fmt.Errorf("cannot ensure .git/config at %s: %w", configFile, err)
+	switch info, err := os.Lstat(configFile); {
+	case err == nil:
+		// Exists. Reject a symlink or directory — the RO bind expects a
+		// regular file, and a symlink here is a host-redirect vector.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf(".git/config at %s is a symlink (refusing to bind a redirected config)", configFile)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf(".git/config at %s is a directory, expected a file", configFile)
+		}
+	case os.IsNotExist(err):
+		cf, cerr := os.OpenFile(configFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if cerr != nil {
+			return nil, fmt.Errorf("cannot create .git/config at %s: %w", configFile, cerr)
+		}
+		if cerr := cf.Close(); cerr != nil {
+			return nil, fmt.Errorf("cannot finalize .git/config at %s: %w", configFile, cerr)
+		}
+	default:
+		return nil, fmt.Errorf("cannot access .git/config at %s: %w", configFile, err)
 	}
 
 	// Source == Target on all three: same absolute path preserves worktree

--- a/internal/workspace/setup_test.go
+++ b/internal/workspace/setup_test.go
@@ -12,41 +12,131 @@ import (
 	"github.com/schmitthub/clawker/internal/logger"
 )
 
-func TestBuildWorktreeGitMount_Success(t *testing.T) {
+// findMountByTarget returns the mount with the given target, or nil.
+func findMountByTarget(mounts []mount.Mount, target string) *mount.Mount {
+	for i := range mounts {
+		if mounts[i].Target == target {
+			return &mounts[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildWorktreeGitMounts_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitDir := filepath.Join(tmpDir, ".git")
 	if err := os.Mkdir(gitDir, 0755); err != nil {
 		t.Fatalf("failed to create .git directory: %v", err)
 	}
 
-	m, err := buildWorktreeGitMount(tmpDir)
+	mounts, err := buildWorktreeGitMounts(tmpDir)
 	if err != nil {
-		t.Fatalf("buildWorktreeGitMount() error = %v, want nil", err)
+		t.Fatalf("buildWorktreeGitMounts() error = %v, want nil", err)
 	}
 
 	resolvedTmpDir, _ := filepath.EvalSymlinks(tmpDir)
 	expectedGitDir := filepath.Join(resolvedTmpDir, ".git")
 
+	if len(mounts) != 3 {
+		t.Fatalf("len(mounts) = %d, want 3 (.git RW + config RO + hooks RO)", len(mounts))
+	}
+
+	m := findMountByTarget(mounts, expectedGitDir)
+	if m == nil {
+		t.Fatalf("no mount with target %q", expectedGitDir)
+	}
 	if m.Type != mount.TypeBind {
 		t.Errorf("mount.Type = %v, want %v", m.Type, mount.TypeBind)
 	}
 	if m.Source != expectedGitDir {
-		t.Errorf("mount.Source = %q, want %q", m.Source, expectedGitDir)
-	}
-	if m.Target != expectedGitDir {
-		t.Errorf("mount.Target = %q, want %q (should match Source)", m.Target, expectedGitDir)
+		t.Errorf("mount.Source = %q, want %q (should match Target)", m.Source, expectedGitDir)
 	}
 	if m.ReadOnly {
-		t.Error("mount.ReadOnly = true, want false")
+		t.Error(".git mount.ReadOnly = true, want false (worktree git ops need RW objects/refs)")
+	}
+
+	// Missing hooks/ and config must be created host-side so the RO binds
+	// always have a source — skipping the mount instead would let the agent
+	// create them inside the RW .git region, reopening the host-exec vector.
+	hooksInfo, err := os.Stat(filepath.Join(gitDir, "hooks"))
+	if err != nil || !hooksInfo.IsDir() {
+		t.Errorf(".git/hooks not created as directory (info=%v, err=%v)", hooksInfo, err)
+	}
+	configInfo, err := os.Stat(filepath.Join(gitDir, "config"))
+	if err != nil || configInfo.IsDir() {
+		t.Errorf(".git/config not created as file (info=%v, err=%v)", configInfo, err)
 	}
 }
 
-func TestBuildWorktreeGitMount_ProjectRootNotExist(t *testing.T) {
+func TestBuildWorktreeGitMounts_ProtectsHooksAndConfig(t *testing.T) {
+	// The main .git is mounted RW, but .git/hooks and .git/config are
+	// host-exec vectors (planted hooks / core.hooksPath / fsmonitor run on
+	// the HOST's next git op). They must be masked by read-only binds.
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "hooks"), 0755); err != nil {
+		t.Fatalf("failed to create .git/hooks: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte("[core]\n"), 0644); err != nil {
+		t.Fatalf("failed to create .git/config: %v", err)
+	}
+
+	mounts, err := buildWorktreeGitMounts(tmpDir)
+	if err != nil {
+		t.Fatalf("buildWorktreeGitMounts() error = %v, want nil", err)
+	}
+
+	resolvedTmpDir, _ := filepath.EvalSymlinks(tmpDir)
+	expectedGitDir := filepath.Join(resolvedTmpDir, ".git")
+
+	for _, sub := range []string{"config", "hooks"} {
+		target := filepath.Join(expectedGitDir, sub)
+		m := findMountByTarget(mounts, target)
+		if m == nil {
+			t.Fatalf("no mount with target %q", target)
+		}
+		if m.Type != mount.TypeBind {
+			t.Errorf("%s mount.Type = %v, want %v", sub, m.Type, mount.TypeBind)
+		}
+		if m.Source != target {
+			t.Errorf("%s mount.Source = %q, want %q (Source must equal Target)", sub, m.Source, target)
+		}
+		if !m.ReadOnly {
+			t.Errorf("%s mount.ReadOnly = false, want true (host-exec vector must be masked)", sub)
+		}
+	}
+}
+
+func TestBuildWorktreeGitMounts_PreservesExistingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatalf("failed to create .git directory: %v", err)
+	}
+	content := []byte("[remote \"origin\"]\n\turl = https://example.com/repo.git\n")
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), content, 0644); err != nil {
+		t.Fatalf("failed to write .git/config: %v", err)
+	}
+
+	if _, err := buildWorktreeGitMounts(tmpDir); err != nil {
+		t.Fatalf("buildWorktreeGitMounts() error = %v, want nil", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(gitDir, "config"))
+	if err != nil {
+		t.Fatalf("failed to read .git/config: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf(".git/config content changed: got %q, want %q", got, content)
+	}
+}
+
+func TestBuildWorktreeGitMounts_ProjectRootNotExist(t *testing.T) {
 	nonExistentDir := filepath.Join(t.TempDir(), "does-not-exist")
 
-	_, err := buildWorktreeGitMount(nonExistentDir)
+	_, err := buildWorktreeGitMounts(nonExistentDir)
 	if err == nil {
-		t.Fatal("buildWorktreeGitMount() error = nil, want error about non-existent directory")
+		t.Fatal("buildWorktreeGitMounts() error = nil, want error about non-existent directory")
 	}
 
 	if !containsAll(err.Error(), "failed to resolve symlinks for project root", nonExistentDir) {
@@ -54,12 +144,12 @@ func TestBuildWorktreeGitMount_ProjectRootNotExist(t *testing.T) {
 	}
 }
 
-func TestBuildWorktreeGitMount_GitDirNotExist(t *testing.T) {
+func TestBuildWorktreeGitMounts_GitDirNotExist(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	_, err := buildWorktreeGitMount(tmpDir)
+	_, err := buildWorktreeGitMounts(tmpDir)
 	if err == nil {
-		t.Fatal("buildWorktreeGitMount() error = nil, want error about missing .git")
+		t.Fatal("buildWorktreeGitMounts() error = nil, want error about missing .git")
 	}
 
 	if !containsAll(err.Error(), ".git not found", "required for worktree support") {
@@ -67,16 +157,16 @@ func TestBuildWorktreeGitMount_GitDirNotExist(t *testing.T) {
 	}
 }
 
-func TestBuildWorktreeGitMount_GitIsFile(t *testing.T) {
+func TestBuildWorktreeGitMounts_GitIsFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	gitFile := filepath.Join(tmpDir, ".git")
 	if err := os.WriteFile(gitFile, []byte("gitdir: /some/path/.git/worktrees/foo\n"), 0644); err != nil {
 		t.Fatalf("failed to create .git file: %v", err)
 	}
 
-	_, err := buildWorktreeGitMount(tmpDir)
+	_, err := buildWorktreeGitMounts(tmpDir)
 	if err == nil {
-		t.Fatal("buildWorktreeGitMount() error = nil, want error about .git not being a directory")
+		t.Fatal("buildWorktreeGitMounts() error = nil, want error about .git not being a directory")
 	}
 
 	if !containsAll(err.Error(), "not a directory", "expected main repository, got worktree") {
@@ -84,7 +174,7 @@ func TestBuildWorktreeGitMount_GitIsFile(t *testing.T) {
 	}
 }
 
-func TestBuildWorktreeGitMount_SymlinkResolution(t *testing.T) {
+func TestBuildWorktreeGitMounts_SymlinkResolution(t *testing.T) {
 	tmpDir := t.TempDir()
 	mainRepoDir := filepath.Join(tmpDir, "main-repo")
 	if err := os.Mkdir(mainRepoDir, 0755); err != nil {
@@ -100,19 +190,20 @@ func TestBuildWorktreeGitMount_SymlinkResolution(t *testing.T) {
 		t.Fatalf("failed to create symlink: %v", err)
 	}
 
-	m, err := buildWorktreeGitMount(symlinkDir)
+	mounts, err := buildWorktreeGitMounts(symlinkDir)
 	if err != nil {
-		t.Fatalf("buildWorktreeGitMount() error = %v, want nil", err)
+		t.Fatalf("buildWorktreeGitMounts() error = %v, want nil", err)
 	}
 
 	resolvedMainRepoDir, _ := filepath.EvalSymlinks(mainRepoDir)
 	expectedGitDir := filepath.Join(resolvedMainRepoDir, ".git")
 
+	m := findMountByTarget(mounts, expectedGitDir)
+	if m == nil {
+		t.Fatalf("no mount with target %q (should be resolved path, not symlink)", expectedGitDir)
+	}
 	if m.Source != expectedGitDir {
 		t.Errorf("mount.Source = %q, want %q (should be resolved path, not symlink)", m.Source, expectedGitDir)
-	}
-	if m.Target != expectedGitDir {
-		t.Errorf("mount.Target = %q, want %q (should match resolved Source)", m.Target, expectedGitDir)
 	}
 }
 

--- a/internal/workspace/setup_test.go
+++ b/internal/workspace/setup_test.go
@@ -131,6 +131,50 @@ func TestBuildWorktreeGitMounts_PreservesExistingConfig(t *testing.T) {
 	}
 }
 
+func TestBuildWorktreeGitMounts_ReadOnlyConfigPreserved(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatalf("failed to create .git directory: %v", err)
+	}
+	content := []byte("[core]\n\trepositoryformatversion = 0\n")
+	cfgPath := filepath.Join(gitDir, "config")
+	if err := os.WriteFile(cfgPath, content, 0444); err != nil {
+		t.Fatalf("failed to write read-only .git/config: %v", err)
+	}
+
+	if _, err := buildWorktreeGitMounts(tmpDir); err != nil {
+		t.Fatalf("buildWorktreeGitMounts() error = %v, want nil on read-only config", err)
+	}
+
+	got, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("failed to read .git/config: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf(".git/config content changed: got %q, want %q", got, content)
+	}
+}
+
+func TestBuildWorktreeGitMounts_ConfigIsSymlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitDir := filepath.Join(tmpDir, ".git")
+	if err := os.Mkdir(gitDir, 0755); err != nil {
+		t.Fatalf("failed to create .git directory: %v", err)
+	}
+	target := filepath.Join(tmpDir, "elsewhere-config")
+	if err := os.WriteFile(target, []byte("[core]\n"), 0644); err != nil {
+		t.Fatalf("failed to write symlink target: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(gitDir, "config")); err != nil {
+		t.Fatalf("failed to create .git/config symlink: %v", err)
+	}
+
+	if _, err := buildWorktreeGitMounts(tmpDir); err == nil {
+		t.Fatal("buildWorktreeGitMounts() error = nil, want error on symlinked .git/config")
+	}
+}
+
 func TestBuildWorktreeGitMounts_ProjectRootNotExist(t *testing.T) {
 	nonExistentDir := filepath.Join(t.TempDir(), "does-not-exist")
 

--- a/test/e2e/worktree_git_protection_test.go
+++ b/test/e2e/worktree_git_protection_test.go
@@ -1,0 +1,135 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/schmitthub/clawker/internal/config"
+	"github.com/schmitthub/clawker/internal/controlplane/cpboot"
+	"github.com/schmitthub/clawker/internal/docker"
+	"github.com/schmitthub/clawker/internal/logger"
+	"github.com/schmitthub/clawker/internal/project"
+	"github.com/schmitthub/clawker/internal/testenv"
+	"github.com/schmitthub/clawker/test/e2e/harness"
+)
+
+// gitInDir runs the host git binary in dir as test fixture setup (creating
+// the repo a worktree container hangs off). Clawker behavior under test is
+// still exercised exclusively through h.Run.
+func gitInDir(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, out)
+}
+
+// TestWorktreeGitProtection_E2E pins the worktree container .git contract:
+// the main repo's .git is mounted RW at its host absolute path so worktree
+// git ops work, but .git/hooks and .git/config are masked read-only (both
+// are host-code-execution vectors — a hook or core.hooksPath/fsmonitor
+// planted from the container would run on the host's next git op in the
+// main checkout), and GOFLAGS=-buildvcs=false is set (Go's VCS walk skips
+// the worktree's .git file, lands on the mounted main .git, and fails or
+// stamps the wrong revision).
+func TestWorktreeGitProtection_E2E(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary required for worktree fixture setup")
+	}
+
+	h := &harness.Harness{
+		T: t,
+		Opts: &harness.FactoryOptions{
+			Config:         config.NewConfig,
+			Client:         docker.NewClient,
+			ProjectManager: project.NewProjectManager,
+			ControlPlane: func(cfg config.Config, log *logger.Logger) cpboot.Manager {
+				return cpboot.NewManager(
+					func(ctx context.Context) (*docker.Client, error) {
+						return docker.NewClient(ctx, cfg, log)
+					},
+					func() (config.Config, error) { return cfg, nil },
+					func() (*logger.Logger, error) { return log, nil },
+				)
+			},
+			UseRealAdminClient: true,
+		},
+	}
+	setup := h.NewIsolatedFS(&harness.FSOptions{ProjectDir: "wt-protect"})
+
+	// The project root must be a real git repo with a commit for worktree
+	// creation to have something to branch from.
+	gitInDir(t, setup.ProjectDir, "init", "-b", "main")
+	gitInDir(t, setup.ProjectDir, "config", "user.email", "e2e@clawker.test")
+	gitInDir(t, setup.ProjectDir, "config", "user.name", "clawker e2e")
+	require.NoError(t, os.WriteFile(filepath.Join(setup.ProjectDir, "README.md"), []byte("worktree e2e\n"), 0o644))
+	gitInDir(t, setup.ProjectDir, "add", "README.md")
+	gitInDir(t, setup.ProjectDir, "commit", "-m", "init")
+
+	initRes := h.Run("project", "init", "wt-protect", "--yes", "--preset", "Bare")
+	require.NoError(t, initRes.Err, "init failed\nstdout: %s\nstderr: %s",
+		initRes.Stdout, initRes.Stderr)
+
+	// use_host_auth: false because the test env has no Claude credentials.
+	setup.WriteYAML(t, testenv.ProjectConfigLocal, setup.ProjectDir, `
+agent:
+  claude_code:
+    use_host_auth: false
+`)
+
+	buildRes := h.Run("build", "--progress=none")
+	require.NoError(t, buildRes.Err, "build failed\nstdout: %s\nstderr: %s",
+		buildRes.Stdout, buildRes.Stderr)
+
+	runRes := h.Run("container", "run", "--detach", "--agent", "wtprobe",
+		"--worktree", "e2e/probe", "@", "sleep", "infinity")
+	require.NoError(t, runRes.Err, "container run --worktree failed\nstdout: %s\nstderr: %s",
+		runRes.Stdout, runRes.Stderr)
+	t.Cleanup(func() {
+		if res := h.Run("container", "stop", "--agent", "wtprobe"); res.Err != nil {
+			t.Logf("cleanup: container stop failed: %v\nstdout: %s\nstderr: %s",
+				res.Err, res.Stdout, res.Stderr)
+		}
+	})
+
+	// Go VCS stamping is disabled by default; user env can override.
+	goflagsRes := h.ExecInContainer("wtprobe", "sh", "-c", `printf %s "$GOFLAGS"`)
+	require.NoError(t, goflagsRes.Err, "GOFLAGS probe failed\nstdout: %s\nstderr: %s",
+		goflagsRes.Stdout, goflagsRes.Stderr)
+	assert.Contains(t, goflagsRes.Stdout, "-buildvcs=false",
+		"worktree containers must default GOFLAGS=-buildvcs=false")
+
+	// Everyday worktree git ops must work against the RW .git mount.
+	gitOpsRes := h.ExecInContainer("wtprobe", "sh", "-c",
+		"git status --porcelain && git -c user.email=e2e@clawker.test -c user.name=e2e commit --allow-empty -m e2e-probe")
+	require.NoError(t, gitOpsRes.Err, "worktree git status/commit must work\nstdout: %s\nstderr: %s",
+		gitOpsRes.Stdout, gitOpsRes.Stderr)
+
+	// Host-exec vector 1: planting a hook in the main repo's .git must fail.
+	hookRes := h.ExecInContainer("wtprobe", "sh", "-c",
+		`touch "$(git rev-parse --git-common-dir)/hooks/e2e-planted-hook"`)
+	assert.Error(t, hookRes.Err,
+		"writing to main .git/hooks must fail (read-only mask)\nstdout: %s\nstderr: %s",
+		hookRes.Stdout, hookRes.Stderr)
+
+	// Host-exec vector 2: writing the shared .git/config must fail. From a
+	// worktree, `git config --local` targets the MAIN repo's config file.
+	configRes := h.ExecInContainer("wtprobe", "sh", "-c", "git config --local clawker.e2eprobe 1")
+	assert.Error(t, configRes.Err,
+		"git config --local must fail (main .git/config is read-only)\nstdout: %s\nstderr: %s",
+		configRes.Stdout, configRes.Stderr)
+
+	// Nothing leaked onto the host side of the mounts.
+	hostHook := filepath.Join(setup.ProjectDir, ".git", "hooks", "e2e-planted-hook")
+	_, statErr := os.Stat(hostHook)
+	assert.True(t, os.IsNotExist(statErr), "planted hook must not exist on host at %s", hostHook)
+	hostConfig, err := os.ReadFile(filepath.Join(setup.ProjectDir, ".git", "config"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(hostConfig), "e2eprobe", "probe key must not land in host .git/config")
+}


### PR DESCRIPTION
## Summary

Two worktree-mode fixes for how containers interact with the main repo's `.git`:

### 1. Protect main `.git` and fix Go builds in worktree containers (#361)

Worktree containers bind-mount the main repo's `.git` read-write at its host absolute path. Two problems:

- **Host code-execution vector**: `.git/hooks` and `.git/config` were writable from the container — a planted hook or config key (`core.hooksPath`, `core.fsmonitor`, `filter.*`) would execute on the host the next time the host user ran git in the main checkout, silently promoting worktree mode to bind-equivalent access. Now masked with read-only binds stacked over the RW `.git` mount; missing hooks/config are created host-side first so the RO bind always has a source. In-worktree casualties (`git config --local`, `git remote add`, `git push -u`) fail loudly, not silently — upstream tracking is already configured host-side at creation.
- **`go build` failure** ("error obtaining VCS status: exit status 128"): Go's VCS walk skips the worktree's `.git` file and lands on the mounted main `.git`, where git trips the dubious-ownership check on the root-owned mount scaffold. Stamping can never be correct in this topology, so worktree containers now set `GOFLAGS=-buildvcs=false` (agent.env overrides win), and the Makefile appends to inherited `GOFLAGS` instead of clobbering.

Deliberately NOT fixed via `safe.directory` or chowning the scaffold: making git operational at the half-materialized main-repo path would let a stray `git add -A` stage mass deletions into the host's real index — the dubious-ownership failure there is a useful guardrail.

### 2. Refuse a worktree on a branch already checked out elsewhere

Native `git worktree add` refuses to check out a branch already checked out in another worktree (including the main repo); go-git's experimental worktree support doesn't enforce this, and `SetupWorktree` never added it. Result: `clawker run --worktree X` while the root was on `X` silently created a second checkout — a later commit in the worktree dragged the root's HEAD onto content it never materialized, leaving the root looking "modified".

`SetupWorktree`'s existing-branch arm now scans the root checkout and each linked worktree for the requested branch and returns `ErrBranchAlreadyCheckedOut` with the conflicting path; the command layer maps it to an actionable hint. The guard only runs on fresh creation — idempotent reuse of an established worktree is unaffected, and new branches can't collide.

## Test plan

- [x] Unit tests for the RO mask mounts, GOFLAGS injection, and the double-checkout guard (`internal/workspace`, `internal/git`, `internal/docker`)
- [x] E2E `TestWorktreeGitProtection_E2E` pins the contract: RW git ops work, RO masks hold, GOFLAGS set, nothing leaks host-side
- [x] Two pre-existing tests that encoded the double-checkout bug corrected/removed

Fixes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)