### PR TITLE
fix(env): give agent.env_file real dotenv semantics via vendored compose-go parser

### DIFF
--- a/.claude/docs/REPO-STRUCTURE.md
+++ b/.claude/docs/REPO-STRUCTURE.md
@@ -51,6 +51,8 @@ Reference map of the clawker repo. Lazy-loaded from root `CLAUDE.md`.
 │   ├── controlplane/          # CP daemon orchestrator (cmd.go): constructs pub/sub topics + domain state repos, wires handlers, runs startup/drain
 │   ├── dnsbpf/                # CoreDNS plugin for BPF dns_cache
 │   ├── docker/                # Docker middleware (wraps pkg/whail + bundler)
+│   ├── dotenv/                # .env parser, compose semantics (vendored from compose-go, MIT/Apache — see LICENSE files; logrus replaced with MissingFn reporting)
+│   │   └── template/          # ${VAR:-default} interpolation engine (vendored compose-go/template)
 │   ├── docs/                  # CLI doc generation
 │   ├── git/                   # Git operations, worktree management (leaf)
 │   ├── hostproxy/             # Host proxy for container-to-host communication

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,9 @@ repos:
         name: NOTICE freshness
         entry: make licenses-check
         language: system
-        files: ^go\.(mod|sum)$
+        # NOTICE derives from module deps AND in-repo LICENSE files
+        # (vendored code), so trigger on either changing.
+        files: ^go\.(mod|sum)$|(^|/)(LICENSE[^/]*|NOTICE[^/]*)$
         pass_filenames: false
 
       - id: claude-freshness

--- a/NOTICE
+++ b/NOTICE
@@ -58,6 +58,7 @@ github.com/prometheus/client_model/go                                          A
 github.com/prometheus/common                                                   Apache-2.0
 github.com/prometheus/exporter-toolkit/web                                     Apache-2.0
 github.com/prometheus/procfs                                                   Apache-2.0
+github.com/schmitthub/clawker/internal/dotenv/template                         Apache-2.0
 github.com/sethvargo/go-retry                                                  Apache-2.0
 github.com/shibumi/go-pathspec                                                 Apache-2.0
 github.com/spf13/cobra                                                         Apache-2.0
@@ -199,6 +200,7 @@ github.com/quic-go/qpack                                                       M
 github.com/quic-go/quic-go                                                     MIT
 github.com/rivo/uniseg                                                         MIT
 github.com/rs/zerolog                                                          MIT
+github.com/schmitthub/clawker/internal/dotenv                                  MIT
 github.com/secure-systems-lab/go-securesystemslib                              MIT
 github.com/sergi/go-diff/diffmatchpatch                                        MIT
 github.com/sirupsen/logrus                                                     MIT

--- a/internal/cmd/container/shared/agentenv.go
+++ b/internal/cmd/container/shared/agentenv.go
@@ -1,14 +1,15 @@
 package shared
 
 import (
-	"bufio"
 	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/schmitthub/clawker/internal/config"
+	"github.com/schmitthub/clawker/internal/dotenv"
 	"github.com/schmitthub/clawker/internal/logger"
 )
 
@@ -70,9 +71,17 @@ func applyEnvSpec(
 		if err != nil {
 			return nil, fmt.Errorf("%s.env_file %q: %w", scope, path, err)
 		}
-		fileEnv, err := parseEnvFile(resolved, log)
+		fileEnv, unsetVars, err := parseEnvFile(resolved, log)
 		if err != nil {
 			return nil, fmt.Errorf("%s.env_file %q: %w", scope, path, err)
+		}
+		for _, name := range unsetVars {
+			log.Debug().
+				Str("var", name).
+				Str("scope", scope).
+				Str("file", path).
+				Msg("env_file: referenced variable not set")
+			warnings = append(warnings, fmt.Sprintf("%s.env_file %q: variable %q is not set", scope, path, name))
 		}
 		maps.Copy(result, fileEnv)
 	}
@@ -97,35 +106,29 @@ func applyEnvSpec(
 // parseEnvFile reads an env file and returns key-value pairs.
 // Format: KEY=VALUE lines, # comments, blank lines skipped.
 // Bare KEY lines (no =) set the key to an empty string.
-func parseEnvFile(path string, log *logger.Logger) (map[string]string, error) {
+func parseEnvFile(path string, log *logger.Logger) (map[string]string, []string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, fmt.Errorf("opening env file: %w", err)
 	}
 	defer f.Close()
 
-	result := make(map[string]string)
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		key, value, hasEquals := strings.Cut(line, "=")
-		if key == "" {
-			continue
-		}
-		if hasEquals {
-			result[key] = value
-		} else {
-			result[key] = ""
-		}
+	// Host env is the lookup source: $VAR references unresolved within the
+	// file fall back to the host environment, and a bare `KEY` line inherits
+	// the host value (docker --env-file passthrough semantics; skipped when
+	// unset). References that resolve nowhere — after default/required
+	// operators apply — are collected so the caller can warn.
+	missed := make(map[string]struct{})
+	result, err := dotenv.ParseWithLookup(f, os.LookupEnv, func(name string) {
+		missed[name] = struct{}{}
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing env file: %w", err)
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
+
+	unsetVars := slices.Sorted(maps.Keys(missed))
 	log.Debug().Str("file", path).Int("count", len(result)).Msg("loaded env file")
-	return result, nil
+	return result, unsetVars, nil
 }
 
 // resolvePath expands a path using standard Unix conventions:

--- a/internal/cmd/container/shared/agentenv_test.go
+++ b/internal/cmd/container/shared/agentenv_test.go
@@ -131,3 +131,259 @@ func TestResolveAgentEnv_HarnessLayering(t *testing.T) {
 		assert.Contains(t, warnings[0], "agent.from_env")
 	})
 }
+
+// resolveEnvFile writes content to a .env file in an isolated temp dir and
+// resolves it through ResolveAgentEnv — the only public entry point over the
+// env-file parser. Returns the resolved env map.
+func resolveEnvFile(t *testing.T, content string) map[string]string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0o600))
+
+	agent := envAgentCfg([]string{".env"}, nil, nil)
+	got, _, err := shared.ResolveAgentEnv(agent, nil, "claude", dir, logger.Nop())
+	require.NoError(t, err)
+	if got == nil {
+		got = map[string]string{}
+	}
+	return got
+}
+
+// TestResolveAgentEnv_EnvFileDotenvSemantics pins the .env parsing contract.
+// The config schema documents env_file as ".env-style files", which users read
+// as standard dotenv semantics (docker compose, via compose-go): surrounding
+// quotes are syntax, not value; single quotes are literal; double quotes
+// process escapes; `export` prefixes and inline comments are tolerated.
+func TestResolveAgentEnv_EnvFileDotenvSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    map[string]string
+	}{
+		{
+			name:    "unquoted value verbatim",
+			content: "KEY=value\n",
+			want:    map[string]string{"KEY": "value"},
+		},
+		{
+			name:    "double-quoted value strips quotes",
+			content: `KEY="quoted value"` + "\n",
+			want:    map[string]string{"KEY": "quoted value"},
+		},
+		{
+			name:    "double-quoted value with escaped inner quotes",
+			content: `KEY="he said \"hi\" ok"` + "\n",
+			want:    map[string]string{"KEY": `he said "hi" ok`},
+		},
+		{
+			name:    "escaped quote at end of double-quoted value",
+			content: `KEY="he said \"hi\""` + "\n",
+			want:    map[string]string{"KEY": `he said "hi"`},
+		},
+		{
+			name:    "hash without preceding space is not a comment",
+			content: "KEY=value#notcomment\n",
+			want:    map[string]string{"KEY": "value#notcomment"},
+		},
+		{
+			name:    "single-quoted value strips quotes",
+			content: "KEY='quoted value'\n",
+			want:    map[string]string{"KEY": "quoted value"},
+		},
+		{
+			name:    "single-quoted value is literal (no escape or dollar processing)",
+			content: `KEY='$HOME \n literal'` + "\n",
+			want:    map[string]string{"KEY": `$HOME \n literal`},
+		},
+		{
+			name:    "double-quoted value expands backslash escapes",
+			content: `KEY="line1\nline2"` + "\n",
+			want:    map[string]string{"KEY": "line1\nline2"},
+		},
+		{
+			name:    "export prefix is stripped",
+			content: "export KEY=value\n",
+			want:    map[string]string{"KEY": "value"},
+		},
+		{
+			name:    "inline comment after unquoted value",
+			content: "KEY=value # trailing comment\n",
+			want:    map[string]string{"KEY": "value"},
+		},
+		{
+			name:    "hash inside double-quoted value is not a comment",
+			content: `KEY="value # kept"` + "\n",
+			want:    map[string]string{"KEY": "value # kept"},
+		},
+		{
+			name:    "whitespace around equals is trimmed",
+			content: "KEY = value\n",
+			want:    map[string]string{"KEY": "value"},
+		},
+		{
+			name:    "empty value",
+			content: "KEY=\n",
+			want:    map[string]string{"KEY": ""},
+		},
+		{
+			name:    "empty double-quoted value",
+			content: `KEY=""` + "\n",
+			want:    map[string]string{"KEY": ""},
+		},
+		{
+			name:    "value containing equals sign",
+			content: "KEY=a=b=c\n",
+			want:    map[string]string{"KEY": "a=b=c"},
+		},
+		{
+			name:    "unquoted value with internal spaces",
+			content: "KEY=one two three\n",
+			want:    map[string]string{"KEY": "one two three"},
+		},
+		{
+			name:    "CRLF line endings",
+			content: "KEY=value\r\nOTHER=x\r\n",
+			want:    map[string]string{"KEY": "value", "OTHER": "x"},
+		},
+		{
+			name:    "comments and blank lines skipped",
+			content: "# header comment\n\nKEY=value\n   # indented comment\n",
+			want:    map[string]string{"KEY": "value"},
+		},
+		{
+			name:    "url value unquoted survives",
+			content: "URL=https://example.com/path?a=1&b=2\n",
+			want:    map[string]string{"URL": "https://example.com/path?a=1&b=2"},
+		},
+		{
+			name:    "json value in single quotes survives verbatim",
+			content: `CONFIG='{"key": "value", "n": 1}'` + "\n",
+			want:    map[string]string{"CONFIG": `{"key": "value", "n": 1}`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveEnvFile(t, tt.content))
+		})
+	}
+}
+
+// TestResolveAgentEnv_EnvFileOrdering pins that later env_file entries win on
+// key collision (list order = precedence order within the layer).
+func TestResolveAgentEnv_EnvFileOrdering(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.env"), []byte("KEY=first\nA_ONLY=a\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.env"), []byte("KEY=second\nB_ONLY=b\n"), 0o600))
+
+	agent := envAgentCfg([]string{"a.env", "b.env"}, nil, nil)
+	got, _, err := shared.ResolveAgentEnv(agent, nil, "claude", dir, logger.Nop())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"KEY": "second", "A_ONLY": "a", "B_ONLY": "b"}, got)
+}
+
+// TestResolveAgentEnv_EnvFileExpansion pins $VAR expansion semantics
+// (compose-go dotenv, host-side at parse time): references resolve from the
+// host OS environment first, then from earlier keys in the same file; a
+// reference unset in both collapses to empty. Compose interpolation
+// operators (${VAR:-default}, ${VAR:?required}) work, and single quotes
+// suppress expansion.
+func TestResolveAgentEnv_EnvFileExpansion(t *testing.T) {
+	t.Setenv("CLAWKER_TEST_ENVFILE_HOST_VAR", "from-host")
+	t.Setenv("CLAWKER_TEST_ENVFILE_SHADOWED", "host-wins")
+
+	got := resolveEnvFile(t,
+		"BASE=file-local\n"+
+			`SAME_FILE="prefix $BASE"`+"\n"+
+			"CLAWKER_TEST_ENVFILE_SHADOWED=file-value\n"+
+			`SHADOW_REF="$CLAWKER_TEST_ENVFILE_SHADOWED"`+"\n"+
+			"UNQUOTED=prefix-$BASE\n"+
+			`HOST="prefix $CLAWKER_TEST_ENVFILE_HOST_VAR"`+"\n"+
+			`UNSET="prefix $CLAWKER_TEST_ENVFILE_DEFINITELY_UNSET"`+"\n"+
+			`DEFAULTED=${CLAWKER_TEST_ENVFILE_DEFINITELY_UNSET:-fallback}`+"\n"+
+			`LITERAL='$BASE'`+"\n")
+
+	assert.Equal(t, map[string]string{
+		"BASE":      "file-local",
+		"SAME_FILE": "prefix file-local",
+		// Interpolation consults the host lookup BEFORE file-local keys
+		// (compose-go expandVariables order): when a referenced name is set
+		// in both, the host value shadows the file's — but the key itself
+		// still resolves to the file value.
+		"CLAWKER_TEST_ENVFILE_SHADOWED": "file-value",
+		"SHADOW_REF":                    "host-wins",
+		"UNQUOTED":                      "prefix-file-local",
+		"HOST":                          "prefix from-host",
+		"UNSET":                         "prefix ",
+		"DEFAULTED":                     "fallback",
+		"LITERAL":                       "$BASE",
+	}, got)
+}
+
+// TestResolveAgentEnv_EnvFileRequiredVarError pins that the compose
+// ${VAR:?message} required-variable operator surfaces as an error carrying
+// the env_file scope so the user can find the offending file.
+func TestResolveAgentEnv_EnvFileRequiredVarError(t *testing.T) {
+	dir := t.TempDir()
+	content := "KEY=${CLAWKER_TEST_ENVFILE_DEFINITELY_UNSET:?must be set}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0o600))
+
+	agent := envAgentCfg([]string{".env"}, nil, nil)
+	_, _, err := shared.ResolveAgentEnv(agent, nil, "claude", dir, logger.Nop())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent.env_file")
+	assert.Contains(t, err.Error(), "must be set")
+}
+
+// TestResolveAgentEnv_EnvFileBareKeyPassthrough pins docker --env-file
+// passthrough semantics for a bare `KEY` line (no separator): the value is
+// inherited from the host environment, and the line is skipped silently when
+// the host variable is unset.
+func TestResolveAgentEnv_EnvFileBareKeyPassthrough(t *testing.T) {
+	t.Setenv("CLAWKER_TEST_ENVFILE_BARE_KEY", "inherited")
+
+	got := resolveEnvFile(t,
+		"CLAWKER_TEST_ENVFILE_BARE_KEY\n"+
+			"CLAWKER_TEST_ENVFILE_DEFINITELY_UNSET\n"+
+			"OTHER=x\n")
+
+	assert.Equal(t, map[string]string{
+		"CLAWKER_TEST_ENVFILE_BARE_KEY": "inherited",
+		"OTHER":                         "x",
+	}, got)
+}
+
+// TestResolveAgentEnv_NoImplicitEnvFileLoad pins that a .env file in the
+// project dir is loaded ONLY when env_file names it. compose-go's higher-level
+// APIs auto-load .env from the working directory — clawker must never do that
+// implicitly.
+func TestResolveAgentEnv_NoImplicitEnvFileLoad(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte("SHOULD_NOT_LOAD=leaked\n"), 0o600))
+
+	agent := envAgentCfg(nil, nil, map[string]string{"EXPLICIT": "v"})
+	got, warnings, err := shared.ResolveAgentEnv(agent, nil, "claude", dir, logger.Nop())
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+	assert.Equal(t, map[string]string{"EXPLICIT": "v"}, got)
+}
+
+// TestResolveAgentEnv_EnvFileUnsetVarWarning pins that an env-file reference
+// to a variable unset in both the file and the host environment surfaces
+// through the warnings return (scoped, like from_env warnings) — never
+// through third-party logger output. Reporting is precise: a reference
+// rescued by a ${VAR:-default} operator does NOT warn.
+func TestResolveAgentEnv_EnvFileUnsetVarWarning(t *testing.T) {
+	dir := t.TempDir()
+	content := `KEY="prefix $CLAWKER_TEST_ENVFILE_DEFINITELY_UNSET"` + "\n" +
+		"DEFAULTED=${CLAWKER_TEST_ENVFILE_ALSO_UNSET:-fallback}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"), []byte(content), 0o600))
+
+	agent := envAgentCfg([]string{".env"}, nil, nil)
+	got, warnings, err := shared.ResolveAgentEnv(agent, nil, "claude", dir, logger.Nop())
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"KEY": "prefix ", "DEFAULTED": "fallback"}, got)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], `agent.env_file ".env"`)
+	assert.Contains(t, warnings[0], "CLAWKER_TEST_ENVFILE_DEFINITELY_UNSET")
+}

--- a/internal/cmd/container/shared/agentenv_test.go
+++ b/internal/cmd/container/shared/agentenv_test.go
@@ -353,6 +353,19 @@ func TestResolveAgentEnv_EnvFileBareKeyPassthrough(t *testing.T) {
 	}, got)
 }
 
+func TestResolveAgentEnv_EnvFileBareKeyAtEOFNoNewline(t *testing.T) {
+	t.Setenv("CLAWKER_TEST_ENVFILE_BARE_EOF", "inherited")
+
+	// No trailing newline: bare inherited key terminated by EOF must still
+	// inherit, not degrade into an empty-key entry.
+	got := resolveEnvFile(t, "OTHER=x\nCLAWKER_TEST_ENVFILE_BARE_EOF")
+
+	assert.Equal(t, map[string]string{
+		"CLAWKER_TEST_ENVFILE_BARE_EOF": "inherited",
+		"OTHER":                         "x",
+	}, got)
+}
+
 // TestResolveAgentEnv_NoImplicitEnvFileLoad pins that a .env file in the
 // project dir is loaded ONLY when env_file names it. compose-go's higher-level
 // APIs auto-load .env from the working directory — clawker must never do that

--- a/internal/dotenv/LICENSE
+++ b/internal/dotenv/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 John Barton
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/internal/dotenv/godotenv.go
+++ b/internal/dotenv/godotenv.go
@@ -1,0 +1,72 @@
+// Package dotenv parses .env files with docker-compose semantics.
+//
+// Vendored from github.com/compose-spec/compose-go/v2@v2.13.0 (dotenv
+// package, MIT — see LICENSE), itself a fork of github.com/joho/godotenv,
+// a Go port of the ruby dotenv library (https://github.com/bkeepers/dotenv).
+//
+// Modified for clawker:
+//   - removed the process-env loading APIs (Load, Read, ReadFile, Unmarshal*)
+//     and the compose file-format registry (env.go, format.go) — clawker only
+//     parses, it never mutates its own environment
+//   - unset-variable references are reported through an injectable MissingFn
+//     instead of logrus logging (see template.WithMissingHandler)
+package dotenv
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/schmitthub/clawker/internal/dotenv/template"
+)
+
+const utf8BOM = "\uFEFF"
+
+// LookupFn represents a lookup function to resolve variables from
+type LookupFn func(string) (string, bool)
+
+func noLookup(_ string) (string, bool) {
+	return "", false
+}
+
+// MissingFn is called once per interpolation reference that resolves through
+// neither the lookup function nor keys already parsed from the file, after
+// default/required operators have had their chance to apply — i.e. only for
+// references that actually collapse to an empty string.
+type MissingFn func(name string)
+
+// Parse reads an env file from an [io.Reader], returning a map of keys and values.
+func Parse(r io.Reader) (map[string]string, error) {
+	return ParseWithLookup(r, nil, nil)
+}
+
+// ParseWithLookup reads an env file from an [io.Reader], returning a map of
+// keys and values. onMissing (optional) observes unresolvable references.
+func ParseWithLookup(r io.Reader, lookupFn LookupFn, onMissing MissingFn) (map[string]string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading env file: %w", err)
+	}
+
+	// seek past the UTF-8 BOM if it exists (particularly on Windows, some
+	// editors tend to add it, and it'll cause parsing to fail)
+	data = bytes.TrimPrefix(data, []byte(utf8BOM))
+
+	vars := map[string]string{}
+	err = newParser(onMissing).parse(string(data), vars, lookupFn)
+	return vars, err
+}
+
+func (p *parser) expandVariables(value string, envMap map[string]string, lookupFn LookupFn) (string, error) {
+	retVal, err := template.SubstituteWithOptions(value, func(k string) (string, bool) {
+		if v, ok := lookupFn(k); ok {
+			return v, true
+		}
+		v, ok := envMap[k]
+		return v, ok
+	}, template.WithMissingHandler(template.MissingFn(p.onMissing)))
+	if err != nil {
+		return value, fmt.Errorf("expanding variables: %w", err)
+	}
+	return retVal, nil
+}

--- a/internal/dotenv/parser.go
+++ b/internal/dotenv/parser.go
@@ -164,7 +164,10 @@ func (p *parser) scanKeyEnd(src string) (string, int, bool, error) {
 				p.line, string(r), strings.Split(src, "\n")[0])
 		}
 	}
-	return "", 0, false, nil
+	// EOF without a terminator: the whole remainder is a bare inherited key
+	// (file ends without a trailing newline). Clawker fix — upstream drops the
+	// key and emits an empty-key entry here.
+	return src, len(src), true, nil
 }
 
 // isValidKeyRune reports whether the rune may appear in a variable name

--- a/internal/dotenv/parser.go
+++ b/internal/dotenv/parser.go
@@ -1,0 +1,325 @@
+// Vendored from github.com/compose-spec/compose-go/v2@v2.13.0 (dotenv
+// package, MIT — see LICENSE). Modified for clawker: the parser carries a
+// MissingFn so unresolvable interpolation references surface to the caller
+// instead of being logged (see package doc in godotenv.go), and functions are
+// restructured to satisfy this repo's linters.
+
+package dotenv
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	charComment       = '#'
+	prefixSingleQuote = '\''
+	prefixDoubleQuote = '"'
+
+	charNextLine         = 0x85 // NEL: treated as space, not line break
+	charNonBreakingSpace = 0xA0
+)
+
+var (
+	escapeSeqRegex = regexp.MustCompile(`(\\(?:[abcfnrtv$"\\]|0\d{0,3}))`)
+	exportRegex    = regexp.MustCompile(`^export\s+`)
+)
+
+type parser struct {
+	line      int
+	onMissing MissingFn
+}
+
+func newParser(onMissing MissingFn) *parser {
+	return &parser{
+		line:      1,
+		onMissing: onMissing,
+	}
+}
+
+func (p *parser) parse(src string, out map[string]string, lookupFn LookupFn) error {
+	cutset := src
+	if lookupFn == nil {
+		lookupFn = noLookup
+	}
+	for {
+		cutset = p.getStatementStart(cutset)
+		if cutset == "" {
+			// reached end of file
+			break
+		}
+
+		rest, err := p.parseStatement(cutset, out, lookupFn)
+		if err != nil {
+			return err
+		}
+		cutset = rest
+	}
+
+	return nil
+}
+
+// parseStatement consumes one `KEY=value` (or inherited `KEY`) statement and
+// returns the rest of the slice.
+func (p *parser) parseStatement(cutset string, out map[string]string, lookupFn LookupFn) (string, error) {
+	key, left, inherited, err := p.locateKeyName(cutset)
+	if err != nil {
+		return "", err
+	}
+	if strings.Contains(key, " ") {
+		return "", fmt.Errorf("line %d: key cannot contain a space", p.line)
+	}
+
+	if inherited {
+		value, ok := lookupFn(key)
+		if ok {
+			out[key] = value
+		}
+		return left, nil
+	}
+
+	value, left, err := p.extractVarValue(left, out, lookupFn)
+	if err != nil {
+		return "", err
+	}
+
+	out[key] = value
+	return left, nil
+}
+
+// getStatementPosition returns position of statement begin.
+//
+// It skips any comment line or non-whitespace character.
+func (p *parser) getStatementStart(src string) string {
+	pos := p.indexOfNonSpaceChar(src)
+	if pos == -1 {
+		return ""
+	}
+
+	src = src[pos:]
+	if src[0] != charComment {
+		return src
+	}
+
+	// skip comment section
+	pos = strings.IndexFunc(src, isCharFunc('\n'))
+	if pos == -1 {
+		return ""
+	}
+	return p.getStatementStart(src[pos:])
+}
+
+// locateKeyName locates and parses key name and returns rest of slice
+func (p *parser) locateKeyName(src string) (string, string, bool, error) {
+	// trim "export" and space at beginning
+	if exportRegex.MatchString(src) {
+		// we use a `strings.trim` to preserve the pointer to the same underlying memory.
+		// a regexp replace would copy the string.
+		src = strings.TrimLeftFunc(strings.TrimPrefix(src, "export"), isSpace)
+	}
+
+	key, offset, inherited, err := p.scanKeyEnd(src)
+	if err != nil {
+		return "", "", inherited, err
+	}
+
+	if src == "" {
+		return "", "", inherited, errors.New("zero length string")
+	}
+
+	if inherited && strings.IndexByte(key, ' ') == -1 {
+		p.line++
+	}
+
+	// trim whitespace
+	key = strings.TrimRightFunc(key, unicode.IsSpace)
+	cutset := strings.TrimLeftFunc(src[offset:], isSpace)
+	return key, cutset, inherited, nil
+}
+
+// scanKeyEnd locates the key terminator (`=`, `:`, or newline for inherited
+// keys), validating key characters along the way. Returns the raw key, the
+// offset just past the terminator, and whether the key is inherited.
+func (p *parser) scanKeyEnd(src string) (string, int, bool, error) {
+	for i, r := range src {
+		if isSpace(r) {
+			continue
+		}
+
+		switch r {
+		case '=', ':', '\n':
+			// library also supports yaml-style value declaration
+			return src[0:i], i + 1, r == '\n', nil
+		default:
+			if isValidKeyRune(r) {
+				continue
+			}
+
+			return "", 0, false, fmt.Errorf(
+				`line %d: unexpected character %q in variable name %q`,
+				p.line, string(r), strings.Split(src, "\n")[0])
+		}
+	}
+	return "", 0, false, nil
+}
+
+// isValidKeyRune reports whether the rune may appear in a variable name
+// ([A-Za-z0-9_.-] plus bracket indexing).
+func isValidKeyRune(r rune) bool {
+	switch r {
+	case '_', '.', '-', '[', ']':
+		return true
+	}
+	return unicode.IsLetter(r) || unicode.IsNumber(r)
+}
+
+// extractVarValue extracts variable value and returns rest of slice
+func (p *parser) extractVarValue(src string, envMap map[string]string, lookupFn LookupFn) (string, string, error) {
+	quote, isQuoted := hasQuotePrefix(src)
+	if !isQuoted {
+		// unquoted value - read until new line
+		value, rest, _ := strings.Cut(src, "\n")
+		p.line++
+
+		// Remove inline comments on unquoted lines
+		value, _, _ = strings.Cut(value, " #")
+		value = strings.TrimRightFunc(value, unicode.IsSpace)
+		retVal, err := p.expandVariables(value, envMap, lookupFn)
+		return retVal, rest, err
+	}
+
+	value, rest, ok := p.extractQuotedValue(src, quote)
+	if !ok {
+		// return formatted error if quoted string is not terminated
+		valEndIndex := strings.IndexFunc(src, isCharFunc('\n'))
+		if valEndIndex == -1 {
+			valEndIndex = len(src)
+		}
+
+		return "", "", fmt.Errorf("line %d: unterminated quoted value %s", p.line, src[:valEndIndex])
+	}
+
+	if quote == prefixDoubleQuote {
+		// expand standard shell escape sequences & then interpolate
+		// variables on the result
+		retVal, err := p.expandVariables(expandEscapes(value), envMap, lookupFn)
+		if err != nil {
+			return "", "", err
+		}
+		value = retVal
+	}
+
+	return value, rest, nil
+}
+
+// extractQuotedValue scans src (which starts with quote) up to the closing
+// quote, unescaping escaped quote characters. Returns the raw value, the rest
+// of the slice, and false when the quoted string is not terminated.
+func (p *parser) extractQuotedValue(src string, quote byte) (string, string, bool) {
+	previousCharIsEscape := false
+	var chars []byte
+	for i := 1; i < len(src); i++ {
+		char := src[i]
+		if char == '\n' {
+			p.line++
+		}
+
+		if previousCharIsEscape {
+			previousCharIsEscape = false
+			// an escaped quote symbol (\" or \', depends on quote) drops its
+			// backslash; any other escaped character keeps it
+			if char != quote {
+				chars = append(chars, '\\')
+			}
+			chars = append(chars, char)
+			continue
+		}
+
+		switch char {
+		case '\\':
+			previousCharIsEscape = true
+		case quote:
+			return string(chars), src[i+1:], true
+		default:
+			chars = append(chars, char)
+		}
+	}
+
+	return "", "", false
+}
+
+func expandEscapes(str string) string {
+	out := escapeSeqRegex.ReplaceAllStringFunc(str, func(match string) string {
+		if match == `\$` {
+			// `\$` is not a Go escape sequence, the expansion parser uses
+			// the special `$$` syntax
+			// both `FOO=\$bar` and `FOO=$$bar` are valid in an env file and
+			// will result in FOO w/ literal value of "$bar" (no interpolation)
+			return "$$"
+		}
+
+		if strings.HasPrefix(match, `\0`) {
+			// octal escape sequences in Go are not prefixed with `\0`, so
+			// rewrite the prefix, e.g. `\0123` -> `\123` -> literal value "S"
+			match = strings.Replace(match, `\0`, `\`, 1)
+		}
+
+		// use Go to unquote (unescape) the literal
+		// see https://go.dev/ref/spec#Rune_literals
+		//
+		// NOTE: Go supports ADDITIONAL escapes like `\x` & `\u` & `\U`!
+		// These are NOT supported, which is why we use a regex to find
+		// only matches we support and then use `UnquoteChar` instead of a
+		// `Unquote` on the entire value
+		v, _, _, err := strconv.UnquoteChar(match, '"')
+		if err != nil {
+			return match
+		}
+		return string(v)
+	})
+	return out
+}
+
+func (p *parser) indexOfNonSpaceChar(src string) int {
+	return strings.IndexFunc(src, func(r rune) bool {
+		if r == '\n' {
+			p.line++
+		}
+		return !unicode.IsSpace(r)
+	})
+}
+
+// hasQuotePrefix reports whether charset starts with single or double quote and returns quote character
+func hasQuotePrefix(src string) (byte, bool) {
+	if src == "" {
+		return 0, false
+	}
+
+	switch quote := src[0]; quote {
+	case prefixDoubleQuote, prefixSingleQuote:
+		return quote, true // isQuoted
+	default:
+		return 0, false
+	}
+}
+
+func isCharFunc(char rune) func(rune) bool {
+	return func(v rune) bool {
+		return v == char
+	}
+}
+
+// isSpace reports whether the rune is a space character but not line break character
+//
+// this differs from [unicode.IsSpace], which also applies line break as space
+func isSpace(r rune) bool {
+	switch r {
+	case '\t', '\v', '\f', '\r', ' ', charNextLine, charNonBreakingSpace:
+		return true
+	}
+	return false
+}

--- a/internal/dotenv/template/LICENSE
+++ b/internal/dotenv/template/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2020 The Compose Specification Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/dotenv/template/NOTICE
+++ b/internal/dotenv/template/NOTICE
@@ -1,0 +1,2 @@
+The Compose Specification
+Copyright 2020 The Compose Specification Authors

--- a/internal/dotenv/template/template.go
+++ b/internal/dotenv/template/template.go
@@ -1,0 +1,413 @@
+/*
+   Copyright 2020 The Compose Specification Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Vendored from github.com/compose-spec/compose-go/v2@v2.13.0 (template
+// package, Apache-2.0 — see LICENSE and NOTICE). Modified for clawker:
+// logrus logging replaced with an injectable missing-variable handler
+// (MissingFn / WithMissingHandler); the unused ExtractVariables API
+// (variables.go) is omitted.
+
+package template
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	delimiter          = "\\$"
+	substitutionNamed  = "[_a-z][_a-z0-9]*"
+	substitutionBraced = "[_a-z][_a-z0-9]*(?::?[-+?](.*))?"
+	groupEscaped       = "escaped"
+	groupNamed         = "named"
+	groupBraced        = "braced"
+	groupInvalid       = "invalid"
+)
+
+var DefaultPattern = regexp.MustCompile(fmt.Sprintf(
+	"%s(?i:(?P<%s>%s)|(?P<%s>%s)|{(?:(?P<%s>%s)}|(?P<%s>)))",
+	delimiter,
+	groupEscaped, delimiter,
+	groupNamed, substitutionNamed,
+	groupBraced, substitutionBraced,
+	groupInvalid,
+))
+
+// InvalidTemplateError is returned when a variable template is not in a valid
+// format
+type InvalidTemplateError struct {
+	Template string
+}
+
+func (e InvalidTemplateError) Error() string {
+	return fmt.Sprintf("Invalid template: %#v", e.Template)
+}
+
+// MissingRequiredError is returned when a variable template is missing
+type MissingRequiredError struct {
+	Variable string
+	Reason   string
+}
+
+func (e MissingRequiredError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("required variable %s is missing a value: %s", e.Variable, e.Reason)
+	}
+	return fmt.Sprintf("required variable %s is missing a value", e.Variable)
+}
+
+// Mapping is a user-supplied function which maps from variable names to values.
+// Returns the value as a string and a bool indicating whether
+// the value is present, to distinguish between an empty string
+// and the absence of a value.
+type Mapping func(string) (string, bool)
+
+// SubstituteFunc is a user-supplied function that apply substitution.
+// Returns the value as a string, a bool indicating if the function could apply
+// the substitution and an error.
+type SubstituteFunc func(string, Mapping) (string, bool, error)
+
+// ReplacementFunc is a user-supplied function that is apply to the matching
+// substring. Returns the value as a string and an error.
+type ReplacementFunc func(string, Mapping, *Config) (string, error)
+
+// MissingFn observes a variable reference that resolved through neither the
+// mapping nor a default/required operator, collapsing to an empty string.
+type MissingFn func(name string)
+
+type Config struct {
+	pattern         *regexp.Regexp
+	substituteFunc  SubstituteFunc
+	replacementFunc ReplacementFunc
+	onMissing       MissingFn
+}
+
+type Option func(*Config)
+
+func WithPattern(pattern *regexp.Regexp) Option {
+	return func(cfg *Config) {
+		cfg.pattern = pattern
+	}
+}
+
+func WithSubstitutionFunction(subsFunc SubstituteFunc) Option {
+	return func(cfg *Config) {
+		cfg.substituteFunc = subsFunc
+	}
+}
+
+func WithReplacementFunction(replacementFunc ReplacementFunc) Option {
+	return func(cfg *Config) {
+		cfg.replacementFunc = replacementFunc
+	}
+}
+
+// WithMissingHandler observes unresolvable variable references. Replaces the
+// upstream logrus warning.
+func WithMissingHandler(onMissing MissingFn) Option {
+	return func(cfg *Config) {
+		cfg.onMissing = onMissing
+	}
+}
+
+// SubstituteWithOptions substitute variables in the string with their values.
+// It accepts additional options such as a custom function or pattern.
+func SubstituteWithOptions(template string, mapping Mapping, options ...Option) (string, error) {
+	var returnErr error
+
+	cfg := &Config{
+		pattern:         DefaultPattern,
+		substituteFunc:  nil,
+		replacementFunc: DefaultReplacementFunc,
+		onMissing:       nil,
+	}
+	for _, o := range options {
+		o(cfg)
+	}
+
+	result := cfg.pattern.ReplaceAllStringFunc(template, func(substring string) string {
+		replacement, err := cfg.replacementFunc(substring, mapping, cfg)
+		if err != nil {
+			// Save the first error to be returned
+			if returnErr == nil {
+				returnErr = annotateTemplateError(err, template)
+			}
+		}
+		return replacement
+	})
+
+	return result, returnErr
+}
+
+// annotateTemplateError stamps the full template onto an
+// [InvalidTemplateError] that carries none.
+func annotateTemplateError(err error, template string) error {
+	var tmplErr *InvalidTemplateError
+	if errors.As(err, &tmplErr) && tmplErr.Template == "" {
+		tmplErr.Template = template
+	}
+	return err
+}
+
+func DefaultReplacementFunc(substring string, mapping Mapping, cfg *Config) (string, error) {
+	value, _, err := DefaultReplacementAppliedFunc(substring, mapping, cfg)
+	return value, err
+}
+
+func DefaultReplacementAppliedFunc(substring string, mapping Mapping, cfg *Config) (string, bool, error) {
+	pattern := cfg.pattern
+	subsFunc := cfg.substituteFunc
+	if subsFunc == nil {
+		_, subsFunc = getSubstitutionFunctionForTemplate(substring)
+	}
+
+	substring, rest := splitAtClosingBrace(substring)
+
+	groups := matchGroups(pattern.FindStringSubmatch(substring), pattern)
+	if escaped := groups[groupEscaped]; escaped != "" {
+		return escaped, true, nil
+	}
+
+	braced := false
+	substitution := groups[groupNamed]
+	if substitution == "" {
+		substitution = groups[groupBraced]
+		braced = true
+	}
+
+	if substitution == "" {
+		return "", false, &InvalidTemplateError{}
+	}
+
+	if braced {
+		value, applied, err := applyBracedSubstitution(substitution, rest, subsFunc, mapping, pattern)
+		if err != nil || applied {
+			return value, applied, err
+		}
+	}
+
+	value, ok := mapping(substitution)
+	if !ok && cfg.onMissing != nil {
+		cfg.onMissing(substitution)
+	}
+
+	return value, ok, nil
+}
+
+// splitAtClosingBrace splits s after the first balanced closing brace,
+// returning the head and the rest (empty when no closing brace exists).
+func splitAtClosingBrace(s string) (string, string) {
+	i := getFirstBraceClosingIndex(s)
+	if i == -1 {
+		return s, ""
+	}
+	return s[:i+1], s[i+1:]
+}
+
+// applyBracedSubstitution runs the operator substitution function for a
+// ${...} reference and, when it applies, interpolates the remainder of the
+// substring after the closing brace.
+func applyBracedSubstitution(
+	substitution, rest string,
+	subsFunc SubstituteFunc,
+	mapping Mapping,
+	pattern *regexp.Regexp,
+) (string, bool, error) {
+	value, applied, err := subsFunc(substitution, mapping)
+	if err != nil {
+		return "", false, err
+	}
+	if !applied {
+		return "", false, nil
+	}
+	interpolatedNested, err := SubstituteWith(rest, mapping, pattern)
+	if err != nil {
+		return "", false, err
+	}
+	return value + interpolatedNested, true, nil
+}
+
+// SubstituteWith substitute variables in the string with their values.
+// It accepts additional substitute function.
+func SubstituteWith(
+	template string,
+	mapping Mapping,
+	pattern *regexp.Regexp,
+	subsFuncs ...SubstituteFunc,
+) (string, error) {
+	options := []Option{
+		WithPattern(pattern),
+	}
+	if len(subsFuncs) > 0 {
+		options = append(options, WithSubstitutionFunction(subsFuncs[0]))
+	}
+
+	return SubstituteWithOptions(template, mapping, options...)
+}
+
+func getSubstitutionFunctionForTemplate(template string) (string, SubstituteFunc) {
+	interpolationMapping := []struct {
+		string
+		SubstituteFunc
+	}{
+		{":?", requiredErrorWhenEmptyOrUnset},
+		{"?", requiredErrorWhenUnset},
+		{":-", defaultWhenEmptyOrUnset},
+		{"-", defaultWhenUnset},
+		{":+", defaultWhenNotEmpty},
+		{"+", defaultWhenSet},
+	}
+	sort.Slice(interpolationMapping, func(i, j int) bool {
+		idxI := strings.Index(template, interpolationMapping[i].string)
+		idxJ := strings.Index(template, interpolationMapping[j].string)
+		if idxI < 0 {
+			return false
+		}
+		if idxJ < 0 {
+			return true
+		}
+		return idxI < idxJ
+	})
+
+	return interpolationMapping[0].string, interpolationMapping[0].SubstituteFunc
+}
+
+func getFirstBraceClosingIndex(s string) int {
+	openVariableBraces := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '}' {
+			openVariableBraces--
+			if openVariableBraces == 0 {
+				return i
+			}
+		}
+		if s[i] == '{' {
+			openVariableBraces++
+			i++
+		}
+	}
+	return -1
+}
+
+// Substitute variables in the string with their values
+func Substitute(template string, mapping Mapping) (string, error) {
+	return SubstituteWith(template, mapping, DefaultPattern)
+}
+
+// Soft default (fall back if unset or empty)
+func defaultWhenEmptyOrUnset(substitution string, mapping Mapping) (string, bool, error) {
+	return withDefaultWhenAbsence(substitution, mapping, true)
+}
+
+// Hard default (fall back if-and-only-if empty)
+func defaultWhenUnset(substitution string, mapping Mapping) (string, bool, error) {
+	return withDefaultWhenAbsence(substitution, mapping, false)
+}
+
+func defaultWhenNotEmpty(substitution string, mapping Mapping) (string, bool, error) {
+	return withDefaultWhenPresence(substitution, mapping, true)
+}
+
+func defaultWhenSet(substitution string, mapping Mapping) (string, bool, error) {
+	return withDefaultWhenPresence(substitution, mapping, false)
+}
+
+func requiredErrorWhenEmptyOrUnset(substitution string, mapping Mapping) (string, bool, error) {
+	return withRequired(substitution, mapping, ":?", func(v string) bool { return v != "" })
+}
+
+func requiredErrorWhenUnset(substitution string, mapping Mapping) (string, bool, error) {
+	return withRequired(substitution, mapping, "?", func(_ string) bool { return true })
+}
+
+func withDefaultWhenPresence(substitution string, mapping Mapping, notEmpty bool) (string, bool, error) {
+	sep := "+"
+	if notEmpty {
+		sep = ":+"
+	}
+	if !strings.Contains(substitution, sep) {
+		return "", false, nil
+	}
+	name, defaultValue := partition(substitution, sep)
+	value, ok := mapping(name)
+	if ok && (!notEmpty || (notEmpty && value != "")) {
+		resolved, err := Substitute(defaultValue, mapping)
+		if err != nil {
+			return "", false, err
+		}
+		return resolved, true, nil
+	}
+	return value, true, nil
+}
+
+func withDefaultWhenAbsence(substitution string, mapping Mapping, emptyOrUnset bool) (string, bool, error) {
+	sep := "-"
+	if emptyOrUnset {
+		sep = ":-"
+	}
+	if !strings.Contains(substitution, sep) {
+		return "", false, nil
+	}
+	name, defaultValue := partition(substitution, sep)
+	value, ok := mapping(name)
+	if !ok || (emptyOrUnset && value == "") {
+		resolved, err := Substitute(defaultValue, mapping)
+		if err != nil {
+			return "", false, err
+		}
+		return resolved, true, nil
+	}
+	return value, true, nil
+}
+
+func withRequired(substitution string, mapping Mapping, sep string, valid func(string) bool) (string, bool, error) {
+	if !strings.Contains(substitution, sep) {
+		return "", false, nil
+	}
+	name, errorMessage := partition(substitution, sep)
+	value, ok := mapping(name)
+	if !ok || !valid(value) {
+		resolved, err := Substitute(errorMessage, mapping)
+		if err != nil {
+			return "", false, err
+		}
+		return "", true, &MissingRequiredError{
+			Reason:   resolved,
+			Variable: name,
+		}
+	}
+	return value, true, nil
+}
+
+func matchGroups(matches []string, pattern *regexp.Regexp) map[string]string {
+	groups := make(map[string]string)
+	for i, name := range pattern.SubexpNames()[1:] {
+		groups[name] = matches[i+1]
+	}
+	return groups
+}
+
+// Split the string at the first occurrence of sep, and return the part before the separator,
+// and the part after the separator.
+//
+// If the separator is not found, return the string itself, followed by an empty string.
+func partition(s, sep string) (string, string) {
+	before, after, _ := strings.Cut(s, sep)
+	return before, after
+}


### PR DESCRIPTION
## Summary

`agent.env_file` parsing was a naive `strings.Cut` on `=`: quoted values leaked their quotes into container env, and `export` prefixes, inline comments, escapes, and interpolation were all unsupported despite the config schema promising ".env-style files".

- Vendor compose-go v2.13.0's `dotenv` + `template` packages into `internal/dotenv` (MIT / Apache-2.0, license texts and per-file modification notices included), trimmed to parse-only and conformed to this repo's linters — no new module dependencies
- Replace the upstream logrus warning with an injectable `MissingFn`: unresolvable `$VAR` references surface through the existing `ResolveAgentEnv` warnings channel, precisely — references rescued by `${VAR:-default}` do not warn
- Host env is the lookup source: `$VAR` fallback plus bare-`KEY` passthrough (docker `--env-file` style)
- Remove the now-fixed env_file quoted-values entry from the clawker-plugin known-issues reference (submodule pointer bump)

## Semantics (all pinned by tests)

Quote stripping, single-quote literals, double-quote escape expansion, `export` prefix, inline comments (space-gated `#`), whitespace around `=`, CRLF, compose interpolation operators (`${VAR:-default}`, `${VAR:?required}` error propagation), host-env shadowing order for interpolation, bare-key passthrough, and no implicit `.env` loading.

## Test plan

- 29 unit tests in `internal/cmd/container/shared/agentenv_test.go` pin the parsing contract end-to-end through `ResolveAgentEnv` with isolated temp-dir env files
- Full unit suite green (6136 tests); all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)