### PR TITLE
fix: resolve host Docker socket via DOCKER_HOST and docker.socket setting

### DIFF
--- a/controlplane/manager/container_config_test.go
+++ b/controlplane/manager/container_config_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/moby/moby/api/types/mount"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -229,25 +230,43 @@ func TestINV_B1_020_ConfigDirMounted(t *testing.T) {
 
 // Tests that Docker socket is bind-mounted read-only for container state verification.
 func TestCPContainerConfig_DockerSocketMounted(t *testing.T) {
-	testenv.New(t)
-	cfg := configmocks.NewBlankConfig()
+	dockerSocketMount := func(t *testing.T) (mount.Mount, bool) {
+		t.Helper()
+		testenv.New(t)
+		cfg := configmocks.NewBlankConfig()
 
-	cpConfig, err := BuildCPContainerConfig(cfg, testCPOpts())
-	require.NoError(t, err)
+		cpConfig, err := BuildCPContainerConfig(cfg, testCPOpts())
+		require.NoError(t, err)
 
-	found := false
-	for _, m := range cpConfig.Mounts {
-		if m.Target == "/var/run/docker.sock" {
-			found = true
-			assert.Equal(t, "/var/run/docker.sock", m.Source,
-				"Docker socket source must be /var/run/docker.sock")
-			assert.True(t, m.ReadOnly,
-				"Docker socket must be mounted read-only")
-			break
+		for _, m := range cpConfig.Mounts {
+			if m.Target == consts.DefaultDockerSocketPath {
+				return m, true
+			}
 		}
+		return mount.Mount{}, false
 	}
-	assert.True(t, found,
-		"Docker socket must be bind-mounted into the CP container")
+
+	t.Run("default host socket", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "")
+		m, found := dockerSocketMount(t)
+		require.True(t, found,
+			"Docker socket must be bind-mounted into the CP container")
+		assert.Equal(t, consts.DefaultDockerSocketPath, m.Source)
+		assert.True(t, m.ReadOnly,
+			"Docker socket must be mounted read-only")
+	})
+
+	t.Run("rootless DOCKER_HOST socket", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "unix:///run/user/1003/docker.sock")
+		m, found := dockerSocketMount(t)
+		require.True(t, found,
+			"Docker socket must be bind-mounted into the CP container")
+		assert.Equal(t, "/run/user/1003/docker.sock", m.Source,
+			"bind source must follow the host's actual socket path")
+		assert.Equal(t, consts.DefaultDockerSocketPath, m.Target,
+			"in-container target stays the conventional path")
+		assert.True(t, m.ReadOnly)
+	})
 }
 
 // Tests INV-B1-020 [unit]: CLAWKER_CONFIG_DIR env var is set.

--- a/controlplane/manager/cp_container.go
+++ b/controlplane/manager/cp_container.go
@@ -282,10 +282,13 @@ func BuildCPContainerConfig(cfg config.Config, opts CPContainerOpts) (*CPContain
 		},
 		// Docker socket — CP needs Docker API access to verify container
 		// existence (bypass timer dead-man switch, future lifecycle ops).
+		// Source resolves the host's actual socket ($DOCKER_HOST /
+		// settings override aware); target stays the conventional path
+		// the CP daemon's Docker client expects.
 		{
 			Type:     mount.TypeBind,
-			Source:   consts.CPDockerSockPath,
-			Target:   consts.CPDockerSockPath,
+			Source:   cfg.DockerSocketPath(),
+			Target:   consts.DefaultDockerSocketPath,
 			ReadOnly: true,
 		},
 		// Firewall state dir — CP is the sole writer (INV-B2-001). Envoy

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -567,7 +567,7 @@ control_plane:
   # In-container gRPC port for clawkerd agent connections (mTLS, clawker-net only)
   agent_port: <integer>  # default: 7444 | required: false
 docker:
-  # Host path to the Docker daemon socket
+  # Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence
   socket: <string>  # default: /var/run/docker.sock | required: false
 
 ```
@@ -672,7 +672,7 @@ Global settings live at `~/.config/clawker/settings.yaml`. The following tables 
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `socket` | string | `/var/run/docker.sock` | Host path to the Docker daemon socket |
+| `socket` | string | `/var/run/docker.sock` | Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence |
 
 
 You can also place a `clawker.yaml` in `~/.config/clawker/` to set user-level project config defaults. This file is merged as the lowest-priority project config layer (just above built-in defaults), so any project-level `.clawker.yaml` overrides it.

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -567,7 +567,7 @@ control_plane:
   # In-container gRPC port for clawkerd agent connections (mTLS, clawker-net only)
   agent_port: <integer>  # default: 7444 | required: false
 docker:
-  # Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence
+  # Host path to the Docker daemon socket; the DOCKER_HOST env var takes precedence
   socket: <string>  # default: /var/run/docker.sock | required: false
 
 ```
@@ -672,7 +672,7 @@ Global settings live at `~/.config/clawker/settings.yaml`. The following tables 
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `socket` | string | `/var/run/docker.sock` | Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence |
+| `socket` | string | `/var/run/docker.sock` | Host path to the Docker daemon socket; the DOCKER_HOST env var takes precedence |
 
 
 You can also place a `clawker.yaml` in `~/.config/clawker/` to set user-level project config defaults. This file is merged as the lowest-priority project config layer (just above built-in defaults), so any project-level `.clawker.yaml` overrides it.

--- a/docs/schemas/settings.schema.json
+++ b/docs/schemas/settings.schema.json
@@ -68,7 +68,7 @@
       "properties": {
         "socket": {
           "default": "/var/run/docker.sock",
-          "description": "Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence",
+          "description": "Host path to the Docker daemon socket; the DOCKER_HOST env var takes precedence",
           "title": "Docker Socket",
           "type": "string"
         }

--- a/docs/schemas/settings.schema.json
+++ b/docs/schemas/settings.schema.json
@@ -68,7 +68,7 @@
       "properties": {
         "socket": {
           "default": "/var/run/docker.sock",
-          "description": "Host path to the Docker daemon socket",
+          "description": "Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence",
           "title": "Docker Socket",
           "type": "string"
         }

--- a/internal/config/CLAUDE.md
+++ b/internal/config/CLAUDE.md
@@ -105,6 +105,7 @@ default is `true`.
 | `HostProxyConfig()` | `host_proxy` | `HostProxyConfig` |
 | `ControlPlaneSettings()` | `control_plane` | `ControlPlaneSettings` |
 | `FirewallEnabled()` | `firewall.enable` (default **true**) | `bool` |
+| `DockerSocketPath()` | `docker.socket` (unix:// `$DOCKER_HOST` wins; default `/var/run/docker.sock`) | `string` |
 
 `HarnessConfigFor` addresses the map entry as a **key segment**, so a qualified
 harness name (`namespace.bundle.component`) is matched exactly — a dotted key
@@ -196,7 +197,7 @@ Import as `configmocks "github.com/schmitthub/clawker/internal/config/mocks"`.
 - **`*bool` pointers in schema** — Nil means "not set" (defaults apply). Non-nil `false` means "explicitly disabled". Callers must handle nil when accessing raw schema fields on a group struct. `FirewallEnabled()` and the nil-tolerant methods on the group structs (`HostProxyEnabled()`, `MountProjectsEnabled()`, `GitSSHEnabled()`, …) handle nil-to-default conversion.
 - **Unset vs set-empty** — a bare `key:` is unset (transparent: lower layers and defaults show through, `Get` → `ErrKeyNotFound`, accessor → zero value); an explicit `""`/`[]`/`{}` is set-and-empty and wins the merge. Clearing a field is `Remove`, never `Set(key, "")`.
 - **Nil vs zero** — Nil pointers/slices mean "not set" (excluded from storage tree). Non-nil zero values mean "explicitly set to zero" (included). This is a semantic distinction in schema design.
-- **No env var overrides** — `CLAWKER_*` env vars affect only directory resolution (`CLAWKER_CONFIG_DIR`, etc.), not config values.
+- **No env var overrides** — `CLAWKER_*` env vars affect only directory resolution (`CLAWKER_CONFIG_DIR`, etc.), not config values. The one deliberate exception: `DockerSocketPath()` honors a unix:// `$DOCKER_HOST` over `docker.socket` — that variable is the docker CLI's own contract.
 - **Registry owned by project** — both the `ProjectRegistry`/`ProjectEntry`/`WorktreeEntry` schema types and the `Store[ProjectRegistry]` live in `internal/project`. `config` has no registry surface.
 - **Harness/overlay names fail the whole load, not just the field** — `NewConfig`/`NewFromString`/`NewBlankConfig` all call `validateProjectNodes` after loading the project store; a `harnesses:`/`build.harnesses:` key that fails `internal/consts.ValidateHarnessRef` (not lowercase kebab-case, >32 chars per segment, a bad qualified segment count, or a reserved image-tag alias used bare) returns a hard error from the constructor, not a partial/degraded `Config`.
 - **Cross-process safety** — Storage uses `gofrs/flock` advisory lock + atomic temp-file rename. Lock files (`.lock` suffix) are left on disk intentionally.

--- a/internal/config/CLAUDE.md
+++ b/internal/config/CLAUDE.md
@@ -105,7 +105,7 @@ default is `true`.
 | `HostProxyConfig()` | `host_proxy` | `HostProxyConfig` |
 | `ControlPlaneSettings()` | `control_plane` | `ControlPlaneSettings` |
 | `FirewallEnabled()` | `firewall.enable` (default **true**) | `bool` |
-| `DockerSocketPath()` | `docker.socket` (unix:// `$DOCKER_HOST` wins; default `/var/run/docker.sock`) | `string` |
+| `DockerSocketPath()` | `docker.socket` (`$DOCKER_HOST` wins, unix:// prefix stripped, no validation; default `/var/run/docker.sock`) | `string` |
 
 `HarnessConfigFor` addresses the map entry as a **key segment**, so a qualified
 harness name (`namespace.bundle.component`) is matched exactly — a dotted key
@@ -197,7 +197,7 @@ Import as `configmocks "github.com/schmitthub/clawker/internal/config/mocks"`.
 - **`*bool` pointers in schema** — Nil means "not set" (defaults apply). Non-nil `false` means "explicitly disabled". Callers must handle nil when accessing raw schema fields on a group struct. `FirewallEnabled()` and the nil-tolerant methods on the group structs (`HostProxyEnabled()`, `MountProjectsEnabled()`, `GitSSHEnabled()`, …) handle nil-to-default conversion.
 - **Unset vs set-empty** — a bare `key:` is unset (transparent: lower layers and defaults show through, `Get` → `ErrKeyNotFound`, accessor → zero value); an explicit `""`/`[]`/`{}` is set-and-empty and wins the merge. Clearing a field is `Remove`, never `Set(key, "")`.
 - **Nil vs zero** — Nil pointers/slices mean "not set" (excluded from storage tree). Non-nil zero values mean "explicitly set to zero" (included). This is a semantic distinction in schema design.
-- **No env var overrides** — `CLAWKER_*` env vars affect only directory resolution (`CLAWKER_CONFIG_DIR`, etc.), not config values. The one deliberate exception: `DockerSocketPath()` honors a unix:// `$DOCKER_HOST` over `docker.socket` — that variable is the docker CLI's own contract.
+- **No env var overrides** — `CLAWKER_*` env vars affect only directory resolution (`CLAWKER_CONFIG_DIR`, etc.), not config values. The one deliberate exception: `DockerSocketPath()` honors `$DOCKER_HOST` (unix:// prefix stripped, no validation) over `docker.socket` — that variable is the docker CLI's own contract.
 - **Registry owned by project** — both the `ProjectRegistry`/`ProjectEntry`/`WorktreeEntry` schema types and the `Store[ProjectRegistry]` live in `internal/project`. `config` has no registry surface.
 - **Harness/overlay names fail the whole load, not just the field** — `NewConfig`/`NewFromString`/`NewBlankConfig` all call `validateProjectNodes` after loading the project store; a `harnesses:`/`build.harnesses:` key that fails `internal/consts.ValidateHarnessRef` (not lowercase kebab-case, >32 chars per segment, a bad qualified segment count, or a reserved image-tag alias used bare) returns a hard error from the constructor, not a partial/degraded `Config`.
 - **Cross-process safety** — Storage uses `gofrs/flock` advisory lock + atomic temp-file rename. Lock files (`.lock` suffix) are left on disk intentionally.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,10 +138,11 @@ type Config interface {
 
 	// DockerSocketPath returns the host-side Docker daemon socket path used
 	// as the bind-mount source for Docker socket mounts. Resolution follows
-	// docker CLI parity — environment beats stored configuration: a unix://
-	// $DOCKER_HOST wins, then settings `docker.socket`, then
-	// consts.DefaultDockerSocketPath. The in-container mount target is
-	// always consts.DefaultDockerSocketPath, independent of this value.
+	// docker CLI parity — environment beats stored configuration:
+	// $DOCKER_HOST (unix:// prefix stripped) wins, then settings
+	// `docker.socket`, then consts.DefaultDockerSocketPath. Values are not
+	// validated. The in-container mount target is always
+	// consts.DefaultDockerSocketPath, independent of this value.
 	DockerSocketPath() string
 
 	// BundleDeclarations returns every declared bundle source paired with the
@@ -818,13 +819,15 @@ func (c *configImpl) FirewallEnabled() bool {
 }
 
 // DockerSocketPath resolves the host Docker socket path: $DOCKER_HOST
-// (unix:// only) > settings docker.socket > default. The env override is a
-// deliberate exception to the no-env-value-overrides rule — DOCKER_HOST is
-// the docker CLI's own contract, and a bind source that ignores it breaks
-// any host whose daemon serves the socket away from the conventional path
-// (rootless Docker under $XDG_RUNTIME_DIR being the common case).
+// (unix:// prefix stripped, otherwise verbatim) > settings docker.socket >
+// default. The env override is a deliberate exception to the
+// no-env-value-overrides rule — DOCKER_HOST is the docker CLI's own
+// contract, and a bind source that ignores it breaks any host whose daemon
+// serves the socket away from the conventional path (rootless Docker under
+// $XDG_RUNTIME_DIR being the common case). Values are not validated; a
+// non-path value surfaces in the daemon's own mount error.
 func (c *configImpl) DockerSocketPath() string {
-	if path, ok := consts.DockerHostSocketPath(); ok {
+	if path := consts.DockerHostSocketPath(); path != "" {
 		return path
 	}
 	socket, err := storage.Get[string](c.settings, keyDocker, keySocket)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,6 +136,14 @@ type Config interface {
 	// (`firewall.enable`), defaulting to true when unset.
 	FirewallEnabled() bool
 
+	// DockerSocketPath returns the host-side Docker daemon socket path used
+	// as the bind-mount source for Docker socket mounts. Resolution follows
+	// docker CLI parity — environment beats stored configuration: a unix://
+	// $DOCKER_HOST wins, then settings `docker.socket`, then
+	// consts.DefaultDockerSocketPath. The in-container mount target is
+	// always consts.DefaultDockerSocketPath, independent of this value.
+	DockerSocketPath() string
+
 	// BundleDeclarations returns every declared bundle source paired with the
 	// clawker.yaml layer that declared it, highest-priority layer first. The
 	// union-merged bundles: list loses per-entry provenance; the
@@ -807,4 +815,21 @@ func (c *configImpl) FirewallEnabled() bool {
 		return true
 	}
 	return enabled
+}
+
+// DockerSocketPath resolves the host Docker socket path: $DOCKER_HOST
+// (unix:// only) > settings docker.socket > default. The env override is a
+// deliberate exception to the no-env-value-overrides rule — DOCKER_HOST is
+// the docker CLI's own contract, and a bind source that ignores it breaks
+// any host whose daemon serves the socket away from the conventional path
+// (rootless Docker under $XDG_RUNTIME_DIR being the common case).
+func (c *configImpl) DockerSocketPath() string {
+	if path, ok := consts.DockerHostSocketPath(); ok {
+		return path
+	}
+	socket, err := storage.Get[string](c.settings, keyDocker, keySocket)
+	if err != nil || socket == "" {
+		return consts.DefaultDockerSocketPath
+	}
+	return socket
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -638,11 +638,12 @@ func TestDockerSocketPath(t *testing.T) {
 		assert.Equal(t, "/run/user/1003/docker.sock", cfg.DockerSocketPath())
 	})
 
-	t.Run("non-unix DOCKER_HOST falls through to settings", func(t *testing.T) {
+	t.Run("non-unix DOCKER_HOST passes through verbatim", func(t *testing.T) {
 		t.Setenv(consts.EnvDockerHost, "tcp://127.0.0.1:2375")
 		cfg, err := NewFromString("", "docker:\n  socket: /custom/docker.sock\n")
 		require.NoError(t, err)
-		assert.Equal(t, "/custom/docker.sock", cfg.DockerSocketPath())
+		assert.Equal(t, "tcp://127.0.0.1:2375", cfg.DockerSocketPath(),
+			"no validation — the daemon's mount error names the raw value")
 	})
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -609,6 +609,43 @@ func TestFirewallEnabled_NilMeansEnabled(t *testing.T) {
 		"an unset firewall.enable should default to enabled")
 }
 
+func TestDockerSocketPath(t *testing.T) {
+	t.Run("default when nothing set", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "")
+		cfg, err := NewFromString("", "")
+		require.NoError(t, err)
+		assert.Equal(t, consts.DefaultDockerSocketPath, cfg.DockerSocketPath())
+	})
+
+	t.Run("defaults layer supplies default", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "")
+		cfg, err := NewBlankConfig()
+		require.NoError(t, err)
+		assert.Equal(t, consts.DefaultDockerSocketPath, cfg.DockerSocketPath())
+	})
+
+	t.Run("settings docker.socket wins over default", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "")
+		cfg, err := NewFromString("", "docker:\n  socket: /custom/docker.sock\n")
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/docker.sock", cfg.DockerSocketPath())
+	})
+
+	t.Run("DOCKER_HOST unix socket wins over settings", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "unix:///run/user/1003/docker.sock")
+		cfg, err := NewFromString("", "docker:\n  socket: /custom/docker.sock\n")
+		require.NoError(t, err)
+		assert.Equal(t, "/run/user/1003/docker.sock", cfg.DockerSocketPath())
+	})
+
+	t.Run("non-unix DOCKER_HOST falls through to settings", func(t *testing.T) {
+		t.Setenv(consts.EnvDockerHost, "tcp://127.0.0.1:2375")
+		cfg, err := NewFromString("", "docker:\n  socket: /custom/docker.sock\n")
+		require.NoError(t, err)
+		assert.Equal(t, "/custom/docker.sock", cfg.DockerSocketPath())
+	})
+}
+
 // TestProjectInit_WritesOnlyWhatItSet reproduces the bug where the file project
 // init wrote carried empty string fields (agent.editor: "", agent.visual: "")
 // that then shadowed the real values in the user-level config (agent.editor:

--- a/internal/config/consts.go
+++ b/internal/config/consts.go
@@ -78,6 +78,8 @@ const (
 	keyMonitoring   = "monitoring"
 	keyHostProxy    = "host_proxy"
 	keyControlPlane = "control_plane"
+	keyDocker       = "docker"
+	keySocket       = "socket"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/config/mocks/config_mock.go
+++ b/internal/config/mocks/config_mock.go
@@ -73,6 +73,9 @@ var _ config.Config = &ConfigMock{}
 //			DataDirEnvVarFunc: func() string {
 //				panic("mock out the DataDirEnvVar method")
 //			},
+//			DockerSocketPathFunc: func() string {
+//				panic("mock out the DockerSocketPath method")
+//			},
 //			DomainFunc: func() string {
 //				panic("mock out the Domain method")
 //			},
@@ -308,6 +311,9 @@ type ConfigMock struct {
 	// DataDirEnvVarFunc mocks the DataDirEnvVar method.
 	DataDirEnvVarFunc func() string
 
+	// DockerSocketPathFunc mocks the DockerSocketPath method.
+	DockerSocketPathFunc func() string
+
 	// DomainFunc mocks the Domain method.
 	DomainFunc func() string
 
@@ -540,6 +546,9 @@ type ConfigMock struct {
 		// DataDirEnvVar holds details about calls to the DataDirEnvVar method.
 		DataDirEnvVar []struct {
 		}
+		// DockerSocketPath holds details about calls to the DockerSocketPath method.
+		DockerSocketPath []struct {
+		}
 		// Domain holds details about calls to the Domain method.
 		Domain []struct {
 		}
@@ -739,6 +748,7 @@ type ConfigMock struct {
 	lockCoreDNSHealthPath       sync.RWMutex
 	lockCoreDNSIPLastOctet      sync.RWMutex
 	lockDataDirEnvVar           sync.RWMutex
+	lockDockerSocketPath        sync.RWMutex
 	lockDomain                  sync.RWMutex
 	lockEgressRulesFileName     sync.RWMutex
 	lockEngineLabelPrefix       sync.RWMutex
@@ -1287,6 +1297,33 @@ func (mock *ConfigMock) DataDirEnvVarCalls() []struct {
 	mock.lockDataDirEnvVar.RLock()
 	calls = mock.calls.DataDirEnvVar
 	mock.lockDataDirEnvVar.RUnlock()
+	return calls
+}
+
+// DockerSocketPath calls DockerSocketPathFunc.
+func (mock *ConfigMock) DockerSocketPath() string {
+	if mock.DockerSocketPathFunc == nil {
+		panic("ConfigMock.DockerSocketPathFunc: method is nil but Config.DockerSocketPath was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockDockerSocketPath.Lock()
+	mock.calls.DockerSocketPath = append(mock.calls.DockerSocketPath, callInfo)
+	mock.lockDockerSocketPath.Unlock()
+	return mock.DockerSocketPathFunc()
+}
+
+// DockerSocketPathCalls gets all the calls that were made to DockerSocketPath.
+// Check the length with:
+//
+//	len(mockedConfig.DockerSocketPathCalls())
+func (mock *ConfigMock) DockerSocketPathCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockDockerSocketPath.RLock()
+	calls = mock.calls.DockerSocketPath
+	mock.lockDockerSocketPath.RUnlock()
 	return calls
 }
 

--- a/internal/config/mocks/stubs.go
+++ b/internal/config/mocks/stubs.go
@@ -67,6 +67,7 @@ func newMockFrom(cfg config.Config) *ConfigMock {
 	mock.HostProxyConfigFunc = cfg.HostProxyConfig
 	mock.ControlPlaneSettingsFunc = cfg.ControlPlaneSettings
 	mock.FirewallEnabledFunc = cfg.FirewallEnabled
+	mock.DockerSocketPathFunc = cfg.DockerSocketPath
 	mock.EgressRulesFileNameFunc = cfg.EgressRulesFileName
 
 	// Constants

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -389,7 +389,7 @@ type Settings struct {
 // socket exposure to agent containers lives separately under
 // SecurityConfig.DockerSocket — these knobs are unrelated.
 type DockerSettings struct {
-	Socket string `yaml:"socket,omitempty" label:"Docker Socket" desc:"Host path to the Docker daemon socket" default:"/var/run/docker.sock"`
+	Socket string `yaml:"socket,omitempty" label:"Docker Socket" desc:"Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence" default:"/var/run/docker.sock"`
 }
 
 // ControlPlaneSettings configures the control plane in settings.yaml.

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -389,7 +389,7 @@ type Settings struct {
 // socket exposure to agent containers lives separately under
 // SecurityConfig.DockerSocket — these knobs are unrelated.
 type DockerSettings struct {
-	Socket string `yaml:"socket,omitempty" label:"Docker Socket" desc:"Host path to the Docker daemon socket; a unix:// DOCKER_HOST env var takes precedence" default:"/var/run/docker.sock"`
+	Socket string `yaml:"socket,omitempty" label:"Docker Socket" desc:"Host path to the Docker daemon socket; the DOCKER_HOST env var takes precedence" default:"/var/run/docker.sock"`
 }
 
 // ControlPlaneSettings configures the control plane in settings.yaml.

--- a/internal/consts/controlplane.go
+++ b/internal/consts/controlplane.go
@@ -151,9 +151,6 @@ const (
 	// same path in the container's own filesystem.
 	CPLogsPath = "/var/log/clawker"
 
-	// CPDockerSockPath is the host-side Docker socket path.
-	CPDockerSockPath = "/var/run/docker.sock"
-
 	// CPClawkerDataDir is the container-side directory for Clawker data.
 	CPClawkerDataDir = "/usr/local/share/clawker"
 

--- a/internal/consts/docker.go
+++ b/internal/consts/docker.go
@@ -13,12 +13,15 @@ import (
 // daemons put it anywhere). Resolution order (docker CLI parity: environment
 // beats stored configuration):
 //
-//  1. $DOCKER_HOST with a unix:// address → its path (DockerHostSocketPath)
+//  1. $DOCKER_HOST, unix:// prefix stripped (DockerHostSocketPath)
 //  2. settings.yaml docker.socket (config.Config.DockerSocketPath composes this)
 //  3. DefaultDockerSocketPath
 //
-// The mount TARGET is always DefaultDockerSocketPath — in-container tools
-// expect the conventional location regardless of where the host serves it.
+// No value is validated — a non-path $DOCKER_HOST flows through and the
+// Docker daemon rejects the mount naming it, exactly like the CLI's own
+// pass-through contract. The mount TARGET is always DefaultDockerSocketPath —
+// in-container tools expect the conventional location regardless of where
+// the host serves it.
 const (
 	// EnvDockerHost is the standard Docker daemon-address override honored
 	// by the docker CLI and SDK (e.g. unix:///run/user/1003/docker.sock).
@@ -34,16 +37,10 @@ const (
 	unixSocketScheme = "unix://"
 )
 
-// DockerHostSocketPath returns the host socket path named by $DOCKER_HOST
-// and true when the variable holds a unix:// address. The other daemon
-// address schemes (tcp://, npipe://, fd://, and docker/cli's ssh://) return
-// false — none names a host filesystem path a bind mount could carry, so
-// callers fall through to configured/default resolution.
-func DockerHostSocketPath() (string, bool) {
-	host := os.Getenv(EnvDockerHost)
-	path, found := strings.CutPrefix(host, unixSocketScheme)
-	if !found || path == "" {
-		return "", false
-	}
-	return path, true
+// DockerHostSocketPath returns $DOCKER_HOST with a unix:// prefix stripped,
+// or "" when unset. It is a dumb getter — no scheme validation: a non-path
+// value passes through verbatim and the Docker daemon rejects the mount
+// naming that exact value, which is the error surface.
+func DockerHostSocketPath() string {
+	return strings.TrimPrefix(os.Getenv(EnvDockerHost), unixSocketScheme)
 }

--- a/internal/consts/docker.go
+++ b/internal/consts/docker.go
@@ -1,0 +1,48 @@
+package consts
+
+import (
+	"os"
+	"strings"
+)
+
+// Host Docker daemon socket resolution.
+//
+// The bind-mount SOURCE for Docker socket mounts must name the socket where
+// it actually lives on the host, which is not always the conventional path
+// (rootless Docker serves it from $XDG_RUNTIME_DIR/docker.sock; custom
+// daemons put it anywhere). Resolution order (docker CLI parity: environment
+// beats stored configuration):
+//
+//  1. $DOCKER_HOST with a unix:// address → its path (DockerHostSocketPath)
+//  2. settings.yaml docker.socket (config.Config.DockerSocketPath composes this)
+//  3. DefaultDockerSocketPath
+//
+// The mount TARGET is always DefaultDockerSocketPath — in-container tools
+// expect the conventional location regardless of where the host serves it.
+const (
+	// EnvDockerHost is the standard Docker daemon-address override honored
+	// by the docker CLI and SDK (e.g. unix:///run/user/1003/docker.sock).
+	EnvDockerHost = "DOCKER_HOST"
+
+	// DefaultDockerSocketPath is the conventional Docker socket path: the
+	// host-side fallback when nothing overrides it, and always the
+	// in-container mount target.
+	DefaultDockerSocketPath = "/var/run/docker.sock"
+
+	// unixSocketScheme prefixes a DOCKER_HOST value that names a host
+	// filesystem socket path.
+	unixSocketScheme = "unix://"
+)
+
+// DockerHostSocketPath returns the host socket path named by $DOCKER_HOST
+// and true when the variable holds a unix:// address. Non-unix schemes
+// (tcp://, ssh://) return false — they name no host path a bind mount could
+// use, so callers fall through to configured/default resolution.
+func DockerHostSocketPath() (string, bool) {
+	host := os.Getenv(EnvDockerHost)
+	path, found := strings.CutPrefix(host, unixSocketScheme)
+	if !found || path == "" {
+		return "", false
+	}
+	return path, true
+}

--- a/internal/consts/docker.go
+++ b/internal/consts/docker.go
@@ -35,9 +35,10 @@ const (
 )
 
 // DockerHostSocketPath returns the host socket path named by $DOCKER_HOST
-// and true when the variable holds a unix:// address. Non-unix schemes
-// (tcp://, ssh://) return false — they name no host path a bind mount could
-// use, so callers fall through to configured/default resolution.
+// and true when the variable holds a unix:// address. The other daemon
+// address schemes (tcp://, npipe://, fd://, and docker/cli's ssh://) return
+// false — none names a host filesystem path a bind mount could carry, so
+// callers fall through to configured/default resolution.
 func DockerHostSocketPath() (string, bool) {
 	host := os.Getenv(EnvDockerHost)
 	path, found := strings.CutPrefix(host, unixSocketScheme)

--- a/internal/consts/docker_test.go
+++ b/internal/consts/docker_test.go
@@ -1,0 +1,43 @@
+package consts_test
+
+import (
+	"testing"
+
+	"github.com/schmitthub/clawker/internal/consts"
+)
+
+func TestDockerHostSocketPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		wantPath string
+		wantOK   bool
+	}{
+		{name: "unset", env: "", wantPath: "", wantOK: false},
+		{
+			name:     "rootless unix socket",
+			env:      "unix:///run/user/1003/docker.sock",
+			wantPath: "/run/user/1003/docker.sock",
+			wantOK:   true,
+		},
+		{
+			name:     "default unix socket",
+			env:      "unix:///var/run/docker.sock",
+			wantPath: "/var/run/docker.sock",
+			wantOK:   true,
+		},
+		{name: "tcp scheme ignored", env: "tcp://127.0.0.1:2375", wantPath: "", wantOK: false},
+		{name: "ssh scheme ignored", env: "ssh://user@host", wantPath: "", wantOK: false},
+		{name: "unix scheme with empty path ignored", env: "unix://", wantPath: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(consts.EnvDockerHost, tt.env)
+			got, ok := consts.DockerHostSocketPath()
+			if ok != tt.wantOK || got != tt.wantPath {
+				t.Errorf("DockerHostSocketPath() = (%q, %v), want (%q, %v)",
+					got, ok, tt.wantPath, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/consts/docker_test.go
+++ b/internal/consts/docker_test.go
@@ -8,35 +8,29 @@ import (
 
 func TestDockerHostSocketPath(t *testing.T) {
 	tests := []struct {
-		name     string
-		env      string
-		wantPath string
-		wantOK   bool
+		name string
+		env  string
+		want string
 	}{
-		{name: "unset", env: "", wantPath: "", wantOK: false},
+		{name: "unset", env: "", want: ""},
 		{
-			name:     "rootless unix socket",
-			env:      "unix:///run/user/1003/docker.sock",
-			wantPath: "/run/user/1003/docker.sock",
-			wantOK:   true,
+			name: "rootless unix socket",
+			env:  "unix:///run/user/1003/docker.sock",
+			want: "/run/user/1003/docker.sock",
 		},
 		{
-			name:     "default unix socket",
-			env:      "unix:///var/run/docker.sock",
-			wantPath: "/var/run/docker.sock",
-			wantOK:   true,
+			name: "default unix socket",
+			env:  "unix:///var/run/docker.sock",
+			want: "/var/run/docker.sock",
 		},
-		{name: "tcp scheme ignored", env: "tcp://127.0.0.1:2375", wantPath: "", wantOK: false},
-		{name: "ssh scheme ignored", env: "ssh://user@host", wantPath: "", wantOK: false},
-		{name: "unix scheme with empty path ignored", env: "unix://", wantPath: "", wantOK: false},
+		{name: "non-unix value passes through verbatim", env: "tcp://127.0.0.1:2375", want: "tcp://127.0.0.1:2375"},
+		{name: "fd value passes through verbatim", env: "fd://", want: "fd://"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(consts.EnvDockerHost, tt.env)
-			got, ok := consts.DockerHostSocketPath()
-			if ok != tt.wantOK || got != tt.wantPath {
-				t.Errorf("DockerHostSocketPath() = (%q, %v), want (%q, %v)",
-					got, ok, tt.wantPath, tt.wantOK)
+			if got := consts.DockerHostSocketPath(); got != tt.want {
+				t.Errorf("DockerHostSocketPath() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/workspace/CLAUDE.md
+++ b/internal/workspace/CLAUDE.md
@@ -127,10 +127,13 @@ func GetGitConfigMount(log *logger.Logger) []mount.Mount
 ## Docker Socket
 
 ```go
-func GetDockerSocketMount() mount.Mount
+func GetDockerSocketMount(hostSocketPath string) mount.Mount
 ```
 
-Only available when `security.docker_socket: true`.
+Only available when `security.docker_socket: true`. Callers pass
+`config.Config.DockerSocketPath()` as the bind source (unix:// `DOCKER_HOST` >
+settings `docker.socket` > default); the target is always
+`consts.DefaultDockerSocketPath`.
 
 ## Share Directory (Bind Mount)
 

--- a/internal/workspace/CLAUDE.md
+++ b/internal/workspace/CLAUDE.md
@@ -131,7 +131,7 @@ func GetDockerSocketMount(hostSocketPath string) mount.Mount
 ```
 
 Only available when `security.docker_socket: true`. Callers pass
-`config.Config.DockerSocketPath()` as the bind source (unix:// `DOCKER_HOST` >
+`config.Config.DockerSocketPath()` as the bind source (`DOCKER_HOST` >
 settings `docker.socket` > default); the target is always
 `consts.DefaultDockerSocketPath`.
 

--- a/internal/workspace/setup.go
+++ b/internal/workspace/setup.go
@@ -257,7 +257,7 @@ func SetupMounts(ctx context.Context, client *docker.Client, cfg SetupMountsConf
 
 	// Add docker socket mount if enabled
 	if cfg.Cfg.SecurityConfig().DockerSocket {
-		mounts = append(mounts, GetDockerSocketMount())
+		mounts = append(mounts, GetDockerSocketMount(cfg.Cfg.DockerSocketPath()))
 	}
 
 	return &SetupMountsResult{

--- a/internal/workspace/strategy.go
+++ b/internal/workspace/strategy.go
@@ -210,12 +210,15 @@ func EnsureConfigVolumes(
 	return result, nil
 }
 
-// GetDockerSocketMount returns the Docker socket mount if enabled
-func GetDockerSocketMount() mount.Mount {
+// GetDockerSocketMount returns the Docker socket bind. hostSocketPath is the
+// resolved host-side socket (config.Config.DockerSocketPath — the host may
+// serve it away from the conventional path); the target is always the
+// conventional in-container location.
+func GetDockerSocketMount(hostSocketPath string) mount.Mount {
 	return mount.Mount{
 		Type:     mount.TypeBind,
-		Source:   "/var/run/docker.sock",
-		Target:   "/var/run/docker.sock",
+		Source:   hostSocketPath,
+		Target:   consts.DefaultDockerSocketPath,
 		ReadOnly: false,
 	}
 }

--- a/pkg/whail/errors.go
+++ b/pkg/whail/errors.go
@@ -85,7 +85,7 @@ func ErrDockerHealthCheckFailed(err error) *DockerError {
 		NextSteps: []string{
 			"Ensure Docker is installed",
 			"Start Docker Desktop (macOS/Windows) or run 'sudo systemctl start docker' (Linux)",
-			"Check if Docker socket is accessible: ls -la /var/run/docker.sock",
+			"Check if the Docker socket is accessible ($DOCKER_HOST if set, otherwise /var/run/docker.sock)",
 			"Verify your user is in the docker group: groups $USER",
 		},
 	}


### PR DESCRIPTION
## Problem

Docker socket bind mounts hardcoded `/var/run/docker.sock` as the bind source. Container create fails on any host whose daemon serves the socket elsewhere — rootless Docker (`$XDG_RUNTIME_DIR/docker.sock`) being the common case:

```
invalid mount config for type "bind": bind source path does not exist: /var/run/docker.sock
```

## Fix

New `config.Config.DockerSocketPath()` accessor with docker-CLI-parity precedence (environment beats stored configuration):

1. `DOCKER_HOST` — pass-through, `unix://` prefix stripped, no validation. A non-path value reaches the daemon, whose mount error names the raw value.
2. `settings.yaml` `docker.socket` (knob existed in the schema but nothing read it — now wired)
3. `/var/run/docker.sock`

Consumers: CP container mount source (`controlplane/manager/cp_container.go`) and agent DooD mount (`workspace.GetDockerSocketMount`, now takes the resolved source). Mount target stays the conventional in-container path in both. SDK connection is untouched — `DOCKER_HOST` passes through to `client.FromEnv` as before. The TCP-local transport gap is #450; support-skill limitation doc in schmitthub/clawker-plugin#6.

## Tests

- `TestDockerHostSocketPath` — env getter table (unix strip, verbatim pass-through, unset)
- `TestDockerSocketPath` — env > settings > default precedence through the real config impl
- `TestCPContainerConfig_DockerSocketMounted` — CP mount source/target under default and rootless `DOCKER_HOST`

Full unit suite passes. End-to-end UAT on a rootless host pending — needs an alpha release; expected result: create succeeds and `docker inspect` shows the rootless source path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)