### PR TITLE
feat(project): shell completion for registered project names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format follows Keep a Changelog, and clawker adheres to Semantic Versioning.
 A release spans many merged PRs and may mix change kinds — Added, Fixed,
 Changed, Removed. Each release section lists those subsections directly.
 
+## [2026.8.4] - 2026-08-16
+
+- **Added:** Shell tab-completion suggests registered project names — when completing `clawker project info` and `clawker project remove` arguments and the `--project` flag value on `clawker ps`.
+
 ## [2026.8.3] - 2026-08-07
 
 - **Added:** Clawker runs on rootless Docker (Linux). A stock rootless install works without configuration — the full feature set is available, including the egress firewall and bind-mounted workspaces. Two steps ask for `sudo` once per boot: a BPF filesystem delegation for the firewall, and an ID-mapped workspace view so bind mounts reach the container user with correct ownership. See [Rootless Docker](https://docs.clawker.dev/container-internals#rootless-docker).

--- a/internal/cmd/container/CLAUDE.md
+++ b/internal/cmd/container/CLAUDE.md
@@ -67,7 +67,7 @@ Separate I/O from resize — `pty.Stream(ctx, hijacked)` in goroutine, `signals.
 
 ### Format/Filter Flags (list command)
 
-`container list` supports `--format`/`--json`/`-q`/`--filter key=value` via `cmdutil.FormatFlags` and `cmdutil.FilterFlags`. Valid filter keys: `name`, `status`, `agent`.
+`container list` supports `--format`/`--json`/`-q`/`--filter key=value` via `cmdutil.FormatFlags` and `cmdutil.FilterFlags`. Valid filter keys: `name`, `status`, `agent`. `--project`/`-p` tab-completes registered project names via `projectshared.NameCompletions(f.ProjectManager)` (`internal/cmd/project/shared`).
 
 ### Per-Command Documentation
 

--- a/internal/cmd/container/list/list.go
+++ b/internal/cmd/container/list/list.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"time"
 
+	projectshared "github.com/schmitthub/clawker/internal/cmd/project/shared"
 	"github.com/schmitthub/clawker/internal/cmdutil"
 	"github.com/schmitthub/clawker/internal/docker"
 	"github.com/schmitthub/clawker/internal/iostreams"
+	"github.com/schmitthub/clawker/internal/project"
 	"github.com/schmitthub/clawker/internal/tui"
 	"github.com/spf13/cobra"
 )
@@ -17,9 +19,10 @@ var containerListValidFilterKeys = []string{"name", "status", "agent"}
 
 // ListOptions holds options for the list command.
 type ListOptions struct {
-	IOStreams *iostreams.IOStreams
-	TUI       *tui.TUI
-	Client    func(context.Context) (*docker.Client, error)
+	IOStreams      *iostreams.IOStreams
+	TUI            *tui.TUI
+	Client         func(context.Context) (*docker.Client, error)
+	ProjectManager func() (project.ProjectManager, error)
 
 	Format  *cmdutil.FormatFlags
 	Filter  *cmdutil.FilterFlags
@@ -41,9 +44,10 @@ type containerRow struct {
 // NewCmdList creates the container list command.
 func NewCmdList(f *cmdutil.Factory, runF func(context.Context, *ListOptions) error) *cobra.Command {
 	opts := &ListOptions{
-		IOStreams: f.IOStreams,
-		TUI:       f.TUI,
-		Client:    f.Client,
+		IOStreams:      f.IOStreams,
+		TUI:            f.TUI,
+		Client:         f.Client,
+		ProjectManager: f.ProjectManager,
 	}
 
 	cmd := &cobra.Command{
@@ -90,6 +94,10 @@ Note: Use 'clawker monitor status' for monitoring stack containers.`,
 	opts.Filter = cmdutil.AddFilterFlags(cmd)
 	cmd.Flags().BoolVarP(&opts.All, "all", "a", false, "Show all containers (including stopped)")
 	cmd.Flags().StringVarP(&opts.Project, "project", "p", "", "Filter by project name")
+	cmd.RegisterFlagCompletionFunc( //nolint:errcheck,gosec // errs only on bad wiring
+		"project",
+		projectshared.NameCompletions(opts.ProjectManager),
+	)
 
 	return cmd
 }

--- a/internal/cmd/project/CLAUDE.md
+++ b/internal/cmd/project/CLAUDE.md
@@ -17,6 +17,8 @@ Project commands are the primary user interface for working with the `ProjectMan
 | `remove/remove.go` | `NewCmdRemove(f, runF)` — remove projects from registry (with confirmation) |
 | `shared/discovery.go` | `HasLocalProjectConfig(cfg, dir)` — config existence check via storage layers + fallback probe |
 | `shared/discovery_test.go` | Table-driven tests: registered/unregistered × all config placements |
+| `shared/completion.go` | `NameCompletions(pmFn)` — cobra completion func for registered project names |
+| `shared/completion_test.go` | Sorted names, typed-arg exclusion, degrade-to-empty on error |
 
 ## Subcommands
 
@@ -24,8 +26,8 @@ Project commands are the primary user interface for working with the `ProjectMan
 - `project edit` — interactively edit existing project configuration. Opens a storeui browser TUI against `cfg.ProjectStore()` via `projectui.Edit`. No flags.
 - `project register` — register existing project in the user's registry (the registry file in the data dir, owned by `internal/project`)
 - `project list` (alias `ls`) — list all registered projects via `ProjectManager.ListProjects()`. Table output with NAME, ROOT, WORKTREES, STATUS columns. Supports `--format`/`--json`/`-q` flags via `FormatFlags`. Status reflects `ProjectState.Status` (ok, missing, inaccessible).
-- `project info NAME` — show detailed info for a single project via `ProjectManager.ListProjects()`: name, root, directory status, worktrees with health status. Supports `--json` output (no `--format`/`--quiet`).
-- `project remove NAME [NAME...]` (alias `rm`) — remove projects from registry by name. Prompts for confirmation in interactive mode; requires `--yes` in non-interactive mode. Does not delete files from disk.
+- `project info NAME` — tab-completes NAME from the registry. Show detailed info for a single project via `ProjectManager.ListProjects()`: name, root, directory status, worktrees with health status. Supports `--json` output (no `--format`/`--quiet`).
+- `project remove NAME [NAME...]` (alias `rm`) — tab-completes NAME from the registry (already-typed names excluded). Remove projects from registry by name. Prompts for confirmation in interactive mode; requires `--yes` in non-interactive mode. Does not delete files from disk.
 
 ## Key Symbols
 
@@ -136,6 +138,12 @@ Checks whether a project config file exists in the given directory. Two-phase:
 2. **Fallback**: Calls `config.ProjectConfigExistsIn(dir)` — config probes the directory itself (both filenames, dual placement, migrations wired), which works for unregistered projects where walk-up can't find the directory. A probe error is reported as "no local config" (a file the loader cannot read is not one the caller can carry forward).
 
 Used by both `init` and `register` to detect existing config before proceeding.
+
+### `NameCompletions(pmFn func() (project.ProjectManager, error)) cobra.CompletionFunc`
+
+Shell tab-completion for registered project names. Reads `ProjectManager.List` (cheap path — no filesystem health checks), sorts names, excludes names already present in the positional args, and returns `cobra.ShellCompDirectiveNoFileComp`. Every failure (nil `pmFn`, manager error, list error) degrades to no suggestions — completion never surfaces errors.
+
+Consumers: `project info` and `project remove` (`cmd.ValidArgsFunction`), `container list --project` (`RegisterFlagCompletionFunc`). Any command that takes a project name as an arg or flag should register this rather than build its own.
 
 ## Config Access Pattern
 

--- a/internal/cmd/project/info/info.go
+++ b/internal/cmd/project/info/info.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/schmitthub/clawker/internal/cmd/project/shared"
 	"github.com/schmitthub/clawker/internal/cmdutil"
 	"github.com/schmitthub/clawker/internal/iostreams"
 	"github.com/schmitthub/clawker/internal/project"
@@ -59,6 +60,8 @@ their health status.`,
 			return infoRun(cmd.Context(), opts)
 		},
 	}
+
+	cmd.ValidArgsFunction = shared.NameCompletions(opts.ProjectManager)
 
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output as JSON")
 

--- a/internal/cmd/project/remove/remove.go
+++ b/internal/cmd/project/remove/remove.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/schmitthub/clawker/internal/cmd/project/shared"
 	"github.com/schmitthub/clawker/internal/cmdutil"
 	"github.com/schmitthub/clawker/internal/iostreams"
 	"github.com/schmitthub/clawker/internal/project"
@@ -55,6 +56,8 @@ Use 'clawker project list' to see registered project names.`,
 			return removeRun(cmd.Context(), opts)
 		},
 	}
+
+	cmd.ValidArgsFunction = shared.NameCompletions(opts.ProjectManager)
 
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, "Skip confirmation prompt")
 

--- a/internal/cmd/project/shared/completion.go
+++ b/internal/cmd/project/shared/completion.go
@@ -1,0 +1,61 @@
+package shared
+
+import (
+	"context"
+	"slices"
+
+	"github.com/spf13/cobra"
+
+	"github.com/schmitthub/clawker/internal/project"
+)
+
+// NameCompletions returns a cobra completion function that suggests registered
+// project names for shell tab-completion. Use it as ValidArgsFunction on
+// commands that take project names as positional args, or register it for
+// flags that take a project name. Names already present in the command's
+// positional args are excluded so multi-arg commands (e.g. project remove)
+// don't re-suggest what was typed. Registry entries are read via
+// ProjectManager.List — the cheap path with no filesystem health checks — so
+// completion stays fast. All failures degrade to no suggestions — completion
+// must never surface errors.
+func NameCompletions(pmFn func() (project.ProjectManager, error)) cobra.CompletionFunc {
+	return func(cmd *cobra.Command, args []string, _ string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		return nameSuggestions(cmd.Context(), pmFn, args), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func nameSuggestions(
+	ctx context.Context,
+	pmFn func() (project.ProjectManager, error),
+	typedArgs []string,
+) []cobra.Completion {
+	if pmFn == nil {
+		return nil
+	}
+
+	mgr, err := pmFn()
+	if err != nil {
+		cobra.CompDebugln("clawker project completion: project manager: "+err.Error(), false)
+		return nil
+	}
+
+	entries, err := mgr.List(ctx)
+	if err != nil {
+		cobra.CompDebugln("clawker project completion: list projects: "+err.Error(), false)
+		return nil
+	}
+
+	typed := make(map[string]bool, len(typedArgs))
+	for _, a := range typedArgs {
+		typed[a] = true
+	}
+
+	var completions []cobra.Completion
+	for _, e := range entries {
+		if e.Name != "" && !typed[e.Name] {
+			completions = append(completions, e.Name)
+		}
+	}
+	slices.Sort(completions)
+	return completions
+}

--- a/internal/cmd/project/shared/completion_test.go
+++ b/internal/cmd/project/shared/completion_test.go
@@ -1,0 +1,90 @@
+package shared_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/schmitthub/clawker/internal/cmd/project/shared"
+	"github.com/schmitthub/clawker/internal/project"
+	projectmocks "github.com/schmitthub/clawker/internal/project/mocks"
+)
+
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func managerWithProjects(names ...string) func() (project.ProjectManager, error) {
+	entries := make([]project.ProjectEntry, 0, len(names))
+	for _, n := range names {
+		entries = append(entries, project.ProjectEntry{Name: n, Root: "/repos/" + n, Worktrees: nil})
+	}
+	mgr := projectmocks.NewMockProjectManager()
+	mgr.ListFunc = func(ctx context.Context) ([]project.ProjectEntry, error) {
+		return entries, nil
+	}
+	return func() (project.ProjectManager, error) { return mgr, nil }
+}
+
+func TestNameCompletions_ReturnsSortedNames(t *testing.T) {
+	fn := shared.NameCompletions(managerWithProjects("zeta", "alpha", "mid"))
+
+	completions, directive := fn(newTestCmd(), nil, "")
+	assert.Equal(t, []cobra.Completion{"alpha", "mid", "zeta"}, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestNameCompletions_ExcludesAlreadyTypedArgs(t *testing.T) {
+	fn := shared.NameCompletions(managerWithProjects("alpha", "beta"))
+
+	completions, directive := fn(newTestCmd(), []string{"alpha"}, "")
+	assert.Equal(t, []cobra.Completion{"beta"}, completions)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestNameCompletions_SkipsEmptyNames(t *testing.T) {
+	fn := shared.NameCompletions(managerWithProjects("alpha", ""))
+
+	completions, _ := fn(newTestCmd(), nil, "")
+	assert.Equal(t, []cobra.Completion{"alpha"}, completions)
+}
+
+func TestNameCompletions_DegradesToNoSuggestions(t *testing.T) {
+	tests := []struct {
+		name string
+		pmFn func() (project.ProjectManager, error)
+	}{
+		{
+			name: "manager error",
+			pmFn: func() (project.ProjectManager, error) { return nil, errors.New("boom") },
+		},
+		{
+			name: "list error",
+			pmFn: func() (project.ProjectManager, error) {
+				mgr := projectmocks.NewMockProjectManager()
+				mgr.ListFunc = func(ctx context.Context) ([]project.ProjectEntry, error) {
+					return nil, errors.New("boom")
+				}
+				return mgr, nil
+			},
+		},
+		{
+			name: "nil manager func",
+			pmFn: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn := shared.NameCompletions(tt.pmFn)
+
+			completions, directive := fn(newTestCmd(), nil, "")
+			assert.Nil(t, completions)
+			assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `shared.NameCompletions(pmFn)` in `internal/cmd/project/shared` — a cobra completion func that suggests registered project names. Sorted, excludes already-typed positional args, reads `ProjectManager.List` (cheap path, no filesystem health checks), and degrades to no suggestions on any error.
- Wire it to `project info NAME`, `project remove NAME...` (`ValidArgsFunction`) and `container ls --project` (`RegisterFlagCompletionFunc`).
- Docs: `internal/cmd/project/CLAUDE.md`, `internal/cmd/container/CLAUDE.md`.

Mirrors the existing `worktree/shared.BranchCompletions` pattern. Any future command that takes a project name should register this rather than build its own.

## Test plan

- [x] `go test ./internal/cmd/project/... ./internal/cmd/container/list/` — new `completion_test.go` covers sorted output, typed-arg exclusion, empty-name skip, degrade table (manager error / list error / nil fn)
- [x] Live: registered a temp project, `clawker __complete project info ""` → name suggested; `__complete project rm <name> ""` → excluded; `__complete container ls --project ""` → name suggested

🤖 Generated with [Claude Code](https://claude.com/claude-code)