### PR TITLE
fix(build): bump linux-libc-dev pin to 6.8.0-136.136

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ BPF_APT_DEPS := \
     clang=1:18.0-59~exp2 \
     llvm=1:18.0-59~exp2 \
     libbpf-dev=1:1.3.0-2build2 \
-    linux-libc-dev=6.8.0-134.134
+    linux-libc-dev=6.8.0-136.136
 
 # Install the pinned BPF toolchain via apt. Requires Ubuntu 24.04 (Noble)
 # and root — versions pinned above only resolve against Noble's apt repos.


### PR DESCRIPTION
## Problem

Ubuntu published the `6.8.0-136.136` kernel security update to noble-updates/noble-security and dropped `6.8.0-134.134` from both the amd64 and arm64 archives. The exact-version pin in `BPF_APT_DEPS` no longer resolves — `make bpf-deps` fails with:

```
E: Version '6.8.0-134.134' for 'linux-libc-dev' was not found
```

CI is currently green only because GitHub runners resolve the lagging Azure apt mirror; every run breaks once that mirror syncs. Local `Dockerfile.controlplane` builds against the main archives fail now.

## Fix

Bump the pin to `6.8.0-136.136`. Verified the complete pinned set (clang, llvm, libbpf-dev, linux-libc-dev at exact versions) resolves via apt dry-run in fresh `ubuntu:24.04` containers on **both arm64 and amd64**. The other three pins are unchanged and still served by the archives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)