### PR TITLE
fix(preset): Typescript preset pre-run npm install soft fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Link to relevant docs inline in the bullets.
 
 ## [0.12.8] - 2026-06-20
 
-- **Fixed:** TypeScript preset's `pre_run` script now tolerates `npm install` failures instead of exiting the container, which could happen on transient registry errors or if the project hasn't set up its dependencies yet.  
+- **Fixed:** TypeScript preset's `pre_run` script now tolerates `npm install` failures instead of exiting the container, which could happen on transient registry errors or if the project hasn't set up its dependencies yet.
 
 ## [0.12.7] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ clawker CLI's "what's new" teaser renders the section bodies verbatim as
 markdown, and the release-notes workflow copies them into the GitHub release.
 Link to relevant docs inline in the bullets.
 
+## [0.12.8] - 2026-06-20
+
+- **Fixed:** TypeScript preset's `pre_run` script now tolerates `npm install` failures instead of exiting the container, which could happen on transient registry errors or if the project hasn't set up its dependencies yet.  
+
 ## [0.12.7] - 2026-06-19
 
 ### **⚠ ACTION REQUIRED — rebuild all agent container images**
+
 > Run `clawker build` in every project after updating. Containers built before 
 > this release run an outdated internal runtime and will be stopped automatically; 
 > they will not work until rebuilt.

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -113,7 +113,9 @@ security:
 // layers on top.
 const typescriptPreset = `agent:
   pre_run: |
-    npm install || true
+    if [ -f package.json ]; then
+      npm install || echo "warning: npm install failed; continuing"
+    fi
 build:
   image: "buildpack-deps:bookworm-scm"
   packages:

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -113,7 +113,7 @@ security:
 // layers on top.
 const typescriptPreset = `agent:
   pre_run: |
-    npm install
+    npm install || true
 build:
   image: "buildpack-deps:bookworm-scm"
   packages:


### PR DESCRIPTION
Fixes a case when using the Typescript preset in a repository without npm packages configured yet resulting in boot failures. 