### PR TITLE
docs(credentials): document Claude Code refresh-token rotation /login

### DIFF
--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "author": {
     "name": "schmitthub"
   },

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/claude-code.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/claude-code.md
@@ -26,7 +26,29 @@ On the **host**, Claude Code keeps this pair in the OS keychain (with a file
 fallback). When the access token expires, Claude Code silently refreshes it
 using the refresh token and writes the rotated pair back to the keychain. The
 user never sees a prompt as long as the refresh token is still valid. A prompt
-(`/login`) appears only when the refresh token itself is expired or revoked.
+(`/login`) appears only when the refresh token itself is expired, revoked, or
+**already rotated away**.
+
+Refresh tokens are **single-use**: each refresh mints a new refresh token and
+**permanently invalidates the old one** (rotation with reuse detection). On the
+host this is invisible — one holder, one keychain, refreshes serialized behind a
+lock, so the rotated pair always lands cleanly. The wrinkle appears only when
+*two* holders share one refresh token, which is exactly what create-time copying
+produces (see below).
+
+**Who actually hits this, and how often.** A collision needs a *refresh*, and a
+refresh only fires once the access token expires. A container that lives shorter
+than the access-token lifetime never refreshes — it rides the inherited,
+still-valid access token and exits — so it never collides. Ephemeral and
+short-lived containers get the full zero-touch benefit with no downside. Only
+**long-lived** containers (ones that outlive the inherited access token) are
+exposed, and only **once**: the forced `/login` mints that container its own
+independent family, permanently decoupling it from the host. So this is a
+bounded, self-correcting, one-time-per-container event — not perpetual churn —
+and the host, as the most frequent refresher, stays current and is not the loser
+in practice. A user who wants a long-lived container to skip even that single
+prompt can set `use_host_auth: false` and `/login` once up front (own family
+from the start).
 
 ### How clawker shares it with a container
 
@@ -81,14 +103,25 @@ validity matters for whether a fresh container starts authenticated.
 **Symptom.** Every new agent container prompts for `/login` even though
 `agent.claude_code.use_host_auth` is on.
 
-**Most likely cause.** The host's **refresh token was already expired or
-revoked** when the container was created. The snapshot clawker copied in could
-not be refreshed, so Claude Code falls back to an interactive login. Nothing is
-misconfigured — the shared credential was simply stale at copy time.
+**Two causes, both expected, neither a misconfiguration:**
 
-This is reasoned about from the model above, not diagnosed from inside the
-container: the credential blob doesn't expose the refresh token's expiry, and
-the sandbox can't reach the host keychain.
+1. **The shared refresh token was rotated away (most common).** The credential
+   clawker copied in was valid at create time, but single-use rotation
+   invalidated this container's copy: the host — or another container created
+   from the same login — refreshed first and "turned the token in," so when
+   *this* container later tries to refresh its (now stale) copy, the OAuth
+   server rejects it (`invalid_grant`) and Claude Code clears the credential and
+   prompts. This is inherent to sharing one rotating credential across two
+   independent holders; it is not stale-at-copy and not a clawker defect.
+
+2. **The host's refresh token was already expired or revoked at create time.**
+   The snapshot could never be refreshed, so Claude Code falls back to login
+   from the start. The shared credential was simply stale when copied.
+
+Both are reasoned about from the model above, not diagnosed from inside the
+container: the credential blob doesn't expose the refresh token's expiry or
+rotation state, and the sandbox can't reach the host keychain. In either case
+the in-container fix is identical — one `/login`, then the volume self-heals.
 
 **For the container that already prompted: nothing more to do.** Once the user
 completes `/login` inside it, Claude Code writes the fresh, rotated credentials

--- a/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
+++ b/claude-plugin/clawker-support/skills/clawker-support/reference/known-issues.md
@@ -56,6 +56,18 @@ re-injected from the host at container create) — or run `/login` once inside
 the existing container. Re-authenticating on the host fixes only future
 containers, not existing volumes.
 
+**Do not confuse this fixed bug with normal rotation.** Claude Code also blanks
+its stored `refreshToken` (same empty-on-failed-refresh behavior) for an
+entirely *expected* reason: refresh tokens are single-use, so if the host or
+another container "turns in" the shared token first, this container's copy is
+invalidated (`invalid_grant`) and a one-time `/login` follows. That is not a
+clawker defect and recreating the container does not prevent it — it is inherent
+to sharing one rotating credential across two holders. Full model and
+troubleshooting in `claude-code.md`. The struct-roundtrip bug above is
+distinguished by a zero-value `organizationUuid` in the poisoned blob and is
+fixed in current releases; rotation-induced `/login` has no such fingerprint and
+is permanent by design.
+
 ## git push -u / upstream tracking in worktree containers
 
 Worktree containers mask the main repo's `.git/hooks/` and `.git/config` with

--- a/docs/credentials.mdx
+++ b/docs/credentials.mdx
@@ -137,6 +137,20 @@ agent:
 
 When disabled, Claude Code inside the container will prompt for authentication on first run.
 
+<Warning>
+**Refresh tokens are single-use and rotate — a `/login` after the access token expires is expected, not a bug.** Clawker copies the host credential **once**, at create time, and never syncs the two sides again. Each time Claude Code refreshes an expired access token, Anthropic's OAuth server issues a **new** refresh token and **permanently invalidates the old one**. The host and the container hold independent copies of the *same* refresh token, so whichever side refreshes first "turns in" that shared token; the other side's copy is now stale, and its next refresh is rejected (`invalid_grant`) — forcing a one-time `/login` in that environment.
+
+This is why a container can start with a perfectly valid credential and still prompt for `/login` later: the host (or another container) turned the shared refresh token in first. After that one `/login`, the container self-heals — it persists its own freshly rotated token in the config volume and won't prompt again.
+
+Clawker never participates in the token exchange. Refresh and rotation are handled entirely by first-party Claude Code, as Anthropic's terms require — clawker only seeds the initial byte-for-byte copy.
+</Warning>
+
+<Note>
+**Which containers are actually exposed — and it's at most once each.** A collision requires a *refresh*, and a refresh only happens once the access token expires. A container that lives **shorter than the access-token lifetime** never refreshes: it uses the inherited (still-valid) access token and exits, so it never collides. The default is a clean win for these ephemeral and short-lived containers — zero-touch auth, no downside.
+
+Only **long-lived** containers — ones that outlive the inherited access token and must refresh — can hit the stale-token `/login`, and only **once**: that `/login` mints the container its **own** independent credential (its own family), after which it is fully decoupled from the host and never collides again. So this is a one-time event per long-lived container, not recurring churn. If you want a long-lived container to skip even that single prompt, set `use_host_auth: false` and `/login` once up front — it starts on its own family from the beginning.
+</Note>
+
 ### Config Strategy
 
 The `config.strategy` setting controls how Claude Code's configuration is initialized:
@@ -194,3 +208,4 @@ agent:
 1. Verify you're logged in on the host: `claude auth status`
 2. Check that `use_host_auth` is `true` (default)
 3. If using the file fallback, verify `~/.claude/.credentials.json` exists
+4. **A one-time `/login` after the access token expires is expected** if the shared refresh token was already rotated by the host or another container. Refresh tokens are single-use (see the warning above) — the stale side must re-login once, then self-heals. This is not a misconfiguration. Re-authenticating on the host only fixes containers created *afterward*.


### PR DESCRIPTION
## Summary

RCA confirmed that the post-entrypoint `refreshToken` strip users see in containers is **OAuth refresh-token rotation + reuse detection**, not a clawker credential-handling defect. The credential is copied byte-for-byte (RT confirmed present in fresh container layers; it vanishes only after Claude Code's entrypoint refresh). The strip is Claude Code reacting to a server `invalid_grant` and blanking its own stored RT.

Root cause: refresh tokens are single-use. Host and a `use_host_auth` container share one server-side **token family**; whichever refreshes first rotates it and invalidates the other's copy. The stale holder's next refresh is rejected -> one-time `/login`. The host alone never collides (single store, single refresh lock). Neither UA nor PKCE/code_verifier is involved — the refresh request body carries only `{grant_type, refresh_token, client_id, scope}`.

This PR is **documentation only** — no code change. Per Anthropic's terms clawker never participates in the token exchange, so there is nothing to "fix" in the cred path; the right move is to document the behavior and its bounds.

## Changes

- **docs/credentials.mdx** — rotation `<Warning>` in the Claude Code Authentication section, a `<Note>` on which containers are actually exposed (ephemeral never collide; only long-lived, and only once), and a troubleshooting bullet.
- **clawker-support skill `claude-code.md`** — single-use rotation added to the credential model; troubleshooting now lists two expected `/login` causes (rotation collision = most common; stale-at-copy second); lifetime-vs-TTL exposure nuance.
- **clawker-support skill `known-issues.md`** — disambiguates the *expected* rotation `/login` from the *fixed* struct-roundtrip bug (the latter has a zero-value `organizationUuid` fingerprint).
- **plugin.json** — bump to 1.0.11 (release pipeline keys on version increment).

## Test plan

- Docs-only; no code paths touched.
- MDX tag structure verified (`<Warning>`/`<Note>` open/close correct).
- Plugin version bumped per the patch-per-change rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)