### PR TITLE
fix(keyring): inject Claude Code credential blob verbatim, never re-marshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ When I began experimenting with Claude Code to keep up with the Agentic AI trend
 - **Jailed from host Docker resources** via `pkg/whail` (whale jail), a standalone package that decorates the moby SDK to prevent callers from seeing resources without the automatically applied management labels. I might use this package in other "agent in container" solutions. So I don't have to worry about accidentally deleting non-clawker managed containers/volumes/images, etc.
 - **Command aliases** — one-word shortcuts expanded to full clawker invocations with `$1..$N` positional placeholders. Ships with `go` (disposable agent: `clawker go dev`) and `wt` (agent on a fresh worktree: `clawker wt auth feature/auth:main`) out of the box; define your own with `clawker alias set` and commit them to the project config with `clawker alias export` so the whole team gets them
 - **Docker CLI-esque commands** for managing containers, Clawker isn't a passthrough to Docker CLI; it uses the moby SDK (via `pkg/whail`). This allowed me to add more flags, modify the behavior, etc over what docker cli offers
-- **Git worktree management and commands**: pass a worktree flag to container run or create commands to automatically create a git worktree in the Clawker home project directory and bind mount it to the container workdir. Also has cli commands and flags to list and manage worktrees created by clawker, uses `go-git` under the hood to avoid relying on the host git binary
+- **Git worktree management and commands**: pass a worktree flag to container run or create commands to automatically create a git worktree in the Clawker home project directory and bind mount it to the container workdir. Also has cli commands and flags to list and manage worktrees created by clawker, uses `go-git` under the hood to avoid relying on the host git binary. Worktree containers ship extra security lockdown for unattended sessions — see [worktree caveats](https://docs.clawker.dev/worktrees#worktree-caveats)
 - **Optional monitoring stack** — OTel Collector + OpenSearch (logs) + OpenSearch Dashboards + Prometheus (metrics) on `clawker-net`. Every container has the environment variables baked in to push OTLP telemetry when the stack is running, and is silenced when it isn't
 - **Interactive configuration editing**: TUI-based editors for project config (`clawker project edit`) and user settings (`clawker settings edit`) with tabbed field browsing, per-field type-appropriate editors (text, boolean, list, multiline), layer-aware provenance display showing which file each value comes from, and per-field save targeting to choose which config layer to write to
 
@@ -190,6 +190,8 @@ clawker wt dev hotfix/example:main
 ```
 
 This creates and attaches my terminal to a new claude instance isolated in a container environment with a git worktree dir created under `~/.local/share/clawker/worktrees/` (or honors the override `$CLAWKER_DATA_DIR`) off of my main branch. Since it has all my plugins, skills, auth tokens, git creds, mcps installed, build deps instantly, it's just a matter of telling the little rascal what to do and letting it go bananas and create a pr about it. I'll periodically check in on it to see how it's doing in another tab. Or you can detach `ctrl p+q` and return to your terminal; to reattach to the same session use `clawker attach --agent dev`. Ez pz no ssh/tmux bullshit, no vscode devcontainer window, no VPS with heavy IO latency, or setting up dedicated servers, or having to pay someone to do it for you.  
+
+> Worktree containers mask `.git/hooks` and `.git/config` read-only — a security measure that keeps unattended agents from planting host-executable git hooks/config. It changes a few git behaviors inside the container (notably `git push -u` won't persist upstream tracking). Read the [worktree caveats](https://docs.clawker.dev/worktrees#worktree-caveats) before your first session.
 
 I can see my worktree paths and open them in an IDE if I want to do some manual work or review the code... or never care about where they are, `clawker` remembers and auto mounts them using branches as an identifier. You can use `clawker worktree` commands to manage them, or `git worktree`. 
 
@@ -319,7 +321,7 @@ Aliases defined in a repository's project config apply automatically to everyone
 
 ## Working with Worktrees
 
-Run separate agents per git worktree for parallel development:
+Run separate agents per git worktree for parallel development. Worktree containers apply extra security lockdown (read-only `.git/hooks` + `.git/config` masks) to make unattended sessions safer — see [worktree caveats](https://docs.clawker.dev/worktrees#worktree-caveats) for the behavioral differences:
 
 ```bash
 # Use the --worktree flag for automatic worktree creation and mounting in containers

--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "author": {
     "name": "schmitthub"
   },

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
@@ -37,6 +37,48 @@ recreate). Do **not** suggest `git config --global --add safe.directory` for
 the main repo path — git at that path sees the whole tree as deleted, and a
 `git add -A` there would stage mass deletions into the host's real index.
 
+## Empty refreshToken / forced /login in older containers
+
+Containers created with an older clawker release injected a host keychain
+credential blob that was round-tripped through a typed struct, fabricating a
+zero-value `organizationUuid` (`00000000-...`) the user is not a member of.
+Claude Code's token refresh endpoint rejects that claim, and Claude Code is
+known to **wipe its stored credential with empty data when a refresh fails**
+(upstream anthropics/claude-code behavior) — the user sees an empty
+`refreshToken` in `~/.claude/.credentials.json` and a forced `/login` at boot.
+
+Current releases inject the credential blob byte-for-byte (no re-marshal), so
+new containers are unaffected. The poisoned blob persists in existing config
+volumes, though.
+
+Fix: upgrade clawker, then **recreate the container** (credentials are
+re-injected from the host at container create) — or run `/login` once inside
+the existing container. Re-authenticating on the host fixes only future
+containers, not existing volumes.
+
+## git push -u / upstream tracking in worktree containers
+
+Worktree containers mask the main repo's `.git/hooks/` and `.git/config` with
+read-only binds. This is a deliberate security measure (always on): anything
+written to those paths from inside the container would execute on the *host*
+the next time the user runs git in the main checkout. See
+`https://docs.clawker.dev/worktrees#worktree-caveats`.
+
+Consequences inside the container: `git config --local` and `git remote add`
+fail loudly; `git push -u` **pushes successfully but fails to persist upstream
+tracking** (easy-to-miss warning — upstream config lives in the read-only
+shared `.git/config`).
+
+Symptom after the session: the user removes the worktree, checks the branch
+out in the repo root, and plain `git push` reports no upstream — even though
+the branch was pushed and has an open PR. Tracking was never persisted.
+
+Fix: one-time on the host: `git push -u origin <branch>` (or
+`git branch --set-upstream-to=origin/<branch>`). Inside the container, push
+with an explicit refspec: `git push origin HEAD`. Branches that already
+existed on the remote at worktree creation get tracking configured host-side
+automatically and are unaffected.
+
 ## --worktree on a branch already checked out
 
 `clawker run --worktree <branch>` for a branch that is already checked out in

--- a/docs/aliases.mdx
+++ b/docs/aliases.mdx
@@ -22,7 +22,7 @@ Clawker ships two aliases out of the box:
 | Alias | Expansion | What it does |
 |-------|-----------|--------------|
 | `go` | `run --rm -it --agent $1 @ --dangerously-skip-permissions` | Launch a disposable interactive agent: `clawker go dev` |
-| `wt` | `run --rm -it --agent $1 --worktree $2 @ --dangerously-skip-permissions` | Launch an agent on a fresh [worktree](/worktrees) — `$2` is a `branch[:base]` spec: `clawker wt auth feature/auth:main` |
+| `wt` | `run --rm -it --agent $1 --worktree $2 @ --dangerously-skip-permissions` | Launch an agent on a fresh [worktree](/worktrees) ([caveats](/worktrees#worktree-caveats)) — `$2` is a `branch[:base]` spec: `clawker wt auth feature/auth:main` |
 
 Defaults are always active — no setup required. They can be overridden (see [Deleting and Overriding](#deleting-and-overriding)) but never deleted.
 

--- a/docs/cli-reference/clawker_worktree.md
+++ b/docs/cli-reference/clawker_worktree.md
@@ -16,6 +16,10 @@ separate checkout of the repository at a specific branch.
 
 Worktrees are created automatically when using 'clawker run --worktree `<branch>`'.
 
+Worktree containers mask the main repo's .git/hooks and .git/config read-only
+(security measure for unattended sessions); 'git config --local', 'git remote add',
+and 'git push -u' fail inside them. See https://docs.clawker.dev/worktrees#worktree-caveats
+
 ### Examples
 
 ```

--- a/docs/container-internals.mdx
+++ b/docs/container-internals.mdx
@@ -62,6 +62,10 @@ For a normal (non-worktree) project, the `.git` directory is part of your worksp
 
 ### Worktree Support
 
+<Note>
+Worktree containers mask `.git/hooks` and `.git/config` read-only as a security measure for unattended sessions. See [Worktree Caveats](/worktrees#worktree-caveats) for the behavioral consequences (`git config --local`, `git remote add`, `git push -u`).
+</Note>
+
 Git worktrees are more complex. A worktree is a separate checkout of your repository that shares the same `.git` metadata as the main repo. The worktree directory contains a `.git` **file** (not a directory) that points back to the main repository's `.git/worktrees/<name>/` metadata.
 
 The challenge: those `.git` file references use **absolute host paths**. If the main repo is at `/Users/schmitthub/Code/myapp`, the worktree's `.git` file says something like:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -42,7 +42,7 @@ clawker run -it --agent review @  # Start a "review" agent in parallel
 - **Bind or snapshot workspaces** -- Mount your repo for live editing, or copy it for pure isolation
 - **Embedded Dockerfile template** -- Parameterized images with common dev tools preinstalled, supporting Alpine or Debian bases
 - **Project-scoped namespacing** -- Multi-agent, multi-project isolation via Docker labels and naming conventions
-- **Git worktree integration** -- Spin up agents on separate branches with automatic worktree management
+- **Git worktree integration** -- Spin up agents on separate branches with automatic worktree management and hardened unattended-session lockdown. See [Worktree Caveats](/worktrees#worktree-caveats).
 - **Command aliases** -- One-word shortcuts that expand to full invocations (`clawker go dev`), shareable with your team via project config. See [Command Aliases](/aliases).
 - **Monitoring stack** -- Optional OpenTelemetry Collector + OpenSearch + OpenSearch Dashboards + Prometheus for agent observability
 - **Per-decision egress observability** -- eBPF event stream (`allowed` / `denied` / `bypassed`) flows to OpenSearch alongside Envoy and CoreDNS access logs, so bypass windows leave a full audit trail. See [Egress Observability](/observability).

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -130,6 +130,10 @@ clawker run -it --rm --agent cache --worktree feature/cache:main @ --dangerously
 
 The `--worktree branch:base` flag creates a Git worktree off the base branch and mounts it into the container. Each agent works on its own branch with no conflicts.
 
+<Note>
+Worktree containers apply extra security lockdown for unattended sessions — `.git/hooks` and `.git/config` are masked read-only, which changes a few git behaviors (notably `git push -u`). See [Worktree Caveats](/worktrees#worktree-caveats) before your first worktree session.
+</Note>
+
 The shipped `wt` [alias](/aliases) collapses each of those commands to three words:
 
 ```bash

--- a/docs/worktrees.mdx
+++ b/docs/worktrees.mdx
@@ -16,6 +16,37 @@ Common patterns:
 - Test multiple approaches to the same problem in parallel
 - Keep the main branch clean while agents experiment on feature branches
 
+## Worktree Caveats
+
+Worktree containers are locked down harder than bind-mode containers, **by design**. They are built for unattended agent sessions (`--dangerously-skip-permissions`), and a worktree shares the main repository's `.git` directory with your host. Anything written to `.git/hooks/` or `.git/config` from inside the container — a planted hook, `core.hooksPath`, `core.fsmonitor`, a `filter.*` driver — would execute **on your host** the next time you run git in the main checkout. To close that vector, both paths are masked **read-only** inside worktree containers. This is a deliberate security measure, always on, and it changes some git behaviors you may take for granted:
+
+| Operation in a worktree container | Behavior |
+|---|---|
+| `git commit`, `git push`, `git fetch`, `git log`, `git status` | Work normally |
+| `git config --local` | Fails — config file is read-only |
+| `git remote add` | Fails — writes to the shared config |
+| `git push -u` / `--set-upstream` | **Push succeeds**, but the upstream tracking write fails (the warning is easy to miss) |
+
+### Upstream tracking
+
+Upstream tracking lives in the shared `.git/config`, which is read-only inside the container, so where tracking comes from depends on how the branch was born:
+
+- **Branch already existed on the remote** when the worktree was created (e.g. after `git fetch`): tracking is configured host-side at creation, and a plain `git push` works immediately inside the container.
+- **New branch created in the worktree** (the typical `--worktree feature/x:main` flow): no upstream exists, and it cannot be set from inside the container. Push with an explicit refspec instead — `git push origin HEAD` — and PR creation (`gh pr create`) works fine.
+
+After you remove the worktree and check the branch out on the host, a plain `git push` will report there is no upstream — even though the branch was pushed and has an open PR. Tracking was never persisted; set it once on the host:
+
+```bash
+git push -u origin <branch>     # or: git branch --set-upstream-to=origin/<branch>
+```
+
+### Other differences
+
+- **Go builds**: worktree containers set `GOFLAGS=-buildvcs=false` because Go's VCS stamping cannot work in a linked worktree. Override via `agent.env`. See [Go builds inside worktree containers](#go-builds-inside-worktree-containers).
+- **Branch-keyed, no detached HEAD**: clawker worktrees are identified by branch name; detached-HEAD worktrees are unsupported.
+
+The lockdown is currently not configurable — secure by default. A policy gate to relax it per project is planned.
+
 ## Creating Worktrees
 
 ```bash
@@ -213,7 +244,7 @@ The main `.git` mount is read-write (commits from the worktree write objects, re
 - `.git/hooks/` — a hook planted from inside the container would execute on the *host* the next time you run git in the main checkout.
 - `.git/config` — config keys like `core.hooksPath`, `core.fsmonitor`, or `filter.*` can execute arbitrary commands; from a worktree, `git config --local` writes to this shared file.
 
-This keeps worktree containers meaningfully more isolated than bind mode. The trade-off: `git config --local`, `git remote add`, and `git push -u` fail inside a worktree container (the config file is read-only). Upstream tracking is already configured on the host when the worktree is created, so a plain `git push` works without `-u`.
+This keeps worktree containers meaningfully more isolated than bind mode. The trade-off: `git config --local`, `git remote add`, and `git push -u` fail inside a worktree container (the config file is read-only). Upstream tracking is configured host-side at creation **only when the branch already existed on the remote**; branches born in the worktree have no upstream — push with `git push origin HEAD`. See [Worktree Caveats](#worktree-caveats) for the full behavioral rundown and the post-removal fix.
 
 ### Go builds inside worktree containers
 

--- a/internal/bundler/assets/clawker-agent-prompt.md
+++ b/internal/bundler/assets/clawker-agent-prompt.md
@@ -14,6 +14,7 @@ When starting a new conversation, lead with readiness to help on their project. 
 - The host user's Claude Code settings, plugins, and credentials were copied in at container creation (unless "fresh" mode was used)
 - Git SSH/GPG agent forwarding from the host is available via socket bridge (commit signing, private repos)
 - Browser authentication flows (e.g., `gh auth login`) are proxied back to the host browser automatically
+- If your workspace is a **git worktree**, the main repository's `.git/hooks/` and `.git/config` are masked read-only as a security measure (writes there would execute code on the host). Consequences: `git config --local`, `git remote add`, and `git push -u` fail — the push itself succeeds but upstream tracking is not persisted. Push with `git push origin HEAD`; tell the user to run `git push -u origin <branch>` once on the host if they need tracking later. Details: https://docs.clawker.dev/worktrees#worktree-caveats
 
 ## Egress Firewall
 
@@ -231,6 +232,7 @@ If `OTEL_*` variables are set, this container is reporting metrics and logs to a
 | `gh auth` hangs | Host proxy not reachable | Check `CLAWKER_HOST_PROXY` is set; user may need to restart host proxy |
 | Workspace changes not visible on host | Container is in `snapshot` mode | Changes only exist in the container; user chose ephemeral isolation |
 | Package install fails (network) | Package repo domain not whitelisted | User needs to `clawker firewall add` the repo domain |
+| `git push -u` / `git config --local` / `git remote add` fails in a worktree container | Read-only security masks on the shared main `.git` (hooks/config) | Expected behavior — push with `git push origin HEAD`; set tracking host-side later; see https://docs.clawker.dev/worktrees#worktree-caveats |
 
 ## Resources
 

--- a/internal/cmd/worktree/worktree.go
+++ b/internal/cmd/worktree/worktree.go
@@ -21,7 +21,11 @@ Worktrees allow running containers against different branches simultaneously
 without switching branches in your main repository. Each worktree is a
 separate checkout of the repository at a specific branch.
 
-Worktrees are created automatically when using 'clawker run --worktree <branch>'.`,
+Worktrees are created automatically when using 'clawker run --worktree <branch>'.
+
+Worktree containers mask the main repo's .git/hooks and .git/config read-only
+(security measure for unattended sessions); 'git config --local', 'git remote add',
+and 'git push -u' fail inside them. See https://docs.clawker.dev/worktrees#worktree-caveats`,
 		Example: `  # Create a worktree for a new branch
   clawker worktree add feat-42
 

--- a/internal/containerfs/CLAUDE.md
+++ b/internal/containerfs/CLAUDE.md
@@ -56,8 +56,8 @@ Each `Prepare*` function returns a temp directory with this layout:
 
 ## Credential Resolution Order
 
-1. OS keyring via `keyring.GetClaudeCodeCredentials()`
-2. File fallback: `<hostConfigDir>/.credentials.json`
+1. OS keyring via `keyring.GetClaudeCodeCredentialsRaw()` — blob written verbatim (no struct round-trip; see keyring CLAUDE.md "Typed vs Raw fetch")
+2. File fallback: `<hostConfigDir>/.credentials.json` — copied byte-for-byte
 3. Error with actionable message if neither source available
 
 ## Testing

--- a/internal/containerfs/containerfs.go
+++ b/internal/containerfs/containerfs.go
@@ -160,15 +160,14 @@ func PrepareCredentials(log *logger.Logger, hostConfigDir string) (stagingDir st
 
 	credsDst := filepath.Join(stagingClaudeDir, ".credentials.json")
 
-	// Try keyring first.
-	creds, keyringErr := keyring.GetClaudeCodeCredentials()
+	// Try keyring first. Write the blob verbatim — never round-trip through a
+	// typed struct, which would fabricate zero-value fields (e.g. a zero
+	// organizationUuid the user is not a member of, which the refresh endpoint
+	// rejects) and drop keys the struct does not model. This mirrors the
+	// byte-for-byte copy the file fallback below performs.
+	raw, keyringErr := keyring.GetClaudeCodeCredentialsRaw()
 	if keyringErr == nil {
-		data, err := json.Marshal(creds)
-		if err != nil {
-			cleanupFn()
-			return "", nil, fmt.Errorf("marshal keyring credentials: %w", err)
-		}
-		if err := os.WriteFile(credsDst, data, 0o600); err != nil {
+		if err := os.WriteFile(credsDst, []byte(raw), 0o600); err != nil {
 			cleanupFn()
 			return "", nil, fmt.Errorf("write credentials: %w", err)
 		}

--- a/internal/containerfs/containerfs_test.go
+++ b/internal/containerfs/containerfs_test.go
@@ -534,19 +534,12 @@ func TestPrepareCredentials_FromKeyring(t *testing.T) {
 		t.Fatalf("get current user: %v", err)
 	}
 
-	validJSON := `{
-		"claudeAiOauth": {
-			"accessToken":      "test-access",
-			"refreshToken":     "test-refresh",
-			"expiresAt":        4102444800000,
-			"scopes":           ["scope1"],
-			"subscriptionType": "pro",
-			"rateLimitTier":    "tier1"
-		},
-		"organizationUuid": "550e8400-e29b-41d4-a716-446655440000"
-	}`
+	// Host blob that omits organizationUuid and carries a key the keyring struct
+	// does not model. The staged file must be a byte-for-byte copy: no
+	// fabricated zero-value organizationUuid, no dropped unknown key.
+	hostBlob := `{"claudeAiOauth":{"accessToken":"test-access","refreshToken":"test-refresh"},"unknownKey":"keepme"}`
 
-	if err := keyring.Set("Claude Code-credentials", current.Username, validJSON); err != nil {
+	if err := keyring.Set("Claude Code-credentials", current.Username, hostBlob); err != nil {
 		t.Fatalf("seed keyring: %v", err)
 	}
 
@@ -564,13 +557,10 @@ func TestPrepareCredentials_FromKeyring(t *testing.T) {
 		t.Fatalf("read credentials: %v", err)
 	}
 
-	var creds map[string]any
-	if err := json.Unmarshal(data, &creds); err != nil {
-		t.Fatalf("unmarshal credentials: %v", err)
-	}
-
-	if _, ok := creds["claudeAiOauth"]; !ok {
-		t.Error("credentials should contain claudeAiOauth")
+	// Verbatim equality subsumes the no-fabrication guarantee: the host blob
+	// omits organizationUuid, so an equal staged file cannot have fabricated one.
+	if string(data) != hostBlob {
+		t.Errorf("keyring blob not copied verbatim:\n got %q\nwant %q", string(data), hostBlob)
 	}
 }
 

--- a/internal/keyring/CLAUDE.md
+++ b/internal/keyring/CLAUDE.md
@@ -11,8 +11,23 @@ Claude Code credentials for injection into agent containers when
 ```
 keyring.go       — Raw ops: Set, Get, Delete + ErrNotFound, TimeoutError, MockInit, MockInitWithError
 service.go       — Generic pipeline: ServiceDef[T], getCredential[T], sentinels, helpers
-claude_code.go   — ClaudeCodeCredentials types + GetClaudeCodeCredentials()
+claude_code.go   — ClaudeCodeCredentials types + GetClaudeCodeCredentials() / GetClaudeCodeCredentialsRaw()
 ```
+
+## Typed vs Raw fetch
+
+| Function | Pipeline | Use for |
+|----------|----------|---------|
+| `getCredential[T]` (typed, e.g. `GetClaudeCodeCredentials`) | fetch → empty-guard → parse → validate | Readers that need typed field access |
+| `getRawCredential[T]` (raw, e.g. `GetClaudeCodeCredentialsRaw`) | fetch → empty-guard | Injection paths that must preserve the blob byte-for-byte |
+
+> **Never round-trip a credential blob through its struct for injection.** The
+> Claude Code blob is plain JSON (not a JWT). Re-encoding a parsed struct
+> fabricates zero-value fields for keys the host omitted — a zero
+> `organizationUuid` claims an org the user is not a member of, which the
+> refresh endpoint rejects — and silently drops keys the struct does not model.
+> `containerfs.PrepareCredentials` uses the raw fetch and writes the blob
+> verbatim, matching its file-fallback path.
 
 ## Error Types
 

--- a/internal/keyring/claude_code.go
+++ b/internal/keyring/claude_code.go
@@ -34,6 +34,24 @@ var claudeCodeService = ServiceDef[ClaudeCodeCredentials]{
 
 // GetClaudeCodeCredentials fetches and parses the current user's Claude Code
 // credentials from the OS keychain.
+//
+// The parsed struct is lossy: keys the host omits surface as zero values and
+// keys absent from the struct are dropped. Readers that only need typed fields
+// can use it; injection paths must use GetClaudeCodeCredentialsRaw to preserve
+// the blob verbatim.
 func GetClaudeCodeCredentials() (*ClaudeCodeCredentials, error) {
 	return getCredential(claudeCodeService)
+}
+
+// GetClaudeCodeCredentialsRaw fetches the current user's Claude Code credential
+// blob from the OS keychain verbatim, without parsing or re-encoding.
+//
+// Claude Code stores this as a plain JSON object (not a JWT) and refreshes it in
+// place at runtime using the embedded refreshToken. The blob must be injected
+// byte-for-byte: round-tripping it through ClaudeCodeCredentials would fabricate
+// a zero-value organizationUuid for a host that omits the key (claiming an org
+// the user is not a member of, which the refresh endpoint rejects) and would
+// drop any field the struct does not model.
+func GetClaudeCodeCredentialsRaw() (string, error) {
+	return getRawCredential(claudeCodeService)
 }

--- a/internal/keyring/claude_code_test.go
+++ b/internal/keyring/claude_code_test.go
@@ -164,3 +164,56 @@ func TestGetClaudeCodeCredentials(t *testing.T) {
 		})
 	}
 }
+
+// TestGetClaudeCodeCredentialsRaw verifies the raw fetch returns the keyring
+// blob byte-for-byte: it must NOT round-trip through the typed struct, which
+// would fabricate a zero-value organizationUuid for a host that omits the key
+// and would drop any key absent from the struct.
+func TestGetClaudeCodeCredentialsRaw(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		doNotSeed bool
+		wantErr   error
+	}{
+		{
+			// Host omits organizationUuid and carries a key the struct does not
+			// model. Verbatim copy must preserve both exactly.
+			name: "omitted org and unknown key preserved verbatim",
+			raw:  `{"claudeAiOauth":{"accessToken":"access","refreshToken":"refresh"},"unknownKey":"keepme"}`,
+		},
+		{
+			name:      "not found",
+			doNotSeed: true,
+			wantErr:   ErrNotFound,
+		},
+		{
+			name:    "empty credential",
+			raw:     "",
+			wantErr: ErrEmptyCredential,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seedKeyring(t, tt.raw, tt.doNotSeed)
+
+			got, err := GetClaudeCodeCredentialsRaw()
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected error wrapping %v, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Byte-for-byte equality subsumes the no-fabrication guarantee: the
+			// fixture omits organizationUuid, so an equal blob cannot contain it.
+			if got != tt.raw {
+				t.Errorf("raw blob mutated:\n got %q\nwant %q", got, tt.raw)
+			}
+		})
+	}
+}

--- a/internal/keyring/service.go
+++ b/internal/keyring/service.go
@@ -76,6 +76,36 @@ func getCredential[T any](def ServiceDef[T]) (*T, error) {
 	return cred, nil
 }
 
+// getRawCredential is the fetch → empty-guard pipeline, returning the keyring
+// value verbatim (no Parse, no Validate, no marshal round-trip).
+//
+// Use this for injection paths that must preserve the stored blob byte-for-byte
+// — re-encoding a parsed struct fabricates zero-value fields for keys the host
+// omitted and silently drops keys the struct does not model. Use getCredential
+// instead when you need typed field access.
+//
+// Error pipeline (fast-fail) mirrors getCredential steps 1–3:
+//  1. User() fails                 → wrapped error
+//  2. Get() fails                  → ErrNotFound (no entry) or *TimeoutError
+//  3. strings.TrimSpace(raw) == "" → ErrEmptyCredential (entry exists but blank)
+func getRawCredential[T any](def ServiceDef[T]) (string, error) {
+	u, err := def.User()
+	if err != nil {
+		return "", fmt.Errorf("resolve keyring user: %w", err)
+	}
+
+	raw, err := Get(def.ServiceName, u)
+	if err != nil {
+		return "", err // ErrNotFound or *TimeoutError — pass through
+	}
+
+	if strings.TrimSpace(raw) == "" {
+		return "", fmt.Errorf("%w: service %q", ErrEmptyCredential, def.ServiceName)
+	}
+
+	return raw, nil
+}
+
 // ---------------------------------------------------------------------------
 // Reusable helpers — any ServiceDef can reference these.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`containerfs.PrepareCredentials` sourced host Claude Code credentials from the OS keyring via the typed `GetClaudeCodeCredentials`, then `json.Marshal`'d the struct back out to write `.credentials.json`. That round-trip was lossy in two ways:

- **Fabricated org membership.** A host blob that omits `organizationUuid` got a zero-value UUID re-emitted: `00000000-0000-0000-0000-000000000000`. The injected credential then claims an org the user is not a member of — which Anthropic's token refresh endpoint rejects, breaking auth inside the container.
- **Dropped unknown keys.** Any field present in the host blob but absent from the `ClaudeCodeCredentials` struct was silently discarded.

`omitempty` does not fix this: `uuid.UUID` is a `[16]byte` array, which `encoding/json` never treats as empty. The round-trip through the struct is itself the wrong approach for an injection path.

## Fix

- Add `keyring.GetClaudeCodeCredentialsRaw()` (fetch + empty-guard, **no** parse/marshal), backed by a generic `getRawCredential[T]` peer to `getCredential[T]`.
- `PrepareCredentials` now writes the keyring blob byte-for-byte, matching the file-fallback path which already copied verbatim.
- The typed `GetClaudeCodeCredentials` stays for readers that need field access; its doc now warns it is lossy and not for injection.

The blob is plain JSON (not a JWT) that Claude Code refreshes in place at runtime via the embedded `refreshToken`, so preserving it exactly is required.

## Tests

- `TestGetClaudeCodeCredentialsRaw` — verbatim return; fixture omits `organizationUuid` and carries an unknown key, so the equality assertion discriminates against the old lossy path. Plus not-found / empty-credential error branches.
- `TestPrepareCredentials_FromKeyring` rewritten to assert byte-exact staged output (was only checking `claudeAiOauth` key presence on a re-parsed map — phantom coverage).

Targeted package tests pass (`internal/keyring`, `internal/containerfs`); pre-commit (lint/SAST/vuln/unit) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)