### PR TITLE
feat(cli): clawker prompt print — host-side managed briefing access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows Keep a Changelog, and clawker adheres to Semantic Versioning.
 A release spans many merged PRs and may mix change kinds — Added, Fixed,
 Changed, Removed. Each release section lists those subsections directly.
 
+## [2026.8.1] - 2026-08-02
+
+- **Added:** `clawker prompt print` writes the managed agent briefing to stdout. Use it when your agent reads its context from a mounted directory, where the build cannot bake the file. This is a low-level command for harness developers.
+
 ## [2026.7.4] - 2026-07-26
 
 - **Added:** Reset firewall rules to your project config with `clawker firewall prune` — removes every egress rule, then re-syncs the harness floor and project rules; `--all` removes everything without re-syncing, `--yes` skips the confirmation prompt. A failed prune restores the previous rules, so the store is never left partially reset.

--- a/docs/authoring-harnesses.mdx
+++ b/docs/authoring-harnesses.mdx
@@ -107,6 +107,12 @@ is copied.
 The copy happens at **build time**, never at runtime, so the destination must
 not sit under a declared volume (a volume mount would shadow it).
 
+If the agent reads managed context only from runtime-mounted state — a
+declared volume or a bind mount — omit the block: a baked file is not visible
+under the mount. Get the briefing host-side with
+[`clawker prompt print`](/cli-reference/clawker_prompt_print) and place it
+where the agent discovers it.
+
 ### `volumes`
 
 Each entry is a persisted directory that becomes a named volume mounted under

--- a/docs/cli-reference/clawker.md
+++ b/docs/cli-reference/clawker.md
@@ -43,6 +43,7 @@ Workspace modes:
 * [clawker pause](clawker_pause) - Pause all processes within one or more containers
 * [clawker plugin](clawker_plugin) - Manage the clawker agent skills plugin
 * [clawker project](clawker_project) - Manage clawker projects
+* [clawker prompt](clawker_prompt) - Access clawker's managed agent briefing
 * [clawker ps](clawker_ps) - List containers
 * [clawker rename](clawker_rename) - Rename a container
 * [clawker restart](clawker_restart) - Restart one or more containers

--- a/docs/cli-reference/clawker_prompt.md
+++ b/docs/cli-reference/clawker_prompt.md
@@ -1,0 +1,46 @@
+---
+title: "clawker prompt"
+---
+
+## clawker prompt
+
+Access clawker's managed agent briefing
+
+### Synopsis
+
+Commands for the managed agent briefing clawker provides to coding agents
+running in its containers.
+
+The briefing is clawker-owned and harness-agnostic: it explains the container
+environment, the egress firewall, and how the agent should surface blocked
+connections. A harness whose agent reads managed context from a fixed image
+path declares that path in its manifest (managed_prompt) and gets the file
+baked at build time; deployments whose agent discovers context in
+runtime-mounted state can print it host-side and place it themselves.
+
+### Examples
+
+```
+  # Print the briefing
+  clawker prompt print
+```
+
+### Subcommands
+
+* [clawker prompt print](clawker_prompt_print) - Print the managed agent briefing to stdout
+
+### Options
+
+```
+  -h, --help   help for prompt
+```
+
+### Options inherited from parent commands
+
+```
+  -D, --debug   Enable debug logging
+```
+
+### See also
+
+* [clawker](clawker) - Run coding agents in secure Docker containers with clawker

--- a/docs/cli-reference/clawker_prompt_print.md
+++ b/docs/cli-reference/clawker_prompt_print.md
@@ -1,0 +1,48 @@
+---
+title: "clawker prompt print"
+---
+
+## clawker prompt print
+
+Print the managed agent briefing to stdout
+
+### Synopsis
+
+Prints clawker's managed agent briefing — the document that tells a coding
+agent it is running inside a clawker container and how to work with the
+egress firewall, credential forwarding, and workspace modes.
+
+Harness images whose agent reads managed context from a fixed image path get
+this file baked in at build time. For agents that read context from
+runtime-mounted state instead, pipe this output to wherever the agent
+discovers it.
+
+```
+clawker prompt print [flags]
+```
+
+### Examples
+
+```
+  # Show the briefing
+  clawker prompt print
+
+  # Place it where an agent reads bootstrap context from a bind-mounted tree
+  clawker prompt print > home/.openclaw/workspace/clawker/AGENTS.md
+```
+
+### Options
+
+```
+  -h, --help   help for print
+```
+
+### Options inherited from parent commands
+
+```
+  -D, --debug   Enable debug logging
+```
+
+### See also
+
+* [clawker prompt](clawker_prompt) - Access clawker's managed agent briefing

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -294,6 +294,13 @@
             ]
           },
           {
+            "group": "Prompt",
+            "pages": [
+              "cli-reference/clawker_prompt",
+              "cli-reference/clawker_prompt_print"
+            ]
+          },
+          {
             "group": "Stack",
             "pages": [
               "cli-reference/clawker_stack",

--- a/internal/cmd/prompt/print/print.go
+++ b/internal/cmd/prompt/print/print.go
@@ -1,0 +1,56 @@
+// Package printcmd provides the `clawker prompt print` command.
+package printcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/schmitthub/clawker/internal/bundler"
+	"github.com/schmitthub/clawker/internal/cmdutil"
+	"github.com/schmitthub/clawker/internal/iostreams"
+)
+
+// Options holds the inputs for the prompt print command.
+type Options struct {
+	IO *iostreams.IOStreams
+}
+
+// NewCmdPrint creates the prompt print command.
+func NewCmdPrint(f *cmdutil.Factory, runF func(*Options) error) *cobra.Command {
+	opts := &Options{IO: f.IOStreams}
+
+	cmd := &cobra.Command{
+		Use:   "print",
+		Short: "Print the managed agent briefing to stdout",
+		Long: `Prints clawker's managed agent briefing — the document that tells a coding
+agent it is running inside a clawker container and how to work with the
+egress firewall, credential forwarding, and workspace modes.
+
+Harness images whose agent reads managed context from a fixed image path get
+this file baked in at build time. For agents that read context from
+runtime-mounted state instead, pipe this output to wherever the agent
+discovers it.`,
+		Example: `  # Show the briefing
+  clawker prompt print
+
+  # Place it where an agent reads bootstrap context from a bind-mounted tree
+  clawker prompt print > home/.openclaw/workspace/clawker/AGENTS.md`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+			return printRun(opts)
+		},
+	}
+
+	return cmd
+}
+
+func printRun(opts *Options) error {
+	if _, err := fmt.Fprint(opts.IO.Out, bundler.AgentPromptContent); err != nil {
+		return fmt.Errorf("writing briefing: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/prompt/print/print_test.go
+++ b/internal/cmd/prompt/print/print_test.go
@@ -1,0 +1,46 @@
+package printcmd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/schmitthub/clawker/internal/bundler"
+	printcmd "github.com/schmitthub/clawker/internal/cmd/prompt/print"
+	"github.com/schmitthub/clawker/internal/cmdutil"
+	"github.com/schmitthub/clawker/internal/iostreams"
+)
+
+func newTestFactory(ios *iostreams.IOStreams) *cmdutil.Factory {
+	return &cmdutil.Factory{
+		Version:         "",
+		IOStreams:       ios,
+		TUI:             nil,
+		Client:          nil,
+		Config:          nil,
+		Logger:          nil,
+		CLIState:        nil,
+		ProjectRegistry: nil,
+		ProjectManager:  nil,
+		GitManager:      nil,
+		HostProxy:       nil,
+		SocketBridge:    nil,
+		Prompter:        nil,
+		AdminClient:     nil,
+		ControlPlane:    nil,
+		HttpClient:      nil,
+		BundleManager:   nil,
+	}
+}
+
+func TestPromptPrint_WritesBriefingToStdout(t *testing.T) {
+	ios, _, out, errOut := iostreams.Test()
+
+	cmd := printcmd.NewCmdPrint(newTestFactory(ios), nil)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, bundler.AgentPromptContent, out.String())
+	assert.Empty(t, errOut.String())
+}

--- a/internal/cmd/prompt/prompt.go
+++ b/internal/cmd/prompt/prompt.go
@@ -1,0 +1,37 @@
+// Package prompt provides the `clawker prompt` command group: access to
+// clawker's managed agent briefing, the clawker-owned document a harness
+// image bakes at its manifest's managed_prompt destination. The group
+// exists so deployments whose agent reads context from runtime-mounted
+// state (where baked files are shadowed) can obtain the briefing host-side.
+package prompt
+
+import (
+	"github.com/spf13/cobra"
+
+	printcmd "github.com/schmitthub/clawker/internal/cmd/prompt/print"
+	"github.com/schmitthub/clawker/internal/cmdutil"
+)
+
+// NewCmdPrompt creates the prompt parent command and registers its
+// subcommands.
+func NewCmdPrompt(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prompt",
+		Short: "Access clawker's managed agent briefing",
+		Long: `Commands for the managed agent briefing clawker provides to coding agents
+running in its containers.
+
+The briefing is clawker-owned and harness-agnostic: it explains the container
+environment, the egress firewall, and how the agent should surface blocked
+connections. A harness whose agent reads managed context from a fixed image
+path declares that path in its manifest (managed_prompt) and gets the file
+baked at build time; deployments whose agent discovers context in
+runtime-mounted state can print it host-side and place it themselves.`,
+		Example: `  # Print the briefing
+  clawker prompt print`,
+	}
+
+	cmd.AddCommand(printcmd.NewCmdPrint(f, nil))
+
+	return cmd
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"github.com/spf13/cobra"
+
 	aliascmd "github.com/schmitthub/clawker/internal/cmd/alias"
 	authcmd "github.com/schmitthub/clawker/internal/cmd/auth"
 	bridgecmd "github.com/schmitthub/clawker/internal/cmd/bridge"
@@ -16,13 +18,13 @@ import (
 	"github.com/schmitthub/clawker/internal/cmd/network"
 	"github.com/schmitthub/clawker/internal/cmd/plugin"
 	"github.com/schmitthub/clawker/internal/cmd/project"
+	promptcmd "github.com/schmitthub/clawker/internal/cmd/prompt"
 	"github.com/schmitthub/clawker/internal/cmd/settings"
 	stackcmd "github.com/schmitthub/clawker/internal/cmd/stack"
 	versioncmd "github.com/schmitthub/clawker/internal/cmd/version"
 	"github.com/schmitthub/clawker/internal/cmd/volume"
 	"github.com/schmitthub/clawker/internal/cmd/worktree"
 	"github.com/schmitthub/clawker/internal/cmdutil"
-	"github.com/spf13/cobra"
 )
 
 // NewCmdRoot creates the root command for the clawker CLI.
@@ -75,6 +77,7 @@ Workspace modes:
 	cmd.AddCommand(authcmd.NewCmdAuth(f))
 	cmd.AddCommand(bundlecmd.NewCmdBundle(f))
 	cmd.AddCommand(harnesscmd.NewCmdHarness(f))
+	cmd.AddCommand(promptcmd.NewCmdPrompt(f))
 	cmd.AddCommand(stackcmd.NewCmdStack(f))
 	cmd.AddCommand(container.NewCmdContainer(f))
 	cmd.AddCommand(controlplanecmd.NewCmdControlPlane(f))


### PR DESCRIPTION
## Summary

The managed agent briefing (`internal/bundler/assets/clawker-agent-prompt.md`) was previously reachable only baked into harness images at their manifest's `managed_prompt` destination. That delivery path assumes the agent reads managed context from a fixed image path (Claude Code's `/etc/claude-code/CLAUDE.md` enterprise managed-policy slot).

Harnesses whose agent discovers context in **runtime-mounted state** get nothing from the bake: bind mounts shadow baked files and never self-seed. OpenClaw is the concrete case — its gateway loads bootstrap context from workspace files under `~/.openclaw`, which deployments bind-mount for host-side inspection.

`clawker prompt print` emits the embedded briefing on stdout so a deployment places it itself:

```
clawker prompt print > home/.openclaw/workspace/clawker/AGENTS.md
```

## Changes

- New `clawker prompt` command group + `print` subcommand (`internal/cmd/prompt/`), factory `NewCmd(f, runF)` pattern, data → stdout
- Registered in root; CLI reference + `docs.json` navigation regenerated via gen-docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)