### PR TITLE
chore: relicense MIT → AGPL-3.0-or-later + dual-licensing CLA

### DIFF
--- a/.clawker.yaml
+++ b/.clawker.yaml
@@ -228,6 +228,8 @@ security:
           - action: allow
             path: /repos/schmitthub/clawker
           - action: allow
+            path: /repos/schmitthub/claude-plugins
+          - action: allow
             path: /repos/envoyproxy/
           - action: allow
             path: /repos/oraios/serena/commits/

--- a/.clawker.yaml
+++ b/.clawker.yaml
@@ -230,6 +230,8 @@ security:
           - action: allow
             path: /repos/schmitthub/claude-plugins
           - action: allow
+            path: /repos/schmitthub/contributor-assistant
+          - action: allow
             path: /repos/envoyproxy/
           - action: allow
             path: /repos/oraios/serena/commits/

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,33 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write        # writes signatures to the cla-signatures branch
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      # The upstream CLA-assistant action is archived but still functional.
+      # Repo policy requires a commit-SHA pin (no floating tags).
+      - name: "CLA Assistant"
+        if: >
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # frozen: v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/v1/cla.json'
+          path-to-document: 'https://github.com/schmitthub/clawker/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: 'schmitthub,dependabot[bot]'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, closed, synchronize]
 
 permissions:
-  actions: write
+  actions: write         # action re-runs the stale CLA check (reRunWorkflow) so it goes green on sign
   contents: write        # writes signatures to the cla-signatures branch
   pull-requests: write
   statuses: write
@@ -20,8 +20,9 @@ jobs:
       # Repo policy requires a commit-SHA pin (no floating tags).
       - name: "CLA Assistant"
         if: >
-          (github.event.comment.body == 'recheck'
-           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+          (github.event.issue.pull_request
+           && (github.event.comment.body == 'recheck'
+               || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
           || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
         env:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,15 +22,19 @@ jobs:
   cla:
     runs-on: ubuntu-24.04
     steps:
-      # The upstream CLA-assistant action is archived but still functional.
-      # Repo policy requires a commit-SHA pin (no floating tags).
+      # Pinned to our own fork of the CLA-assistant action. Upstream
+      # (contributor-assistant/github-action) is archived — no security patches
+      # land there — and this action runs privileged (pull_request_target with a
+      # write token), so we keep it under our control. The SHA is upstream's
+      # audited v2.6.1 commit, now in our custody; repo policy requires a
+      # commit-SHA pin (no floating tags).
       - name: "CLA Assistant"
         if: >
           (github.event.issue.pull_request
            && (github.event.comment.body == 'recheck'
                || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
           || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
+        uses: schmitthub/contributor-assistant@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1 (fork)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   cla:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # The upstream CLA-assistant action is archived but still functional.
       # Repo policy requires a commit-SHA pin (no floating tags).
@@ -23,15 +23,15 @@ jobs:
           (github.event.comment.body == 'recheck'
            || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
           || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # frozen: v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/schmitthub/clawker/blob/main/CLA.md'
-          # Signatures are committed directly to this branch via GITHUB_TOKEN.
-          # It must stay UNPROTECTED (keep it out of main's branch protection),
-          # and must exist before the first PR.
+          # Signatures are committed directly to the cla-signatures branch via
+          # GITHUB_TOKEN. It must stay UNPROTECTED (keep it out of main's branch
+          # protection), and must exist before the first PR.
           branch: 'cla-signatures'
           allowlist: 'schmitthub,dependabot[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -3,6 +3,12 @@ name: "CLA Assistant"
 on:
   issue_comment:
     types: [created]
+  # pull_request_target runs in the BASE-repo context with a write-scoped token
+  # so the action can comment and commit signatures on forked PRs (plain
+  # pull_request hands forks a read-only token). Privileged, but safe here: the
+  # action is JS-only and never checks out or executes PR-head code, so the
+  # "pwn request" prerequisite (privileged checkout-and-build of fork code) is
+  # absent.
   pull_request_target:
     types: [opened, closed, synchronize]
 
@@ -30,9 +36,12 @@ jobs:
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/schmitthub/clawker/blob/main/CLA.md'
-          # Signatures are committed directly to the cla-signatures branch via
-          # GITHUB_TOKEN. It must stay UNPROTECTED (keep it out of main's branch
-          # protection), and must exist before the first PR.
+          # Signatures are committed to the cla-signatures branch via
+          # GITHUB_TOKEN through the GitHub Contents API, so the commits are
+          # auto-signed by the web-flow key and pass any required-signature
+          # rule. The branch must exist before the first PR and must NOT require
+          # PR reviews or status checks, which would block the bot's direct
+          # commits.
           branch: 'cla-signatures'
           allowlist: 'schmitthub,dependabot[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,14 +20,18 @@ jobs:
       # Repo policy requires a commit-SHA pin (no floating tags).
       - name: "CLA Assistant"
         if: >
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          (github.event.comment.body == 'recheck'
+           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
           || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08  # frozen: v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-signatures: 'signatures/v1/cla.json'
+          path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/schmitthub/clawker/blob/main/CLA.md'
+          # Signatures are committed directly to this branch via GITHUB_TOKEN.
+          # It must stay UNPROTECTED (keep it out of main's branch protection),
+          # and must exist before the first PR.
           branch: 'cla-signatures'
           allowlist: 'schmitthub,dependabot[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,10 +38,10 @@ jobs:
         run: |
           if [ -n "$BASE_SHA" ]; then
             echo "Incremental scan against base $BASE_SHA"
-            semgrep scan --sarif --output semgrep.sarif --baseline-commit "$BASE_SHA" --config p/golang --config p/security-audit --error
+            semgrep scan --sarif --output semgrep.sarif --baseline-commit "$BASE_SHA" --config p/golang --config p/security-audit --config p/github-actions --config .semgrep/ --error
           else
             echo "Full scan (no baseline)"
-            semgrep scan --sarif --output semgrep.sarif --config p/golang --config p/security-audit --error
+            semgrep scan --sarif --output semgrep.sarif --config p/golang --config p/security-audit --config p/github-actions --config .semgrep/ --error
           fi
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,7 +91,7 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/schmitthub/clawker
     description: "Development containers for AI coding agents"
-    license: "MIT"
+    license: "AGPL-3.0-or-later"
     hooks:
       post:
         install: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,16 @@ repos:
         language: system
         types: [go]
         pass_filenames: false
+      - id: semgrep-actions
+        name: Semgrep GitHub Actions
+        # Scans workflow YAML: p/github-actions catches the pull_request_target
+        # checkout (pwn-request); .semgrep/ adds the pull_request_target cache
+        # (poisoning) rule. Separate hook so workflow edits are gated even when
+        # no Go file changes. CI mirror: security.yml.
+        entry: semgrep scan --config p/github-actions --config .semgrep/ --error
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
 
   # ── Lint ──────────────────────────────────────────────────────────────────
   - repo: https://github.com/golangci/golangci-lint

--- a/.semgrep/clawker-actions.yaml
+++ b/.semgrep/clawker-actions.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: clawker-pull-request-target-cache
+    languages: [yaml]
+    severity: ERROR
+    message: >-
+      This workflow triggers on `pull_request_target` AND uses a cache-capable
+      action (`actions/cache`, or a `setup-*` action whose cache defaults on).
+      `pull_request_target` runs in the BASE-branch cache scope, so any cache it
+      writes is later restored by push-to-main and release workflows — the
+      GitHub Actions cache-poisoning primitive behind the May 2026 TanStack
+      supply-chain compromise (a privileged release job restored a poisoned
+      build cache and had its publish/OIDC token lifted from runner memory).
+      Do not share a cache from a `pull_request_target` job: set `cache: false`
+      on the setup-* action, drop `actions/cache`, or move the cached build to a
+      `pull_request` job (PR-scoped cache, unreachable from main/release). If the
+      cache is provably safe, add a justified
+      `# nosemgrep: clawker-pull-request-target-cache` on the `uses:` line.
+    paths:
+      include:
+        - ".github/workflows/*.yml"
+        - ".github/workflows/*.yaml"
+    patterns:
+      - pattern-inside: |
+          on:
+            ...
+            pull_request_target: ...
+          ...
+      - pattern: "uses: $U"
+      - metavariable-regex:
+          metavariable: $U
+          regex: "^actions/(cache|setup-go|setup-node|setup-python|setup-java|setup-dotnet|setup-ruby)"

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,66 @@
+# Clawker Contributor License Agreement
+
+Clawker is **dual-licensed**. It is offered to the public under the
+GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later), and the
+maintainer separately offers commercial licenses to parties who do not wish to
+be bound by the AGPL. Keeping that second option open requires that the
+maintainer hold the right to relicense every line in the project — including
+yours. This agreement secures that right while letting you keep ownership of
+your work.
+
+By submitting a contribution to this project (a pull request, a patch, or any
+other work), you agree to the following terms for that and all future
+contributions you submit.
+
+1. **Definitions.** "You" means the copyright owner, or the person legally
+   authorized by the copyright owner, making the contribution. "Contribution"
+   means any original work of authorship — including any modification or
+   addition to existing work — that you intentionally submit to this project.
+
+2. **You retain ownership.** This is a license, not an assignment. You keep all
+   right, title, and interest in and to your contribution.
+
+3. **Public license (outbound).** Your contribution is, and will be made,
+   available to the public under the AGPL-3.0-or-later — the same license as
+   the rest of the project.
+
+4. **License to the maintainer.** You grant Andrew J Schmitt (the project
+   maintainer) a perpetual, irrevocable, worldwide, non-exclusive,
+   royalty-free, sublicensable, and transferable license to use, reproduce,
+   modify, prepare derivative works of, publicly display, publicly perform,
+   distribute, and otherwise exploit your contribution, in whole or in part,
+   under any license terms the maintainer chooses — including proprietary or
+   commercial terms — and to relicense and sublicense your contribution under
+   any such terms. This grant is what permits your contribution to be included
+   in commercially licensed builds of Clawker alongside the public AGPL
+   release.
+
+5. **Patent license.** You grant the maintainer and all recipients of the
+   software a perpetual, irrevocable, worldwide, non-exclusive, royalty-free
+   patent license to make, have made, use, offer to sell, sell, import, and
+   otherwise transfer your contribution. This license applies only to those
+   patent claims you can license that are necessarily infringed by your
+   contribution alone or by combination of your contribution with the project
+   to which it was submitted.
+
+6. **You have the right to grant this.** You represent that each of your
+   contributions is your original creation and that you are legally entitled to
+   grant the above licenses. If your employer has rights to intellectual
+   property you create, you represent that you have received permission to make
+   the contribution on behalf of that employer, or that your employer has
+   waived such rights for the contribution.
+
+7. **No obligation; no warranty.** You understand that the maintainer is under
+   no obligation to use or include your contribution. Unless required by law or
+   agreed in writing, you provide your contribution on an "AS IS" basis,
+   without warranties or conditions of any kind.
+
+---
+
+*How you accept:* on your pull request, a CLA assistant comments with these
+terms and asks you to sign by replying with the exact phrase it specifies.
+Submitting a contribution constitutes your agreement to these terms; the
+mechanism used to record that agreement may change over time without changing
+the terms.
+
+Questions, or interested in a commercial license? Contact andrew@ajschmitt.io.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,4 +124,4 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). Be kind, be co
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+By contributing, you agree that your contributions will be licensed under the [GNU Affero General Public License v3.0 or later](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,9 @@ both, this project uses a Contributor License Agreement: you keep copyright of
 your work, your contribution is published under the AGPL-3.0-or-later, and you
 grant the maintainer the right to also license it under commercial terms.
 
+One subproject is the exception: the `claude-plugin/clawker-support/` plugin is
+licensed separately under the MIT License (see its LICENSE file).
+
 Read the full text in [CLA.md](CLA.md). On your first pull request, a CLA
 assistant asks you to sign by commenting a short confirmation phrase; merging is
 gated until you do.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,14 @@ Package-specific docs live in `internal/*/CLAUDE.md` files.
 
 Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). Be kind, be constructive, be welcoming.
 
-## License
+## License & Contributor Agreement
 
-By contributing, you agree that your contributions will be licensed under the [GNU Affero General Public License v3.0 or later](LICENSE).
+Clawker is dual-licensed: AGPL-3.0-or-later for everyone, with commercial
+licenses available from the maintainer. So that contributions can ship under
+both, this project uses a Contributor License Agreement: you keep copyright of
+your work, your contribution is published under the AGPL-3.0-or-later, and you
+grant the maintainer the right to also license it under commercial terms.
+
+Read the full text in [CLA.md](CLA.md). On your first pull request, a CLA
+assistant asks you to sign by commenting a short confirmation phrase; merging is
+gated until you do.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,662 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 Andrew J Schmitt
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+

--- a/README.md
+++ b/README.md
@@ -425,4 +425,8 @@ Clawker is free software: GNU Affero General Public License v3.0 or later (AGPL-
 
 The AGPL's network-use clause (section 13) is deliberate: if you run a modified Clawker as a network service, you must offer its source to users of that service. This keeps Clawker free and open — for learning from and building on, not for closed SaaS wrappers.
 
+**Commercial licensing.** Don't want the AGPL's copyleft and network-use obligations — for example, to embed Clawker in a closed-source product or service? A commercial license is available. Contact andrew@ajschmitt.io.
+
+**Contributing.** Contributions are accepted under a Contributor License Agreement ([CLA.md](CLA.md)): you keep your copyright, your work is published under the AGPL, and you grant the maintainer the right to also offer it under a commercial license. This is what keeps dual-licensing possible.
+
 > I feel obligated to state this... **Clawker** is a portmanteau of Claude + Docker. The project was at first named `claucker`, but reading it, saying it, and especially typing it always felt awkward to my brain because it violates the phonetic rules of English. Before I was aware of the whole `clawdbot` `openclaw` `clawthis` `clawthat` naming craze, I changed it to be the "correct" phonetic spelling, `clawker`, purely because it just rolls off the fingers when typing it. For those reasons I'm not going to change the name, but I want to make it clear the decision wasn't to chase a trend and this has no relation to openclaw.  

--- a/README.md
+++ b/README.md
@@ -423,6 +423,8 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 Clawker is free software: GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later) — see [LICENSE](LICENSE).
 
+One subproject is the exception: the `claude-plugin/clawker-support/` plugin is licensed separately under the MIT License — see [its LICENSE](claude-plugin/clawker-support/LICENSE). Everything else in this repository is AGPL-3.0-or-later as described below.
+
 The AGPL's network-use clause (section 13) is deliberate: if you run a modified Clawker as a network service, you must offer its source to users of that service. This keeps Clawker free and open — for learning from and building on, not for closed SaaS wrappers.
 
 **Commercial licensing.** Don't want the AGPL's copyleft and network-use obligations — for example, to embed Clawker in a closed-source product or service? A commercial license is available. Contact andrew@ajschmitt.io.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://golang.org"><img src="https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go" alt="Go"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL%20v3-blue.svg" alt="License"></a>
   <a href="https://deepwiki.com/schmitthub/clawker"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   <a href="#"><img src="https://img.shields.io/badge/Platform-macOS-lightgrey?logo=apple" alt="macOS"></a>
   <a href="#"><img src="https://img.shields.io/badge/Platform-Linux-4DA3FF?logo=linux&logoColor=fff&labelColor=0057B8" alt="Linux"></a>
@@ -421,6 +421,8 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+Clawker is free software: GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later) — see [LICENSE](LICENSE).
+
+The AGPL's network-use clause (section 13) is deliberate: if you run a modified Clawker as a network service, you must offer its source to users of that service. This keeps Clawker free and open — for learning from and building on, not for closed SaaS wrappers.
 
 > I feel obligated to state this... **Clawker** is a portmanteau of Claude + Docker. The project was at first named `claucker`, but reading it, saying it, and especially typing it always felt awkward to my brain because it violates the phonetic rules of English. Before I was aware of the whole `clawdbot` `openclaw` `clawthis` `clawthat` naming craze, I changed it to be the "correct" phonetic spelling, `clawker`, purely because it just rolls off the fingers when typing it. For those reasons I'm not going to change the name, but I want to make it clear the decision wasn't to chase a trend and this has no relation to openclaw.  

--- a/claude-plugin/CLAUDE.md
+++ b/claude-plugin/CLAUDE.md
@@ -18,7 +18,8 @@ the Claude Code plugin and skill authoring conventions:
   are loaded by skill agents during execution. They teach methodology — they
   are not executed, compiled, or parsed programmatically.
 - **plugin.json is the package manifest.** It follows the Claude Code plugin
-  spec (`name`, `description`, `version`, `author`, `repository`, `homepage`).
+  spec (`name`, `description`, `version`, `author`, `license`, `repository`,
+  `homepage`).
 - Consult `https://docs.claude.com/en/docs/claude-code/plugins` for the
   current plugin and skill authoring standards when making structural changes.
 

--- a/claude-plugin/clawker-support/.claude-plugin/plugin.json
+++ b/claude-plugin/clawker-support/.claude-plugin/plugin.json
@@ -1,10 +1,11 @@
 {
   "name": "clawker-support",
   "description": "Clawker support expert for setup, configuration, and troubleshooting",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": {
     "name": "schmitthub"
   },
+  "license": "MIT",
   "repository": "https://github.com/schmitthub/clawker",
   "homepage": "https://docs.clawker.dev"
 }

--- a/internal/controlplane/firewall/ebpf/bpf/clawker.c
+++ b/internal/controlplane/firewall/ebpf/bpf/clawker.c
@@ -5,8 +5,8 @@
 // bpf_map_lookup_elem, cgroup sock_addr redirection, etc.) behind a GPL
 // license declaration — setting `_license[] = "GPL"` at the bottom of this
 // file is a runtime requirement enforced by the verifier when loading on any
-// production kernel. The rest of the clawker repository remains under the
-// MIT license. The resulting .o object file is loaded into the kernel at
+// production kernel. The rest of the clawker repository is licensed under
+// AGPL-3.0-or-later. The resulting .o object file is loaded into the kernel at
 // runtime via cilium/ebpf; it is not statically linked into the Go binary.
 //
 // clawker.c — All clawker eBPF programs in a single compilation unit.

--- a/internal/controlplane/firewall/ebpf/bpf/common.h
+++ b/internal/controlplane/firewall/ebpf/bpf/common.h
@@ -2,7 +2,8 @@
 //
 // GPL-2.0 is required here (see clawker.c licensing note) because the BPF
 // helpers invoked from files that #include this header are kernel-gated to
-// GPL-licensed programs. The rest of the clawker repository is MIT-licensed.
+// GPL-licensed programs. This compilation unit stays GPL-2.0 for that kernel
+// requirement; the rest of the clawker repository is AGPL-3.0-or-later.
 //
 // common.h — Shared types, maps, and routing helpers for clawker eBPF
 // programs.

--- a/internal/controlplane/firewall/ebpf/bpf/common.h
+++ b/internal/controlplane/firewall/ebpf/bpf/common.h
@@ -2,8 +2,9 @@
 //
 // GPL-2.0 is required here (see clawker.c licensing note) because the BPF
 // helpers invoked from files that #include this header are kernel-gated to
-// GPL-licensed programs. This compilation unit stays GPL-2.0 for that kernel
-// requirement; the rest of the clawker repository is AGPL-3.0-or-later.
+// GPL-licensed programs. This header is GPL-2.0 so the programs that include
+// it satisfy that kernel requirement; the rest of the clawker repository is
+// AGPL-3.0-or-later.
 //
 // common.h — Shared types, maps, and routing helpers for clawker eBPF
 // programs.


### PR DESCRIPTION
## Summary

Relicenses clawker from MIT to **AGPL-3.0-or-later** and adds the contributor-side machinery to keep **dual licensing** (AGPL for the public, commercial licenses on request) viable.

The AGPL's network-use clause (§13) is the deliberate lever: run a modified clawker as a network service and you must offer its source — keeping it free to learn from and build on, not to wrap into a closed SaaS. Dual licensing preserves the maintainer's ability to sell commercial exceptions to parties who don't want AGPL's copyleft.

## Changes

**License swap**
- `LICENSE` — MIT replaced with verbatim GNU AGPLv3 (662 lines).
- `README.md` — badge MIT→AGPL; new License section (AGPL rationale + commercial-licensing contact + Contributing/CLA notes).
- `CONTRIBUTING.md` — dual-license + CLA pointer.
- `.goreleaser.yaml` — homebrew cask `license: AGPL-3.0-or-later`.

**BPF GPL-2.0 carve-out (unchanged license, updated comments)**
- `internal/controlplane/firewall/ebpf/bpf/clawker.c`, `common.h` — keep `SPDX-License-Identifier: GPL-2.0` (the kernel verifier gates BPF helpers behind a GPL-compatible `_license[]` string; "AGPL" is not accepted). The `.o` is loaded into the kernel at runtime, not statically linked into the Go binary — GPL-2.0 BPF and AGPL userspace coexist by aggregation. Comments updated to say the rest of the repo is AGPL.

**Dual-licensing CLA**
- `CLA.md` (new) — license-not-assignment; contribution published outbound under AGPL; grant to maintainer to use/modify/sublicense/relicense under any terms incl. commercial; patent grant; right-to-grant representation; contributor retains copyright.
- `.github/workflows/cla.yml` (new) — `contributor-assistant/github-action` sign-by-comment CLA check. Upstream archived but functional; SHA-pinned to `v2.6.1`. Signatures stored on an unprotected `cla-signatures` branch. Verified against the action's v2.6.1 README (recheck trigger, `signatures/version1/cla.json`, permissions, unprotected-branch caveat).

## Dependency license audit

All deps are AGPL-3.0-compatible (Apache-2.0, MIT, BSD-2/3, MPL-2.0, ISC). No BSD-4-Clause/GPL/LGPL/CDDL/EPL/proprietary. MPL-2.0 §3.3 permits AGPL combination; Apache-2.0 is GPLv3/AGPLv3-compatible. No third-party attribution obligations change with the MIT→AGPL switch; `NOTICE` and `make licenses-check` unaffected.

## Intentionally MIT
`claude-plugin/clawker-support/` keeps its own MIT LICENSE — it's a shareable Claude Code skill, meant to be copied freely.

## Review

`/pr-review-toolkit:review-pr` (code-reviewer + comment-analyzer) run; all actionable findings fixed (runner pin, pin-comment style, comment clarity). SPDX carve-out, SHA pin (= upstream v2.6.1 tag commit), workflow injection-safety, and CLA internal consistency verified.

## Follow-up (host-side, not in this PR — issue #379)
- Create the unprotected `cla-signatures` branch (must exist before first PR).
- Branch-protect `main`: require the `CLA Assistant` status check.
- Eventually fork the archived action so we own it (#379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)