### PR TITLE
chore(build): remove git-delta from base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows Keep a Changelog, and clawker adheres to Semantic Versioning.
 A release spans many merged PRs and may mix change kinds — Added, Fixed,
 Changed, Removed. Each release section lists those subsections directly.
 
+## [2026.8.2] - 2026-08-03
+
+- **Removed:** The base image does not include git-delta. This dependency is not necessary. Git shows diffs with its standard output.
+
 ## [2026.8.1] - 2026-08-02
 
 - **Added:** `clawker prompt print` writes the managed agent briefing to stdout. Use it when your agent reads its context from a mounted directory, where the build cannot bake the file. This is a low-level command for harness developers.

--- a/docs/custom-images.mdx
+++ b/docs/custom-images.mdx
@@ -16,7 +16,7 @@ Each project gets a shared **base image** plus one **harness image** per coding-
 | Base image | `clawker-<project>:base` | Harness-agnostic layers: the substrate, Clawker's tooling floor, your `build.packages`, project-declared stacks, your `instructions` and base-stage `inject` points, the unprivileged container user (`clawker`) |
 | Harness image | `clawker-<project>:<harness>` | Built `FROM` the base: the harness's own stacks and install steps, config seeds, harness-stage `inject` points, and Clawker's runtime assets (`clawkerd`, credential helpers, firewall CA) |
 
-The base image starts from a pinned `debian:bookworm-slim` digest and layers in the development floor every container gets: `git`, `zsh`, `sudo`, `gh`, `curl`, `wget`, `jq`, `fzf`, `make`, `gcc`, editors (`nano`, `vim`), locales, the Docker CLI (for socket-mount workflows), and `git-delta`. Your `build.packages` install into the same apt layer.
+The base image starts from a pinned `debian:bookworm-slim` digest and layers in the development floor every container gets: `git`, `zsh`, `sudo`, `gh`, `curl`, `wget`, `jq`, `fzf`, `make`, `gcc`, editors (`nano`, `vim`), locales, and the Docker CLI (for socket-mount workflows). Your `build.packages` install into the same apt layer.
 
 The harness image adds whatever the selected harness declares — for example, `claude` installs Claude Code (plus the `node` stack it runs on), while `codex` installs the standalone Codex binary — and ends with `ENTRYPOINT ["clawkerd"]` and the harness's `CMD`.
 

--- a/internal/bundle/assets/harnesses/claude/Dockerfile.harness.tmpl
+++ b/internal/bundle/assets/harnesses/claude/Dockerfile.harness.tmpl
@@ -79,7 +79,7 @@ ENV OTEL_LOG_USER_PROMPTS=1
 # cache at an ARG's DECLARATION line, not at first use — that "first use, not
 # definition" rule is the classic (pre-BuildKit) builder's, and Docker 23+
 # builds with BuildKit by default. Hoisting this declaration up the stage would
-# re-run every layer below it (stacks, git-delta, zsh-in-docker, ...) on
+# re-run every layer below it (stacks, zsh-in-docker, ...) on
 # every CC release. Adjacent placement scopes the CC-version cache miss to the
 # install layer + the late root block alone.
 # Override: clawker build --build-arg CLAUDE_CODE_VERSION=<version>

--- a/internal/bundler/assets/Dockerfile.base.tmpl
+++ b/internal/bundler/assets/Dockerfile.base.tmpl
@@ -164,25 +164,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR {{.WorkspacePath}}
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-{{- if $.BuildKitEnabled}}
-RUN --mount=type=cache,target=/tmp/downloads \
-    ARCH=$(dpkg --print-architecture) && \
-{{- else}}
-RUN mkdir -p /tmp/downloads && \
-    ARCH=$(dpkg --print-architecture) && \
-{{- end}}
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/dockerfile_test.go
+++ b/internal/bundler/dockerfile_test.go
@@ -360,7 +360,7 @@ func TestBuildContext_ClawkerdIsPID1(t *testing.T) {
 // TestBuildContext_HarnessVersionIsARG pins the ENV→ARG conversion. ARG
 // (not ENV) is required so the ARG-cache behaviour applies: a changed value
 // busts cache at the ARG's declaration line (BuildKit) — so the declaration
-// is placed directly above its only consumer, keeping apt/Node/git-delta/
+// is placed directly above its only consumer, keeping apt/Node/
 // zsh-in-docker cached above. ENV would create a layer whose hash propagates
 // downward and bust every layer below.
 func TestBuildContext_HarnessVersionIsARG(t *testing.T) {
@@ -379,7 +379,7 @@ func TestBuildContext_HarnessVersionIsARG(t *testing.T) {
 	// consumer (the install RUN), AFTER the expensive upstream layers. BuildKit
 	// busts the cache at an ARG's declaration line (not at first use), so a CC
 	// release that rolls the rendered default must invalidate only the install
-	// layer downward — never the Node/git-delta/zsh-in-docker chain. Hoisting
+	// layer downward — never the Node/zsh-in-docker chain. Hoisting
 	// the declaration up the stage reintroduces a full rebuild on every release.
 	argIdx := strings.Index(content, "ARG CLAUDE_CODE_VERSION=")
 	nvmIdx := strings.Index(content, "raw.githubusercontent.com/nvm-sh/nvm")

--- a/internal/bundler/testdata/golden/harness-overlay.base.Dockerfile
+++ b/internal/bundler/testdata/golden/harness-overlay.base.Dockerfile
@@ -118,20 +118,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR /workspace
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-RUN --mount=type=cache,target=/tmp/downloads \
-    ARCH=$(dpkg --print-architecture) && \
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/testdata/golden/harness-overlay.harness.Dockerfile
+++ b/internal/bundler/testdata/golden/harness-overlay.harness.Dockerfile
@@ -243,7 +243,7 @@ SHELL ["/bin/zsh", "-o", "pipefail", "-c"]
 # cache at an ARG's DECLARATION line, not at first use — that "first use, not
 # definition" rule is the classic (pre-BuildKit) builder's, and Docker 23+
 # builds with BuildKit by default. Hoisting this declaration up the stage would
-# re-run every layer below it (stacks, git-delta, zsh-in-docker, ...) on
+# re-run every layer below it (stacks, zsh-in-docker, ...) on
 # every CC release. Adjacent placement scopes the CC-version cache miss to the
 # install layer + the late root block alone.
 # Override: clawker build --build-arg CLAUDE_CODE_VERSION=<version>

--- a/internal/bundler/testdata/golden/minimal-buildkit.base.Dockerfile
+++ b/internal/bundler/testdata/golden/minimal-buildkit.base.Dockerfile
@@ -118,20 +118,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR /workspace
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-RUN --mount=type=cache,target=/tmp/downloads \
-    ARCH=$(dpkg --print-architecture) && \
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/testdata/golden/minimal-buildkit.harness.Dockerfile
+++ b/internal/bundler/testdata/golden/minimal-buildkit.harness.Dockerfile
@@ -197,7 +197,7 @@ SHELL ["/bin/zsh", "-o", "pipefail", "-c"]
 # cache at an ARG's DECLARATION line, not at first use — that "first use, not
 # definition" rule is the classic (pre-BuildKit) builder's, and Docker 23+
 # builds with BuildKit by default. Hoisting this declaration up the stage would
-# re-run every layer below it (stacks, git-delta, zsh-in-docker, ...) on
+# re-run every layer below it (stacks, zsh-in-docker, ...) on
 # every CC release. Adjacent placement scopes the CC-version cache miss to the
 # install layer + the late root block alone.
 # Override: clawker build --build-arg CLAUDE_CODE_VERSION=<version>

--- a/internal/bundler/testdata/golden/minimal.base.Dockerfile
+++ b/internal/bundler/testdata/golden/minimal.base.Dockerfile
@@ -114,20 +114,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR /workspace
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-RUN mkdir -p /tmp/downloads && \
-    ARCH=$(dpkg --print-architecture) && \
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/testdata/golden/minimal.harness.Dockerfile
+++ b/internal/bundler/testdata/golden/minimal.harness.Dockerfile
@@ -193,7 +193,7 @@ SHELL ["/bin/zsh", "-o", "pipefail", "-c"]
 # cache at an ARG's DECLARATION line, not at first use — that "first use, not
 # definition" rule is the classic (pre-BuildKit) builder's, and Docker 23+
 # builds with BuildKit by default. Hoisting this declaration up the stage would
-# re-run every layer below it (stacks, git-delta, zsh-in-docker, ...) on
+# re-run every layer below it (stacks, zsh-in-docker, ...) on
 # every CC release. Adjacent placement scopes the CC-version cache miss to the
 # install layer + the late root block alone.
 # Override: clawker build --build-arg CLAUDE_CODE_VERSION=<version>

--- a/internal/bundler/testdata/golden/packages-instructions-inject.base.Dockerfile
+++ b/internal/bundler/testdata/golden/packages-instructions-inject.base.Dockerfile
@@ -124,20 +124,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR /workspace
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-RUN --mount=type=cache,target=/tmp/downloads \
-    ARCH=$(dpkg --print-architecture) && \
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/testdata/golden/packages-instructions-inject.harness.Dockerfile
+++ b/internal/bundler/testdata/golden/packages-instructions-inject.harness.Dockerfile
@@ -197,7 +197,7 @@ SHELL ["/bin/zsh", "-o", "pipefail", "-c"]
 # cache at an ARG's DECLARATION line, not at first use — that "first use, not
 # definition" rule is the classic (pre-BuildKit) builder's, and Docker 23+
 # builds with BuildKit by default. Hoisting this declaration up the stage would
-# re-run every layer below it (stacks, git-delta, zsh-in-docker, ...) on
+# re-run every layer below it (stacks, zsh-in-docker, ...) on
 # every CC release. Adjacent placement scopes the CC-version cache miss to the
 # install layer + the late root block alone.
 # Override: clawker build --build-arg CLAUDE_CODE_VERSION=<version>

--- a/internal/bundler/testdata/golden/qualified-stack.base.Dockerfile
+++ b/internal/bundler/testdata/golden/qualified-stack.base.Dockerfile
@@ -119,20 +119,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR /workspace
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-RUN --mount=type=cache,target=/tmp/downloads \
-    ARCH=$(dpkg --print-architecture) && \
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/testdata/golden/telemetry-flags-off.base.Dockerfile
+++ b/internal/bundler/testdata/golden/telemetry-flags-off.base.Dockerfile
@@ -114,20 +114,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 
 WORKDIR /workspace
 
-# Install git-delta
-ARG GIT_DELTA_VERSION=0.19.1
-ARG GIT_DELTA_SHA256_AMD64=3b3064c5e474d120366f5917f54c612bbfd5733a70e5d10988d8028c7c877de9
-ARG GIT_DELTA_SHA256_ARM64=1bd252110eafa1065c0798f9e68de0682127408e4b53db79733efa72c53b68bf
-RUN mkdir -p /tmp/downloads && \
-    ARCH=$(dpkg --print-architecture) && \
-    DEB="git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
-    [ -f "/tmp/downloads/$DEB" ] || wget -O "/tmp/downloads/$DEB" "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/$DEB" && \
-    if [ "$ARCH" = "amd64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_AMD64}"; \
-    elif [ "$ARCH" = "arm64" ]; then EXPECTED_SHA="${GIT_DELTA_SHA256_ARM64}"; \
-    else echo "ERROR: git-delta does not support architecture: $ARCH (only amd64 and arm64)" >&2; exit 1; fi && \
-    echo "$EXPECTED_SHA  /tmp/downloads/$DEB" | sha256sum -c - && \
-    dpkg -i "/tmp/downloads/$DEB"
-
 # Switch to non-root user for ENV/WORKDIR resolution. clawkerd (PID 1)
 # is invoked as root by Docker — the USER directive only affects
 # ENV/WORKDIR/RUN scope below this line. The harness image switches back

--- a/internal/bundler/testdata/golden/telemetry-flags-off.harness.Dockerfile
+++ b/internal/bundler/testdata/golden/telemetry-flags-off.harness.Dockerfile
@@ -189,7 +189,7 @@ SHELL ["/bin/zsh", "-o", "pipefail", "-c"]
 # cache at an ARG's DECLARATION line, not at first use — that "first use, not
 # definition" rule is the classic (pre-BuildKit) builder's, and Docker 23+
 # builds with BuildKit by default. Hoisting this declaration up the stage would
-# re-run every layer below it (stacks, git-delta, zsh-in-docker, ...) on
+# re-run every layer below it (stacks, zsh-in-docker, ...) on
 # every CC release. Adjacent placement scopes the CC-version cache miss to the
 # install layer + the late root block alone.
 # Override: clawker build --build-arg CLAUDE_CODE_VERSION=<version>


### PR DESCRIPTION
## Problem

Base image builds fail on amd64 linux at the git-delta install step:

```
dpkg: dependency problems prevent configuration of git-delta ... leaving unconfigured
```

Root cause: the pinned git-delta 0.19.1 amd64 .deb declares `libc6 (>= 2.39)` (a known upstream issue — the 0.19.x amd64 release deb was built against a newer glibc; upstream rebuilt for Debian 12 in 0.19.2 and added a release-time libc6 compat check). Our base is `debian:bookworm-slim` with glibc 2.36, so `dpkg -i` fails on amd64. The sha and arch checks pass — only the dependency check fails, and only on amd64.

## Fix

Remove git-delta from the image floor entirely rather than chasing the version pin — it was convenience tooling, not load-bearing.

- Drop the install block from `internal/bundler/assets/Dockerfile.base.tmpl`
- Regenerate bundler golden files
- Scrub git-delta from layer-cache comments in the harness template and tests
- Update `docs/custom-images.mdx` floor package list
- Plugin reference template synced in schmitthub/clawker-plugin#5 (calver 2026.8.3); submodule pointer bump to follow after that merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)