### PR TITLE
fix(presets): TypeScript preset runs npm install pre_run

### DIFF
--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -111,7 +111,10 @@ security:
 // is set globally there. registry.npmjs.org is in the required firewall set
 // (see internal/config/defaults.go). TypeScript-specific tooling (pnpm, tsc)
 // layers on top.
-const typescriptPreset = `build:
+const typescriptPreset = `agent:
+  pre_run: |
+    npm install
+build:
   image: "buildpack-deps:bookworm-scm"
   packages:
     - ripgrep

--- a/internal/config/presets_test.go
+++ b/internal/config/presets_test.go
@@ -1,24 +1,101 @@
-package config
+package config_test
+
+// External test package: testenv imports config, so the write+reload test
+// cannot live in package config without an import cycle.
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/schmitthub/clawker/internal/config"
+	"github.com/schmitthub/clawker/internal/consts"
 	"github.com/schmitthub/clawker/internal/storage"
+	"github.com/schmitthub/clawker/internal/testenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
-func TestPresets_AllParseSuccessfully(t *testing.T) {
-	for _, p := range Presets() {
+// TestPresets_StrictDecode decodes every preset with KnownFields enabled so
+// any key the Project schema doesn't recognize fails the test. The store's
+// normal load path silently accepts unknown fields, which lets mis-nested
+// keys (e.g. pre_run at top level instead of under agent:) vanish without a
+// trace — this is the tripwire for that class of bug.
+func TestPresets_StrictDecode(t *testing.T) {
+	for _, p := range config.Presets() {
 		t.Run(p.Name, func(t *testing.T) {
-			store, err := storage.NewFromString[Project](p.YAML,
-				storage.WithDefaultsFromStruct[Project](),
-			)
-			require.NoError(t, err, "preset %q failed to parse", p.Name)
+			dec := yaml.NewDecoder(strings.NewReader(p.YAML))
+			dec.KnownFields(true)
+			var proj config.Project
+			require.NoError(t, dec.Decode(&proj),
+				"preset %q has unknown or mis-nested keys", p.Name)
 
-			snap := store.Read()
-			require.NotNil(t, snap, "preset %q produced nil snapshot", p.Name)
+			if proj.Security.Firewall != nil {
+				for _, r := range proj.Security.Firewall.Rules {
+					require.NoError(t, r.ValidatePortSpec(),
+						"preset %q: invalid egress rule port spec", p.Name)
+				}
+			}
 		})
+	}
+}
+
+// TestPresets_WriteAndReload exercises the same path project init uses:
+// NewProjectStoreFromPreset → WriteTo(.clawker.yaml) → full config load with
+// walk-up discovery. It then asserts every key the preset specifies survives
+// the write+reload round trip with its value intact. A preset field that
+// parses but never lands in the discovered config (mis-nesting, dropped
+// merge) fails here even though the lenient store load reports no error.
+func TestPresets_WriteAndReload(t *testing.T) {
+	for _, p := range config.Presets() {
+		t.Run(p.Name, func(t *testing.T) {
+			env := testenv.New(t)
+			projDir := filepath.Join(env.Dirs.Base, "proj")
+			require.NoError(t, os.MkdirAll(projDir, 0o755))
+
+			store, err := config.NewProjectStoreFromPreset(p.YAML)
+			require.NoError(t, err)
+			require.NoError(t, store.WriteTo(filepath.Join(projDir, "."+consts.ProjectConfigFile)))
+
+			t.Chdir(projDir)
+			cfg, err := config.NewConfig(config.WithProjectRoot(projDir))
+			require.NoError(t, err)
+
+			reloaded, err := yaml.Marshal(cfg.Project())
+			require.NoError(t, err)
+
+			var want, got map[string]any
+			require.NoError(t, yaml.Unmarshal([]byte(p.YAML), &want))
+			require.NoError(t, yaml.Unmarshal(reloaded, &got))
+			assertYAMLSubset(t, want, got, p.Name)
+		})
+	}
+}
+
+// assertYAMLSubset asserts that every mapping key and sequence element in
+// want is present in got with an equal value. got may contain extra keys
+// (schema defaults merged at load time); want may not lose any.
+func assertYAMLSubset(t *testing.T, want, got any, path string) {
+	t.Helper()
+	switch w := want.(type) {
+	case map[string]any:
+		g, ok := got.(map[string]any)
+		require.True(t, ok, "%s: expected mapping, got %T", path, got)
+		for k, wv := range w {
+			gv, present := g[k]
+			require.True(t, present, "%s.%s: preset key missing after write+reload", path, k)
+			assertYAMLSubset(t, wv, gv, path+"."+k)
+		}
+	case []any:
+		g, ok := got.([]any)
+		require.True(t, ok, "%s: expected sequence, got %T", path, got)
+		for _, wv := range w {
+			require.Contains(t, g, wv, "%s: preset element missing after write+reload", path)
+		}
+	default:
+		require.Equal(t, want, got, "%s: preset value changed after write+reload", path)
 	}
 }
 
@@ -32,10 +109,10 @@ func TestPresets_FieldAssertions(t *testing.T) {
 		"Java": true, "Ruby": true, "C#/.NET": true,
 	}
 
-	for _, p := range Presets() {
+	for _, p := range config.Presets() {
 		t.Run(p.Name, func(t *testing.T) {
-			store, err := storage.NewFromString[Project](p.YAML,
-				storage.WithDefaultsFromStruct[Project](),
+			store, err := storage.NewFromString[config.Project](p.YAML,
+				storage.WithDefaultsFromStruct[config.Project](),
 			)
 			require.NoError(t, err)
 
@@ -50,6 +127,13 @@ func TestPresets_FieldAssertions(t *testing.T) {
 			// the Dockerfile template base and no longer listed in presets).
 			assert.Contains(t, snap.Build.Packages, "ripgrep",
 				"preset %q: build.packages must include ripgrep", p.Name)
+
+			// Node users rely on dependencies being installed out of the box;
+			// the TypeScript preset must ship an npm install pre_run.
+			if p.Name == "TypeScript" {
+				assert.Contains(t, snap.Agent.PreRun, "npm install",
+					"preset %q: agent.pre_run must run npm install", p.Name)
+			}
 
 			// VCS domains (github.com, etc.) are no longer in presets — they
 			// come from the VCS wizard/flags. Only language-specific domains
@@ -68,7 +152,7 @@ func TestPresets_FieldAssertions(t *testing.T) {
 
 func TestPresets_AutoCustomizeContract(t *testing.T) {
 	var autoCount int
-	for _, p := range Presets() {
+	for _, p := range config.Presets() {
 		if p.AutoCustomize {
 			autoCount++
 			assert.Equal(t, "Build from scratch", p.Name,
@@ -80,10 +164,10 @@ func TestPresets_AutoCustomizeContract(t *testing.T) {
 }
 
 func TestPresets_SchemaDefaultsFillGaps(t *testing.T) {
-	for _, p := range Presets() {
+	for _, p := range config.Presets() {
 		t.Run(p.Name, func(t *testing.T) {
-			store, err := storage.NewFromString[Project](p.YAML,
-				storage.WithDefaultsFromStruct[Project](),
+			store, err := storage.NewFromString[config.Project](p.YAML,
+				storage.WithDefaultsFromStruct[config.Project](),
 			)
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Node users got no out-of-the-box dependency install from the TypeScript preset — a popular template. The preset now ships `agent.pre_run: npm install`, which runs on every container start in the workdir (exits 0 when no `package.json` exists, so non-Node workspaces are unaffected).

## Test hardening

The first cut of this fix mis-nested `pre_run` at top level. It parsed cleanly, every existing test stayed green, and the value silently vanished — the store's load path accepts unknown fields by design. Preset tests now close that hole with three independent layers (each mutation-tested against the original bug):

- **Strict decode** — `yaml.v3` `KnownFields(true)` per preset rejects unknown/mis-nested keys with exact field+line diagnostics; also validates any egress rule port specs
- **Write+reload round-trip** — real-fs via `testenv`: `NewProjectStoreFromPreset` → `WriteTo(.clawker.yaml)` (init's exact path) → `NewConfig` walk-up discovery → every preset key must survive with value intact
- **Semantic tripwire** — TypeScript preset must carry `npm install` in `agent.pre_run` (catches outright removal, which the generic layers can't)

Replaces the lenient `TestPresets_AllParseSuccessfully` (its leniency was the exact mechanism that let the bug through). Test file moved to `package config_test` — the round-trip needs `testenv`, which imports `config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)