### PR TITLE
fix(socketbridge): drop duplicate container field in daemon log lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changed, Removed. Each release section lists those subsections directly.
 
 - `.clawkerignore` patterns now follow real `.gitignore` matching semantics. Anchored patterns (`/build/`) mask only the workspace-root directory — previously they matched nothing — and unanchored patterns (`build/`) match at any depth, exactly like git. A malformed glob no longer aborts container start; like git, it just doesn't match.
 - In bind mode, a directory ignored via a `**/`-prefixed pattern (e.g. `**/node_modules/`) now gets its tmpfs overlay even when it doesn't exist on the host yet — previously a `node_modules` created inside the container (e.g. by `npm install`) wrote straight through the bind mount onto the host until the container was recreated.
-- Socket bridge daemons now share a single size-capped log (`socketbridge.log`, one rotated backup) instead of leaving a new `bridge-<id>.log` behind for every container run, and every line — including the in-container socket server's output — is tagged with its container ID. Leftover per-run files from earlier releases are harmless; reclaim the space with `rm ~/.local/state/clawker/logs/bridge-*.log`.
+- Socket bridge daemons now share a single size-capped log (`socketbridge.log`, one rotated backup) instead of leaving a new `bridge-<id>.log` behind for every container run, and every line — including the in-container socket server's output — is tagged with its container ID. Leftover `bridge-<id>.log` files from earlier releases are harmless and can be deleted from clawker's logs directory — `$CLAWKER_STATE_DIR/logs` if you set that override, otherwise `$XDG_STATE_HOME/clawker/logs`, which defaults to `~/.local/state/clawker/logs`.
 
 ### Added
 

--- a/internal/cmd/bridge/bridge.go
+++ b/internal/cmd/bridge/bridge.go
@@ -77,8 +77,9 @@ func NewCmdBridgeServe() *cobra.Command {
 				}
 			}
 
+			// containerID is not re-logged here: log already carries the short
+			// form under "container", and pidFile embeds the full ID.
 			log.Debug().
-				Str("container", containerID).
 				Bool("gpg", gpgEnabled).
 				Str("pid_file", pidFile).
 				Msg("starting socket bridge daemon")
@@ -124,7 +125,7 @@ func NewCmdBridgeServe() *cobra.Command {
 					return
 				}
 				if err := watchContainerEvents(ctx, cli, containerID, func() {
-					log.Debug().Str("container", containerID).Msg("container died, stopping bridge")
+					log.Debug().Msg("container died, stopping bridge")
 					bridge.Stop()
 					cancel()
 				}); err != nil && ctx.Err() == nil {


### PR DESCRIPTION
## Summary

- The bridge daemon logger is tagged `.With("container", ShortID(id))`, but two call sites in `internal/cmd/bridge/bridge.go` re-added `Str("container", containerID)` with the full ID. zerolog emits both, producing JSON lines with a repeated `container` key whose surviving value depends on the consumer's parser. Both re-adds are dropped — the tagged short ID is on every line, and the daemon-start line's `pid_file` value embeds the full container ID.
- Rewords the previous release's changelog note that told users to `rm` a hardcoded `~/.local/state` path. The state dir resolves through `CLAWKER_STATE_DIR` / `XDG_STATE_HOME`, so the note now spells out the resolution chain instead of assuming the default location.

## Test plan

- [x] `go test ./internal/cmd/bridge/ ./internal/socketbridge/`
- [x] Verified live shared `socketbridge.log` with three concurrent bridge daemons interleaving cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)