### PR TITLE
fix(logger): caller-owned Close(ctx) flush deadline + CP signal-context shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ clawker CLI's "what's new" teaser renders the section bodies verbatim as
 markdown, and the release-notes workflow copies them into the GitHub release.
 Link to relevant docs inline in the bullets.
 
+## [0.12.6] - 2026-06-18
+
+- **Fixed:** CLI otel logger timeout blocking cli command exit for 5 seconds if monitoring was down. 
+
 ## [0.12.5] - 2026-06-17
 
 - **Fixed:** Agent prompt causing agents to forgo setting up branch upstream tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Link to relevant docs inline in the bullets.
 
 ## [0.12.6] - 2026-06-18
 
-- **Fixed:** CLI otel logger timeout blocking cli command exit for 5 seconds if monitoring was down. 
+- **Fixed:** CLI OTEL logger no longer blocks command exit for up to 5 seconds when monitoring is down. 
 
 ## [0.12.5] - 2026-06-17
 

--- a/cmd/clawker-cp/main.go
+++ b/cmd/clawker-cp/main.go
@@ -270,7 +270,18 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 	// flush is bounded by the OTLP SDK export timeout and the supervisor's
 	// SIGKILL grace, not an invented deadline.
 	ctx := context.Background()
-	defer log.Close(ctx)
+	defer func() {
+		// Surface a Close failure on stderr (→ docker logs), NOT into retErr.
+		// The OTEL mirror is non-fatal/self-healing by design (an unreachable
+		// collector is expected, not a teardown fault), and CP's exit code is a
+		// teardown-integrity signal — poisoning it would trip the on-failure
+		// restart policy on a benign telemetry outage. stderr also survives the
+		// logger itself closing here, unlike a log.Error() that races its own
+		// shutdown. Mirrors clawkerd's logger-close handling.
+		if cErr := log.Close(ctx); cErr != nil {
+			fmt.Fprintf(os.Stderr, "%s: logger close failed: %v\n", consts.ContainerCP, cErr)
+		}
+	}()
 	log.Info().Msg("starting")
 
 	// Wire the real logger into the Service now that logger.New has

--- a/cmd/clawker-cp/main.go
+++ b/cmd/clawker-cp/main.go
@@ -263,7 +263,14 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 		fmt.Fprintf(os.Stderr, "%s: warning: file logging unavailable (%v), using stderr only\n", consts.ContainerCP, err)
 	}
 	log = log.With("component", consts.ContainerCP)
-	defer log.Close()
+	// Base context for the run, and the parent of signalCtx below. log.Close
+	// rides the base (not signalCtx) so the final flush survives the very signal
+	// that triggers shutdown; idempotent + deferred, it covers every arm where
+	// run returns (signal, drain-to-zero, subprocess-crash, startup error). The
+	// flush is bounded by the OTLP SDK export timeout and the supervisor's
+	// SIGKILL grace, not an invented deadline.
+	ctx := context.Background()
+	defer log.Close(ctx)
 	log.Info().Msg("starting")
 
 	// Wire the real logger into the Service now that logger.New has
@@ -333,8 +340,12 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 		return fmt.Errorf("hydra: %w", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Signal-aware context for startup + serve, forked off the base. SIGTERM is
+	// the `docker stop` path (CP is PID 1 of the controlplane container); SIGINT
+	// covers manual/dev runs. SIGKILL is absent by necessity — it cannot be
+	// caught and is the supervisor's hard backstop.
+	signalCtx, signalStop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
+	defer signalStop()
 
 	// Build CLI CA cert pool — used for health checks, Hydra introspection,
 	// client registration, and mTLS client cert verification.
@@ -352,13 +363,13 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 		MinVersion: tls.VersionTLS13,
 	}
 
-	if err := subMgr.WaitHealthy(ctx, "kratos", controlplane.HealthCheck{
+	if err := subMgr.WaitHealthy(signalCtx, "kratos", controlplane.HealthCheck{
 		URL: fmt.Sprintf("https://"+consts.Localhost+":%d/health/alive", cp.KratosPublicPort), Interval: healthCheckInterval, Timeout: healthCheckTimeout,
 		TLS: caTLS,
 	}); err != nil {
 		return fmt.Errorf("kratos health: %w", err)
 	}
-	if err := subMgr.WaitHealthy(ctx, "hydra", controlplane.HealthCheck{
+	if err := subMgr.WaitHealthy(signalCtx, "hydra", controlplane.HealthCheck{
 		URL: fmt.Sprintf("https://"+consts.Localhost+":%d/health/alive", cp.HydraPublicPort), Interval: healthCheckInterval, Timeout: healthCheckTimeout,
 		TLS: caTLS,
 	}); err != nil {
@@ -368,7 +379,7 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 	// The public health check above confirms the public listener is ready,
 	// but client registration goes to the admin port — a separate listener
 	// that may take longer under resource pressure. Wait for it explicitly.
-	if err := subMgr.WaitHealthy(ctx, "hydra", controlplane.HealthCheck{
+	if err := subMgr.WaitHealthy(signalCtx, "hydra", controlplane.HealthCheck{
 		URL: fmt.Sprintf("https://"+consts.Localhost+":%d/health/alive", cp.HydraAdminPort), Interval: healthCheckInterval, Timeout: healthCheckTimeout,
 		TLS: caTLS,
 	}); err != nil {
@@ -388,10 +399,10 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 	// See controlplane.RegisterAgentClient for why both clients share
 	// one JWK with distinct client_id + scope.
 	hydraAdminURL := fmt.Sprintf("https://"+consts.Localhost+":%d", cp.HydraAdminPort)
-	if err := controlplane.RegisterCLIClient(ctx, hydraAdminURL, jwkData, caTLS); err != nil {
+	if err := controlplane.RegisterCLIClient(signalCtx, hydraAdminURL, jwkData, caTLS); err != nil {
 		return fmt.Errorf("register CLI client: %w", err)
 	}
-	if err := controlplane.RegisterAgentClient(ctx, hydraAdminURL, jwkData, caTLS); err != nil {
+	if err := controlplane.RegisterAgentClient(signalCtx, hydraAdminURL, jwkData, caTLS); err != nil {
 		return fmt.Errorf("register agent client: %w", err)
 	}
 	log.Info().Msg("CLI + agent clients registered with Hydra")
@@ -409,7 +420,7 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 	// Docker client. Used by the container resolver (bypass
 	// dead-man timer), the firewall stack (Envoy + CoreDNS sibling
 	// containers over DooD), and the AgentWatcher poll loop.
-	dockerCli, err := docker.NewClient(ctx, cfg, log)
+	dockerCli, err := docker.NewClient(signalCtx, cfg, log)
 	if err != nil {
 		return fmt.Errorf("docker client: %w", err)
 	}
@@ -419,7 +430,7 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 	// cgroup paths come from firewall.EBPFCgroupPath in the firewall
 	// subpackage — the single source of truth for the systemd/cgroupfs
 	// path formats.
-	cgroupDriver, err := fwhandler.DetectCgroupDriver(ctx, dockerCli)
+	cgroupDriver, err := fwhandler.DetectCgroupDriver(signalCtx, dockerCli)
 	if err != nil {
 		return fmt.Errorf("cgroup driver: %w", err)
 	}
@@ -1285,12 +1296,9 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 
 	log.Info().Msg("clawker-cp ready")
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
-
 	select {
-	case sig := <-sigCh:
-		log.Info().Stringer("signal", sig).Msg("shutdown signal received")
+	case <-signalCtx.Done():
+		log.Info().Msg("shutdown signal received")
 		// Any subprocess exit past this point is part of graceful shutdown;
 		// suppress crash reporting so it doesn't race with us.
 		subMgr.BeginShutdown()

--- a/cmd/clawker-cp/main.go
+++ b/cmd/clawker-cp/main.go
@@ -358,6 +358,15 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 	signalCtx, signalStop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer signalStop()
 
+	// signalCtx drives cancellation but does not expose which signal fired.
+	// Keep a parallel buffered channel solely to record the signal value for the
+	// shutdown log line (and to disambiguate the teardown-failure message between
+	// SIGTERM/`docker stop` and SIGINT/Ctrl-C). Buffered(1) so delivery never
+	// blocks; cancellation is still owned by signalCtx.
+	sigValueCh := make(chan os.Signal, 1)
+	signal.Notify(sigValueCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigValueCh)
+
 	// Build CLI CA cert pool — used for health checks, Hydra introspection,
 	// client registration, and mTLS client cert verification.
 	caCertPEM, err := os.ReadFile(caCertPath)
@@ -1309,7 +1318,19 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 
 	select {
 	case <-signalCtx.Done():
-		log.Info().Msg("shutdown signal received")
+		// signalCtx fired because a signal was delivered, so the value is
+		// already queued on sigValueCh; read it non-blocking (default guards
+		// against any theoretical stall). nil only in that guard case.
+		var sig os.Signal
+		select {
+		case sig = <-sigValueCh:
+		default:
+		}
+		shutdownLog := log.Info()
+		if sig != nil {
+			shutdownLog = shutdownLog.Stringer("signal", sig)
+		}
+		shutdownLog.Msg("shutdown signal received")
 		// Any subprocess exit past this point is part of graceful shutdown;
 		// suppress crash reporting so it doesn't race with us.
 		subMgr.BeginShutdown()
@@ -1324,7 +1345,14 @@ func run(caCertPath, serverCertPath, serverKeyPath, jwkPath, logDir string) (ret
 		// containers and stale BPF map state.
 		teardownCtx, teardownCancel := context.WithTimeout(context.Background(), cpDrainTimeout)
 		if err := drainCallback(teardownCtx); err != nil {
-			log.Error().Err(err).Msg("sigterm teardown failed")
+			// Generic message + the signal as a structured field: this arm
+			// fires on SIGTERM (docker stop) or SIGINT (Ctrl-C), so a
+			// hardcoded "sigterm" would misattribute a Ctrl-C teardown.
+			teardownLog := log.Error().Err(err)
+			if sig != nil {
+				teardownLog = teardownLog.Stringer("signal", sig)
+			}
+			teardownLog.Msg("shutdown teardown failed")
 		}
 		teardownCancel()
 	case err := <-watcherDone:

--- a/cmd/clawkerd/main.go
+++ b/cmd/clawkerd/main.go
@@ -124,7 +124,7 @@ func main() {
 	} else {
 		log.Info().Int("exit_code", exitCode).Str("event", "shutdown").Msg("clawkerd exiting")
 	}
-	if err := log.Close(); err != nil {
+	if err := log.Close(context.Background()); err != nil {
 		// Fallback to stderr because the logger itself is what's
 		// closing — any zerolog-routed surface is unreliable here.
 		fmt.Fprintf(os.Stderr, "clawkerd: logger close failed: %v\n", err)

--- a/internal/clawker/CLAUDE.md
+++ b/internal/clawker/CLAUDE.md
@@ -13,7 +13,7 @@ func Main() int     // Entry point: builds root command via internal/cmd/root, e
 
 Called from `cmd/clawker/main.go`. Build metadata (version, date) lives in `internal/build` — this package reads it at the top of `Main()` and passes the version string to `factory.New()`.
 
-After Factory construction, `Main()` calls `storage.ValidateDirectories()` to fail fast if XDG directories collide (e.g. `CLAWKER_DATA_DIR == CLAWKER_CONFIG_DIR`) before any file I/O. On exit, a deferred `f.Logger().Close()` flushes zerolog file output and shuts down the OTEL provider.
+After Factory construction, `Main()` calls `storage.ValidateDirectories()` to fail fast if XDG directories collide (e.g. `CLAWKER_DATA_DIR == CLAWKER_CONFIG_DIR`) before any file I/O. On exit, a deferred `f.Logger().Close(ctx)` flushes zerolog file output and shuts down the OTEL provider. The flush context is canceled before the deferred Close runs, so a short-lived command never blocks its exit on a final OTEL export — every record is already durable in the file, and the OTEL batch rides the export interval during the run.
 
 All symbols are in `cmd.go` (`Main`, `notificationsSuppressed`, `printUpdateNotification`, `printChangelogTeaser`, `printDockerInstallHelper`, `printError`, `userFormattedError` duck-type interface).
 

--- a/internal/clawker/cmd.go
+++ b/internal/clawker/cmd.go
@@ -42,15 +42,6 @@ func Main() int {
 		return 1
 	}
 
-	// Ensure logs and OTEL provider are flushed on exit.
-	// TODO: give logger a Shutdown(ctx) for bounded flush (ctx as flush deadline,
-	// not a replacement for Close).
-	defer func() {
-		if log, err := f.Logger(); err == nil {
-			log.Close()
-		}
-	}()
-
 	// CLI runtime state (the update-check cache + changelog cursor) is resolved
 	// lazily inside checkForUpdate/checkForChanges via f.CLIState(). A state-store
 	// error there aborts that one background check and is logged to the file log,
@@ -162,6 +153,22 @@ func Main() int {
 	defer signalStop()
 	rootCmd.SetContext(signalCtx)
 
+	// Flush buffered logs + the OTEL provider on exit. loggerCtx is a child of the
+	// signal context, and loggerCancel() is called below (before draining the
+	// notifications) once the command has returned — so the deferred Close always
+	// runs with an already-canceled context and never does a blocking final
+	// export. A short-lived command must not block its own exit on an unreachable
+	// collector; every record is already durable in the file, and the OTEL batch
+	// rides the export interval during the run. A Ctrl+C cancels signalCtx, which
+	// tears the flush down the same way.
+	loggerCtx, loggerCancel := context.WithCancel(signalCtx)
+	defer loggerCancel()
+	defer func() {
+		if log, err := f.Logger(); err == nil {
+			_ = log.Close(loggerCtx)
+		}
+	}()
+
 	cmd, err := rootCmd.ExecuteC()
 
 	// gh CLI pattern: cancel the background checks now, before draining their
@@ -174,6 +181,10 @@ func Main() int {
 	// never reach here (e.g. root command creation failing).
 	updateCancel()
 	changelogCancel()
+	// Cancel the logger context now that the command has returned, so the
+	// deferred Close above unwinds its OTEL shutdown immediately instead of
+	// blocking exit on a final export.
+	loggerCancel()
 
 	// drainNotifications blocks on both channels (only when goroutines were
 	// launched) and renders both notifications. printUpdateNotification and

--- a/internal/cmd/bridge/bridge.go
+++ b/internal/cmd/bridge/bridge.go
@@ -65,7 +65,7 @@ func NewCmdBridgeServe() *cobra.Command {
 						Filename: fmt.Sprintf("bridge-%s.log", containerID[:12]),
 					}); lErr == nil {
 						log = l
-						defer log.Close()
+						defer log.Close(context.Background())
 					}
 				}
 			}

--- a/internal/cmd/hostproxy/serve.go
+++ b/internal/cmd/hostproxy/serve.go
@@ -42,7 +42,7 @@ func NewCmdServe() *cobra.Command {
 			if logsDir, dirErr := cfg.LogsSubdir(); dirErr == nil {
 				if l, lErr := logger.New(logger.Options{LogsDir: logsDir, Filename: "hostproxy.log"}); lErr == nil {
 					log = l
-					defer l.Close()
+					defer l.Close(context.Background())
 				}
 			}
 

--- a/internal/controlplane/subprocess.go
+++ b/internal/controlplane/subprocess.go
@@ -157,13 +157,18 @@ func (m *SubprocessManager) WaitHealthy(ctx context.Context, name string, check 
 
 		select {
 		case <-ctx.Done():
-			// Distinguish the caller's context being canceled (e.g. a shutdown
-			// signal propagated through the parent context) from this check's
-			// own health-timeout deadline. WithTimeout(ctx, check.Timeout) at
-			// the top means ctx.Done() fires for both; reporting a parent
-			// cancellation as a phantom "did not become healthy within N"
-			// latency failure sends an operator chasing a startup problem that
-			// never existed.
+			// A parent *cancellation* (e.g. a SIGTERM/SIGINT shutdown propagated
+			// through the caller's context) surfaces as context.Canceled; report
+			// it as canceled, not as a phantom "did not become healthy within N"
+			// latency failure that would send an operator chasing a startup
+			// problem that never existed. Any *deadline* — including the
+			// WithTimeout(ctx, check.Timeout) installed at the top — surfaces as
+			// DeadlineExceeded and is reported as the health timeout. Callers
+			// pass a deadline-free context (CP uses signal.NotifyContext over
+			// context.Background), so the only deadline in play is this check's
+			// own; a caller that ever passes a deadline-bearing context would
+			// have it attributed here to the health timeout — revisit this
+			// branch (compare the parent ctx error) if that case is introduced.
 			if errors.Is(ctx.Err(), context.Canceled) {
 				return fmt.Errorf("subprocess %s health wait canceled: %w", name, ctx.Err())
 			}

--- a/internal/controlplane/subprocess.go
+++ b/internal/controlplane/subprocess.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -156,6 +157,16 @@ func (m *SubprocessManager) WaitHealthy(ctx context.Context, name string, check 
 
 		select {
 		case <-ctx.Done():
+			// Distinguish the caller's context being canceled (e.g. a shutdown
+			// signal propagated through the parent context) from this check's
+			// own health-timeout deadline. WithTimeout(ctx, check.Timeout) at
+			// the top means ctx.Done() fires for both; reporting a parent
+			// cancellation as a phantom "did not become healthy within N"
+			// latency failure sends an operator chasing a startup problem that
+			// never existed.
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return fmt.Errorf("subprocess %s health wait canceled: %w", name, ctx.Err())
+			}
 			return fmt.Errorf("subprocess %s did not become healthy within %s", name, check.Timeout)
 		case <-ticker.C:
 		}

--- a/internal/logger/CLAUDE.md
+++ b/internal/logger/CLAUDE.md
@@ -138,7 +138,7 @@ func (l *Logger) LogFilePath() string      // log file path (empty for Nop)
 ### Lifecycle
 
 ```go
-func (l *Logger) Close() error  // flush OTEL + close file writer; safe to call multiple times
+func (l *Logger) Close(ctx context.Context) error  // flush OTEL (caller's ctx is the flush deadline; a canceled/expired ctx unwinds the export immediately) + close file writer; safe to call multiple times
 ```
 
 ## Factory Integration

--- a/internal/logger/CLAUDE.md
+++ b/internal/logger/CLAUDE.md
@@ -138,7 +138,7 @@ func (l *Logger) LogFilePath() string      // log file path (empty for Nop)
 ### Lifecycle
 
 ```go
-func (l *Logger) Close(ctx context.Context) error  // flush OTEL (caller's ctx is the flush deadline; a canceled/expired ctx unwinds the export immediately) + close file writer; safe to call multiple times
+func (l *Logger) Close(ctx context.Context) error  // flush OTEL (ctx is the flush deadline — a canceled/expired ctx unwinds the export immediately) + close file writer; returns the true shutdown outcome (does NOT swallow ctx errors — the caller interprets a cancellation it requested); safe to call multiple times
 ```
 
 ## Factory Integration

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -298,7 +299,7 @@ func (l *Logger) LogFilePath() string {
 
 // Close flushes pending OTEL batches and closes the file writer.
 // Safe to call multiple times. Safe to call on a Nop logger.
-func (l *Logger) Close() error {
+func (l *Logger) Close(ctx context.Context) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -307,23 +308,33 @@ func (l *Logger) Close() error {
 	}
 	l.closed = true
 
-	var firstErr error
+	var provErr, fwErr error
 
 	if l.provider != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := l.provider.Shutdown(ctx); err != nil {
-			firstErr = fmt.Errorf("logger: shutdown OTEL provider: %w", err)
+		// Pass the caller's context straight through. The final synchronous
+		// export honors it, so a canceled or expired context unwinds the export
+		// (and the exporter's retry backoff) immediately rather than blocking on
+		// an unreachable collector — the caller owns the shutdown deadline. On a
+		// still-live context the bound is OtelOptions.Timeout when set, else the
+		// OTLP SDK's own default export timeout.
+		//
+		// A canceled/expired context is the intended CLI shutdown path (it
+		// cancels before this runs), so context.Canceled/DeadlineExceeded is the
+		// expected outcome here, not a failure — drop it instead of reporting it
+		// as a Close error that would mask the file-writer result below.
+		if err := l.provider.Shutdown(ctx); err != nil &&
+			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			provErr = fmt.Errorf("logger: shutdown OTEL provider: %w", err)
 		}
 	}
 
 	if l.fw != nil {
-		if err := l.fw.Close(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("logger: close file writer: %w", err)
+		if err := l.fw.Close(); err != nil {
+			fwErr = fmt.Errorf("logger: close file writer: %w", err)
 		}
 	}
 
-	return firstErr
+	return errors.Join(provErr, fwErr)
 }
 
 // absorbingWriter forwards writes to an inner writer but always

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -311,19 +311,14 @@ func (l *Logger) Close(ctx context.Context) error {
 	var provErr, fwErr error
 
 	if l.provider != nil {
-		// Pass the caller's context straight through. The final synchronous
-		// export honors it, so a canceled or expired context unwinds the export
-		// (and the exporter's retry backoff) immediately rather than blocking on
-		// an unreachable collector — the caller owns the shutdown deadline. On a
-		// still-live context the bound is OtelOptions.Timeout when set, else the
-		// OTLP SDK's own default export timeout.
-		//
-		// A canceled/expired context is the intended CLI shutdown path (it
-		// cancels before this runs), so context.Canceled/DeadlineExceeded is the
-		// expected outcome here, not a failure — drop it instead of reporting it
-		// as a Close error that would mask the file-writer result below.
-		if err := l.provider.Shutdown(ctx); err != nil &&
-			!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		// ctx is the flush deadline. Shutdown honors it: a canceled or expired
+		// ctx unwinds the final export (and the exporter's retry backoff) at once
+		// rather than blocking on an unreachable collector. With a live ctx the
+		// bound is OtelOptions.Timeout when set, else the OTLP SDK default export
+		// timeout. Whatever Shutdown returns is the true outcome of the close —
+		// report it. Interpreting a ctx cancellation it requested (e.g. a caller
+		// that cancels for a fast exit) is the caller's job, not the logger's.
+		if err := l.provider.Shutdown(ctx); err != nil {
 			provErr = fmt.Errorf("logger: shutdown OTEL provider: %w", err)
 		}
 	}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,7 +20,7 @@ func TestNew_WritesToFile(t *testing.T) {
 	}
 
 	l.Info().Msg("hello from test")
-	l.Close()
+	l.Close(context.Background())
 
 	content, err := os.ReadFile(filepath.Join(dir, "clawker.log"))
 	if err != nil {
@@ -42,7 +43,7 @@ func TestNew_AllLevels(t *testing.T) {
 	l.Info().Msg("i")
 	l.Warn().Msg("w")
 	l.Error().Msg("e")
-	l.Close()
+	l.Close(context.Background())
 
 	content, err := os.ReadFile(filepath.Join(dir, "clawker.log"))
 	if err != nil {
@@ -79,7 +80,7 @@ func TestNew_Compress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
-	defer l.Close()
+	defer l.Close(context.Background())
 
 	if l.fw == nil {
 		t.Fatal("file writer should not be nil")
@@ -102,7 +103,7 @@ func TestNop(t *testing.T) {
 		t.Error("Nop logger should have empty log file path")
 	}
 
-	if err := l.Close(); err != nil {
+	if err := l.Close(context.Background()); err != nil {
 		t.Errorf("Nop Close should not error: %v", err)
 	}
 }
@@ -117,7 +118,7 @@ func TestWith(t *testing.T) {
 
 	sub := l.With("project", "foo", "agent", "bar")
 	sub.Info().Msg("with context")
-	l.Close()
+	l.Close(context.Background())
 
 	content, err := os.ReadFile(filepath.Join(dir, "clawker.log"))
 	if err != nil {
@@ -154,7 +155,7 @@ func TestLogFilePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
-	defer l.Close()
+	defer l.Close(context.Background())
 
 	want := filepath.Join(dir, "clawker.log")
 	if got := l.LogFilePath(); got != want {
@@ -170,10 +171,10 @@ func TestClose_Idempotent(t *testing.T) {
 		t.Fatalf("New failed: %v", err)
 	}
 
-	if err := l.Close(); err != nil {
+	if err := l.Close(context.Background()); err != nil {
 		t.Errorf("first Close: %v", err)
 	}
-	if err := l.Close(); err != nil {
+	if err := l.Close(context.Background()); err != nil {
 		t.Errorf("second Close: %v", err)
 	}
 }
@@ -221,7 +222,7 @@ func TestNew_NoStderrOutput(t *testing.T) {
 	}
 	l.Info().Msg("should not appear on stderr")
 	l.Warn().Msg("also not on stderr")
-	l.Close()
+	l.Close(context.Background())
 
 	w.Close()
 	os.Stderr = oldStderr
@@ -256,7 +257,7 @@ func TestNew_EchoStdout_MirrorsRecords(t *testing.T) {
 		t.Fatalf("New failed: %v", err)
 	}
 	l.Info().Str("event", "ready").Msg("clawker-cp ready")
-	l.Close()
+	l.Close(context.Background())
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -294,7 +295,7 @@ func TestNew_EchoStdoutOff_KeepsStdoutQuiet(t *testing.T) {
 		t.Fatalf("New failed: %v", err)
 	}
 	l.Info().Msg("should not appear on stdout")
-	l.Close()
+	l.Close(context.Background())
 
 	w.Close()
 	os.Stdout = oldStdout
@@ -318,6 +319,7 @@ func TestNew_OtelFallback(t *testing.T) {
 		Otel: &OtelOptions{
 			Endpoint:       consts.Localhost + ":19876",
 			Insecure:       true,
+			Timeout:        50 * time.Millisecond,
 			ExportInterval: 50 * time.Millisecond,
 			MaxQueueSize:   10,
 		},
@@ -325,7 +327,99 @@ func TestNew_OtelFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New with OTEL should not fail: %v", err)
 	}
-	defer l.Close()
+	defer l.Close(context.Background())
 
 	l.Info().Msg("otel fallback test")
+}
+
+// TestClose_CanceledContext_ReturnsPromptly pins the exit-lag fix: Close must
+// honor a canceled caller context so the final OTEL flush unwinds immediately
+// instead of blocking on an unreachable collector. The CLI relies on exactly
+// this — it cancels the flush context when the command returns, so the deferred
+// Close never does a blocking final export. Before the fix Close ignored the
+// caller context entirely (hardcoded 5s context.Background()), so cancellation
+// could not stop the ~5s block; the blocking shutdown path had no coverage.
+func TestClose_CanceledContext_ReturnsPromptly(t *testing.T) {
+	dir := t.TempDir()
+
+	l, err := New(Options{
+		LogsDir:   dir,
+		MaxSizeMB: 1,
+		Otel: &OtelOptions{
+			// Nothing listens here: with a live context the final export
+			// would retry against the unreachable endpoint until the export
+			// timeout. A canceled context must short-circuit that.
+			Endpoint: consts.Localhost + ":19876",
+			Insecure: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New with OTEL should not fail: %v", err)
+	}
+	if l.provider == nil {
+		t.Fatal("OTEL provider must be wired for this test to exercise the flush path")
+	}
+
+	l.Info().Msg("buffered record awaiting export")
+
+	// Mirror the CLI: the flush context is already canceled by the time Close
+	// runs (loggerCancel() fires before the deferred Close).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_ = l.Close(ctx)
+	elapsed := time.Since(start)
+
+	// A canceled context unwinds Shutdown's export immediately. The regressed
+	// behavior ignored the context and blocked ~5s on the export timeout. The
+	// 2s threshold sits well clear of both, so the test is fast and not flaky.
+	if elapsed >= 2*time.Second {
+		t.Errorf("Close blocked %v on a canceled context; the flush must unwind immediately", elapsed)
+	}
+}
+
+// TestClose_LiveContext_BoundedByExportTimeout pins the daemon shutdown path,
+// the symmetric partner to the canceled-context test. clawker-cp passes a live
+// (never-canceled) base context to Close, so a final flush against an
+// unreachable collector must be bounded by the exporter's own export timeout
+// (OtelOptions.Timeout), not ride the OTLP retry backoff (~1m MaxElapsedTime).
+// Without WithTimeout wired from OtelOptions.Timeout in newOtelProvider, this
+// blocks for tens of seconds — so the assertion goes red if that wiring
+// regresses.
+func TestClose_LiveContext_BoundedByExportTimeout(t *testing.T) {
+	dir := t.TempDir()
+
+	l, err := New(Options{
+		LogsDir:   dir,
+		MaxSizeMB: 1,
+		Otel: &OtelOptions{
+			// Unreachable endpoint + a short export timeout: the final flush
+			// must give up at the timeout, not ride the retry backoff.
+			Endpoint: consts.Localhost + ":19876",
+			Insecure: true,
+			Timeout:  100 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("New with OTEL should not fail: %v", err)
+	}
+	if l.provider == nil {
+		t.Fatal("OTEL provider must be wired for this test to exercise the flush path")
+	}
+
+	l.Info().Msg("buffered record awaiting export")
+
+	// Live context — never canceled, mirroring clawker-cp's deferred
+	// log.Close(ctx) on the base background context.
+	start := time.Now()
+	_ = l.Close(context.Background())
+	elapsed := time.Since(start)
+
+	// The 100ms export timeout bounds the final flush. The 2s threshold sits
+	// well clear of it yet far under the ~1m retry MaxElapsedTime the unbounded
+	// path would block for — fast and not flaky.
+	if elapsed >= 2*time.Second {
+		t.Errorf("Close blocked %v on a live context; OtelOptions.Timeout must bound the flush", elapsed)
+	}
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -413,7 +413,7 @@ func TestClose_LiveContext_BoundedByExportTimeout(t *testing.T) {
 	// Live context — never canceled, mirroring clawker-cp's deferred
 	// log.Close(ctx) on the base background context.
 	start := time.Now()
-	_ = l.Close(context.Background())
+	err = l.Close(context.Background())
 	elapsed := time.Since(start)
 
 	// The 100ms export timeout bounds the final flush. The 2s threshold sits
@@ -421,5 +421,13 @@ func TestClose_LiveContext_BoundedByExportTimeout(t *testing.T) {
 	// path would block for — fast and not flaky.
 	if elapsed >= 2*time.Second {
 		t.Errorf("Close blocked %v on a live context; OtelOptions.Timeout must bound the flush", elapsed)
+	}
+
+	// The export failure against the unreachable collector is the true outcome
+	// of the close and must surface — Close reports whatever Shutdown returns
+	// and no longer swallows context errors. Goes red if the suppression is
+	// reintroduced (which would hide a real daemon-path export failure).
+	if err == nil {
+		t.Error("Close returned nil on a live context with an unreachable collector; the export-timeout failure must surface")
 	}
 }


### PR DESCRIPTION
## What

`Logger.Close()` gains a `context.Context` parameter, passed straight to `provider.Shutdown(ctx)` in place of a hardcoded 5s `context.WithTimeout`. The **caller owns the flush deadline**.

- **CLI** (`internal/clawker/cmd.go`): cancels its flush context before the deferred `Close`, so a short-lived command never blocks its exit on a final OTEL export. Every record is already durable in the file; the OTEL batch rides the export interval during the run.
- **Daemons**: pass a live context. The flush is bounded by the exporter's own `OtelOptions.Timeout` (or the OTLP SDK default when unset) and, for `clawker-cp`, the supervisor's SIGKILL grace — not an invented number.

## Why

The old hardcoded 5s was an arbitrary timeout standing in for a deadline the caller should own. Background-with-fixed-timeout couldn't distinguish "running normally" from "operator ran `docker stop` / Ctrl-C", and forced the CLI to eat up-to-5s of exit lag on an unreachable collector.

## Changes

- **`Logger.Close(ctx)`**: caller ctx is the flush deadline → passed straight to `provider.Shutdown(ctx)` (a canceled/expired ctx unwinds the export and its retry backoff immediately rather than blocking on an unreachable collector). Returns the **true** Shutdown outcome — wrapped and `errors.Join`'d with the file-writer close error, with **no** suppression (no first-wins masking). A returned `context.Canceled`/`DeadlineExceeded` is information, not a failure verdict: interpreting a cancellation it requested is the caller's job (the CLI cancels for a fast exit and discards the return; `clawkerd`/`clawker-cp` pass a live context, and `clawker-cp` surfaces a non-nil Close error to stderr without poisoning its exit code).
- **`clawker-cp` shutdown refactor**: `signal.NotifyContext(SIGTERM, SIGINT)` forked off a base `context.Background()` replaces the hand-rolled `sigCh` + `signal.Notify` + `context.WithCancel`. Startup/serve phase runs on the signal context (clean abort on signal mid-startup); deferred `log.Close` rides the base context so the final flush survives the triggering signal. SIGKILL intentionally absent (uncatchable backstop).
- **`SubprocessManager.WaitHealthy`**: distinguishes parent-context cancellation (shutdown signal) from its own health timeout — no more phantom "did not become healthy within N" on `docker stop` during boot.
- All `Close` callers migrated; `internal/logger/CLAUDE.md` + `internal/clawker/CLAUDE.md` updated.

## Tests

- `TestClose_CanceledContext_ReturnsPromptly` — canceled ctx unwinds the final export immediately (pins the exit-lag fix; goes red under the old hardcoded-5s behavior).
- `TestClose_LiveContext_BoundedByExportTimeout` — live ctx + short `OtelOptions.Timeout` bounds the flush against an unreachable collector (pins the daemon path; goes red if the `WithTimeout` wiring regresses).
- Existing logger tests migrated to `Close(ctx)`.
- `go build ./...`, `go vet`, and `internal/logger` / `cmd/clawker-cp` / `internal/controlplane` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
