### PR TITLE
fix(workspace): copy .git into snapshots; reject worktree+snapshot

### DIFF
--- a/.clawker.yaml
+++ b/.clawker.yaml
@@ -20,7 +20,7 @@ build:
     root_run:
       - npm install -g wscat
       - |-
-        GH_VERSION=2.92.0 && \
+        GH_VERSION=2.94.0 && \
           ARCH=$(dpkg --print-architecture) && \
           GH_FILE="gh_${GH_VERSION}_linux_${ARCH}.tar.gz" && \
           CHECKSUMS_FILE="gh_${GH_VERSION}_checksums.txt" && \
@@ -277,12 +277,6 @@ security:
             path: /opensearch-project/OpenSearch-Dashboards/
         port: 443
         proto: https
-      # tcpbin.com: TLS echo (:4243) as OPAQUE tcp — Envoy proxies the bytes (no MITM),
-      # the agent runs TLS end-to-end through the dedicated STATIC listener.
-      - action: allow
-        dst: 45.79.112.203
-        proto: tcp
-        port: "4242-4243" # dynamic port: inclusive range → one dedicated STATIC listener per port
   git_credentials:
     copy_git_config: true
     forward_gpg: true

--- a/docs/container-internals.mdx
+++ b/docs/container-internals.mdx
@@ -58,7 +58,7 @@ Clawker makes git work seamlessly inside containers, even for advanced setups li
 
 ### Standard Repositories
 
-For a normal (non-worktree) project, the `.git` directory is part of your workspace and gets mounted along with everything else. Git commands inside the container work exactly as they do on your host.
+For a normal (non-worktree) project, the `.git` directory is part of your workspace and comes along with everything else — bind-mounted in bind mode, or copied into the volume in snapshot mode. Either way, git commands inside the container work exactly as they do on your host (snapshot's `.git` is a disposable copy, so history and commits inside the container never reach the host). Exclude it from a snapshot by adding `.git/` to `.clawkerignore`.
 
 ### Worktree Support
 

--- a/docs/worktrees.mdx
+++ b/docs/worktrees.mdx
@@ -44,6 +44,7 @@ git push -u origin <branch>     # or: git branch --set-upstream-to=origin/<branc
 
 - **Go builds**: worktree containers set `GOFLAGS=-buildvcs=false` because Go's VCS stamping cannot work in a linked worktree. Override via `agent.env`. See [Go builds inside worktree containers](#go-builds-inside-worktree-containers).
 - **Branch-keyed, no detached HEAD**: clawker worktrees are identified by branch name; detached-HEAD worktrees are unsupported.
+- **Bind mode only**: worktrees require `workspace.default_mode: bind` (or `--mode bind`). They are rejected in snapshot mode — a worktree binds the host's main `.git` read-write, and a snapshot copy on top of that would let in-container writes reach your host repo, defeating snapshot isolation. Snapshot mode already isolates the workspace from the host on its own, so the two are mutually exclusive.
 
 The lockdown is currently not configurable — secure by default. A policy gate to relax it per project is planned.
 

--- a/internal/cmd/container/shared/container_create.go
+++ b/internal/cmd/container/shared/container_create.go
@@ -1515,6 +1515,19 @@ func CreateContainer(ctx context.Context, opts *CreateContainerOptions, events c
 		return nil, err
 	}
 
+	// Fail fast on worktree + snapshot before resolveWorkDir creates a git
+	// worktree we'd only reject later. workspace.SetupMounts enforces the same
+	// invariant as the load-bearing guard; this is the fail-fast UX layer.
+	if containerOpts.Worktree != "" {
+		mode, err := workspace.ResolveMode(containerOpts.Mode, projectCfg.Workspace.DefaultMode)
+		if err != nil {
+			return nil, fmt.Errorf("invalid workspace mode: %w", err)
+		}
+		if mode == config.ModeSnapshot {
+			return nil, workspace.ErrWorktreeSnapshot
+		}
+	}
+
 	wd, projectRootDir, err := resolveWorkDir(ctx, containerOpts, agentName, projectRoot, opts.ProjectManager, log)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/container/shared/init_test.go
+++ b/internal/cmd/container/shared/init_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/schmitthub/clawker/internal/hostproxy/hostproxytest"
 	"github.com/schmitthub/clawker/internal/logger"
 	projectpkg "github.com/schmitthub/clawker/internal/project"
+	"github.com/schmitthub/clawker/internal/workspace"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
@@ -138,6 +139,51 @@ func TestCreateContainer_HappyPath(t *testing.T) {
 	require.Equal(t, "test-agent", result.AgentName)
 	require.Equal(t, "clawker.testproject.test-agent", result.ContainerName)
 	fake.AssertCalled(t, "ContainerCreate")
+}
+
+// snapshotModeProject builds a *config.Project whose workspace.default_mode is
+// snapshot, for exercising the config-default branch of the worktree guard.
+func snapshotModeProject(t *testing.T) *config.Project {
+	t.Helper()
+	cfg, err := config.NewFromString("workspace:\n  default_mode: snapshot\n", "")
+	require.NoError(t, err)
+	return cfg.Project()
+}
+
+// TestCreateContainer_RejectsWorktreeInSnapshotMode locks in the fail-fast
+// guard: worktree + snapshot must be rejected before resolveWorkDir creates a
+// git worktree on disk. This is a distinct guard from the one in
+// workspace.SetupMounts. ContainerCreate must never be called — the rejection
+// happens before any Docker work. Covers both the --mode override and the
+// config workspace.default_mode paths.
+func TestCreateContainer_RejectsWorktreeInSnapshotMode(t *testing.T) {
+	setupAuthEnv(t)
+	tests := []struct {
+		name    string
+		project *config.Project
+		mode    string
+	}{
+		{name: "explicit --mode snapshot override", project: testConfig(), mode: "snapshot"},
+		{name: "config workspace.default_mode: snapshot", project: snapshotModeProject(t), mode: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := mocks.NewFakeClient(configmocks.NewBlankConfig())
+
+			containerOpts := NewContainerOptions()
+			containerOpts.Image = "alpine"
+			containerOpts.Agent = "test-agent"
+			containerOpts.Worktree = "feature/x"
+			containerOpts.Mode = tt.mode
+
+			_, err := CreateContainer(context.Background(),
+				testCreateConfig(fake, tt.project, containerOpts, testFlags()), nil)
+
+			require.ErrorIs(t, err, workspace.ErrWorktreeSnapshot)
+			fake.AssertNotCalled(t, "ContainerCreate")
+		})
+	}
 }
 
 func TestCreateContainer_ContainerCreateError(t *testing.T) {

--- a/internal/docker/CLAUDE.md
+++ b/internal/docker/CLAUDE.md
@@ -87,7 +87,9 @@ type Container struct {
 
 `EnsureVolume(...)`, `CopyToVolume(...)`, `LoadIgnorePatterns(path)`, `FindIgnoredDirs(hostPath, patterns)`. CopyToVolume uses two-phase ownership fix: tar headers with UID/GID 1001 + post-copy chown via `Client.ChownImage` (defaults to a busybox image when unset); set `Client.ChownImage` to override.
 
-`FindIgnoredDirs` walks a host directory and returns relative paths of directories matching ignore patterns. Used by bind mode to generate tmpfs overlay mounts. Key differences from snapshot's `shouldIgnore`: only returns directories, never masks `.git/` (bind mode needs git), and skips recursion into matched directories for performance.
+`FindIgnoredDirs` walks a host directory and returns relative paths of directories matching ignore patterns. Used by bind mode to generate tmpfs overlay mounts. Key differences from snapshot's `shouldIgnore`: only returns directories, force-keeps `.git/` even if a pattern would match it (bind mode needs git for live development), and skips recursion into matched directories for performance.
+
+**Snapshot `.git` handling**: snapshot's `shouldIgnore` honors `.clawkerignore` patterns verbatim and has **no** hardcoded `.git` skip — `.git` is copied into the ephemeral volume by default (snapshot's isolation comes from the copy-to-volume direction, not from withholding git history), and is excluded only if a pattern explicitly matches it.
 
 `BindOverlayDirsFromPatterns(patterns) []string` — derives directory overlay targets from ignore patterns for bind mode. Only returns deterministic directory paths, skips file-glob patterns.
 

--- a/internal/docker/volume.go
+++ b/internal/docker/volume.go
@@ -250,11 +250,6 @@ func createTarArchive(log *logger.Logger, srcDir string, buf io.Writer, ignorePa
 
 // shouldIgnore checks if a path should be ignored based on patterns.
 func shouldIgnore(log *logger.Logger, path string, isDir bool, patterns []string) bool {
-	// Always ignore .git directory
-	if path == ".git" || strings.HasPrefix(path, ".git/") || strings.HasPrefix(path, ".git\\") {
-		return true
-	}
-
 	for _, pattern := range patterns {
 		pattern = strings.TrimSpace(pattern)
 
@@ -455,7 +450,9 @@ func BindOverlayDirsFromPatterns(patterns []string) []string {
 //
 // Key differences from snapshot's shouldIgnore:
 //   - Only returns directories (file patterns like *.log are not actionable)
-//   - Does NOT mask .git/ (bind mode needs git for live development)
+//   - Force-keeps .git/ even if a pattern would match it (bind mode needs git
+//     for live development); snapshot's shouldIgnore honors patterns verbatim,
+//     including .git, and copies .git by default when no pattern excludes it
 //   - Skips recursion into matched directories (performance)
 func FindIgnoredDirs(log *logger.Logger, hostPath string, patterns []string) ([]string, error) {
 	if log == nil {
@@ -512,7 +509,6 @@ func FindIgnoredDirs(log *logger.Logger, hostPath string, patterns []string) ([]
 }
 
 // shouldIgnoreForBind checks if a directory path matches any of the given patterns.
-// Unlike shouldIgnore, this skips the hardcoded .git check (caller handles it).
 // The caller is responsible for passing only directory paths.
 func shouldIgnoreForBind(log *logger.Logger, path string, patterns []string) bool {
 	for _, pattern := range patterns {

--- a/internal/docker/volume_test.go
+++ b/internal/docker/volume_test.go
@@ -111,17 +111,24 @@ func TestShouldIgnore(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "empty patterns still ignores .git",
+			name:     ".git is copied by default (no longer hardcoded-ignored)",
 			path:     ".git",
 			isDir:    true,
 			patterns: []string{},
-			want:     true,
+			want:     false,
 		},
 		{
-			name:     ".git subdirectory ignored",
+			name:     ".git subdirectory copied by default",
 			path:     ".git/objects/pack",
 			isDir:    false,
 			patterns: []string{},
+			want:     false,
+		},
+		{
+			name:     ".git ignored only when explicitly listed in patterns",
+			path:     ".git",
+			isDir:    true,
+			patterns: []string{".git/"},
 			want:     true,
 		},
 		{

--- a/internal/workspace/CLAUDE.md
+++ b/internal/workspace/CLAUDE.md
@@ -32,7 +32,9 @@ type Config struct {
 
 `BindStrategy` — Direct host mount (live sync). `GetMounts()` generates tmpfs overlays for directories matching `.clawkerignore` patterns (file-level patterns like `*.env` cannot be enforced in bind mode). Prepare/Cleanup are no-ops. `ShouldPreserve()` returns true.
 
-`SnapshotStrategy` — Ephemeral volume copy (isolated). Creates volume and copies files on Prepare. `IgnorePatterns` are applied during tar archive creation to exclude matching files/directories. `ShouldPreserve()` returns false. Extra methods: `VolumeName() string`, `WasCreated() bool`.
+`SnapshotStrategy` — Ephemeral volume copy (isolated). Creates volume and copies files on Prepare. `IgnorePatterns` are applied during tar archive creation to exclude matching files/directories — the only exclusion authority (there is no hardcoded `.git` skip; `.git` is copied so in-container git works, and isolation comes from the copy being a disposable volume, not from withholding history). `ShouldPreserve()` returns false. Extra methods: `VolumeName() string`, `WasCreated() bool`.
+
+**Worktree + snapshot are mutually exclusive.** Worktrees bind the host's main `.git` read-write (see Worktree support below); layering a snapshot copy on top would let in-container writes reach the host repo, defeating snapshot isolation. `SetupMounts` rejects the combination (after mode resolution, before `strategy.Prepare`) with an error pointing the user at `workspace.default_mode: bind` / `--mode bind`. `CreateContainer` (`internal/cmd/container/shared`) also fails fast on the same invariant before creating a git worktree.
 
 ### Constructors
 
@@ -65,6 +67,8 @@ type SetupMountsResult struct {
     ContainerPath       string    // Resolved container-side workspace mount path
 }
 
+func ResolveMode(override, defaultMode string) (config.Mode, error)  // mode precedence: CLI --mode override wins, else config default; empty resolves to ModeBind (ParseMode default), only unrecognized non-empty errors
+var ErrWorktreeSnapshot error  // sentinel: worktree + snapshot rejected. SetupMounts keys on ProjectRootDir != ""; CreateContainer fail-fast keys on the --worktree flag — equivalent because resolveWorkDir sets ProjectRootDir iff a worktree is requested
 func SetupMounts(ctx context.Context, client *docker.Client, cfg SetupMountsConfig) (*SetupMountsResult, error)
 func GetConfigVolumeMounts(projectName, agentName string) ([]mount.Mount, error)
 func EnsureConfigVolumes(ctx context.Context, cli *docker.Client, projectName, agentName string) (ConfigVolumeResult, error)

--- a/internal/workspace/setup.go
+++ b/internal/workspace/setup.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,25 @@ import (
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/logger"
 )
+
+// ErrWorktreeSnapshot is returned when a git worktree is requested together
+// with snapshot workspace mode. The two are mutually exclusive: a worktree
+// binds the host's main .git read-write, and a snapshot copy on top of that
+// would let in-container writes reach the host repo, defeating snapshot
+// isolation. Snapshot already isolates the workspace from the host on its own.
+var ErrWorktreeSnapshot = errors.New("worktrees are not supported in snapshot mode (snapshot already isolates the workspace from the host); set workspace.default_mode: bind or pass --mode bind")
+
+// ResolveMode applies workspace-mode precedence: an explicit override (CLI
+// --mode flag) wins, otherwise the project's configured default mode. An empty
+// resulting value resolves to ModeBind (config.ParseMode's default); only an
+// unrecognized non-empty value returns an error.
+func ResolveMode(override, defaultMode string) (config.Mode, error) {
+	modeStr := override
+	if modeStr == "" {
+		modeStr = defaultMode
+	}
+	return config.ParseMode(modeStr)
+}
 
 // SetupMountsConfig holds configuration for workspace mount setup
 type SetupMountsConfig struct {
@@ -88,14 +108,15 @@ func SetupMounts(ctx context.Context, client *docker.Client, cfg SetupMountsConf
 
 	// Determine workspace mode (CLI flag overrides config default)
 	project := cfg.Cfg.Project()
-	modeStr := cfg.ModeOverride
-	if modeStr == "" {
-		modeStr = project.Workspace.DefaultMode
-	}
-
-	mode, err := config.ParseMode(modeStr)
+	mode, err := ResolveMode(cfg.ModeOverride, project.Workspace.DefaultMode)
 	if err != nil {
 		return nil, fmt.Errorf("invalid workspace mode: %w", err)
+	}
+
+	// Worktree (ProjectRootDir set) + snapshot is mutually exclusive — see
+	// ErrWorktreeSnapshot.
+	if cfg.ProjectRootDir != "" && mode == config.ModeSnapshot {
+		return nil, ErrWorktreeSnapshot
 	}
 
 	// Load ignore patterns (no ignore file when no project is registered)

--- a/internal/workspace/setup_test.go
+++ b/internal/workspace/setup_test.go
@@ -1,12 +1,14 @@
 package workspace
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/moby/moby/api/types/mount"
+	"github.com/schmitthub/clawker/internal/config"
 	configmocks "github.com/schmitthub/clawker/internal/config/mocks"
 	"github.com/schmitthub/clawker/internal/docker/mocks"
 	"github.com/schmitthub/clawker/internal/logger"
@@ -275,6 +277,77 @@ func TestSetupMounts_RelativeContainerPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must be absolute") {
 		t.Errorf("error message = %q, should mention 'must be absolute'", err.Error())
+	}
+}
+
+func TestSetupMounts_RejectsWorktreeInSnapshotMode(t *testing.T) {
+	// Worktree (ProjectRootDir set) + snapshot must be rejected before any
+	// Docker call — the nil client proves the guard fires early. Covers both
+	// the explicit --mode override and the config workspace.default_mode path.
+	tests := []struct {
+		name         string
+		cfg          config.Config
+		modeOverride string
+	}{
+		{
+			name:         "explicit --mode snapshot override",
+			cfg:          configmocks.NewBlankConfig(),
+			modeOverride: "snapshot",
+		},
+		{
+			name:         "config workspace.default_mode: snapshot",
+			cfg:          configmocks.NewFromString("workspace:\n  default_mode: snapshot\n", ""),
+			modeOverride: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SetupMounts(t.Context(), nil, SetupMountsConfig{
+				Log:            logger.Nop(),
+				Cfg:            tt.cfg,
+				ModeOverride:   tt.modeOverride,
+				ContainerPath:  "/workspace",
+				WorkDir:        t.TempDir(),
+				ProjectRootDir: t.TempDir(), // non-empty == worktree
+			})
+			if !errors.Is(err, ErrWorktreeSnapshot) {
+				t.Fatalf("SetupMounts() error = %v, want ErrWorktreeSnapshot", err)
+			}
+		})
+	}
+}
+
+func TestResolveMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		override    string
+		defaultMode string
+		want        config.Mode
+		wantErr     bool
+	}{
+		{name: "override wins over default", override: "snapshot", defaultMode: "bind", want: config.ModeSnapshot},
+		{name: "empty override falls back to default", override: "", defaultMode: "snapshot", want: config.ModeSnapshot},
+		{name: "both empty resolves to bind", override: "", defaultMode: "", want: config.ModeBind},
+		{name: "unrecognized value errors", override: "bogus", defaultMode: "bind", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveMode(tt.override, tt.defaultMode)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ResolveMode(%q, %q) error = nil, want error", tt.override, tt.defaultMode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveMode(%q, %q) unexpected error = %v", tt.override, tt.defaultMode, err)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveMode(%q, %q) = %v, want %v", tt.override, tt.defaultMode, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related workspace fixes.

**Snapshot `.git` is copied by default.** Snapshot mode previously hardcoded a `.git` skip in `shouldIgnore`, so containers in snapshot mode had no git history — a bug against user expectation. `.git` is now copied into the ephemeral volume by default (honoring `.clawkerignore` only), so in-container git works. Isolation comes from the copy being a disposable volume, not from withholding history. Users can still exclude it by adding `.git/` to `.clawkerignore`.

**Worktree + snapshot is rejected.** The two are mutually exclusive: a worktree binds the host's main `.git` read-write, so a snapshot copy layered on top would let in-container writes reach the host repo, defeating snapshot isolation. Enforced at two layers via a shared `ErrWorktreeSnapshot` sentinel and a new `ResolveMode` helper:
- `workspace.SetupMounts` — load-bearing guard, reachable by any caller.
- `CreateContainer` — fail-fast guard that runs *before* `resolveWorkDir` creates a git worktree on disk.

## Test plan

- `go build ./...` — clean
- `go test ./internal/workspace/... ./internal/docker/... ./internal/cmd/container/shared/...` — pass
- New: `TestResolveMode` (precedence + error), `TestSetupMounts_RejectsWorktreeInSnapshotMode`, `TestCreateContainer_RejectsWorktreeInSnapshotMode` (both `--mode` override + config-default paths; asserts `ContainerCreate` never called)
- Updated: `TestShouldIgnore` (`.git` copied by default, ignored only when a pattern lists it)
- Docs + package CLAUDE.md files updated; user-facing docs/plugin/README swept for stale snapshot/`.git` claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)
