### PR TITLE
chore(copilot): add code review instructions, skill, and instructions scaffold

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,8 @@
   },
   "enabledPlugins": {
     "mintlify@claude-plugins-official": true
+  },
+  "attribution": {
+    "sessionUrl": false
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,141 @@
+# Copilot code review instructions
+
+You review pull requests for this repository. `AGENTS.md` at the repository
+root and the rule files in `.claude/rules/` are the coding standard. This file
+tells you what to look for first and how to write each comment.
+
+Read the head branch of the pull request. Compare every added or changed line
+against the priorities below, in order.
+
+## Priority 1: lint suppression
+
+Flag every added or changed lint suppression. One comment per occurrence.
+
+Markers to find in the diff:
+
+- `//nolint` and `// nolint` (with or without a linter list)
+- `#nosec`
+- `//lint:ignore`
+- Changes to `exclusions`, `exclude`, or `nolintlint` settings in `.golangci.yml`
+
+The repository rule (`AGENTS.md`, section "Error Handling") is: do not add a
+lint suppression without explicit maintainer approval. Correct the code so the
+linter passes. An explanation text after the marker is not sufficient on its
+own. In each comment:
+
+1. Quote the marker and the linter it silences.
+2. State that the rule requires maintainer approval.
+3. Propose the code change that removes the need for the suppression.
+
+## Priority 2: control plane servers and listeners
+
+Applies to new or changed calls to `grpc.NewServer`, `net.Listen`,
+`net.ListenConfig.Listen`, `http.Server`, and `ListenAndServe` in these paths:
+
+- `controlplane/**`
+- `internal/controlplane/**`
+- `cmd/clawkercp/**`
+- `clawkerd/**`
+
+The canonical authorization code is `controlplane/auth`:
+
+- `auth.NewAuthInterceptor` builds the interceptor from a Hydra introspector
+  and a method-to-scope map.
+- `AuthInterceptor.UnaryInterceptor`, `AuthInterceptor.StreamInterceptor`, and
+  `AuthInterceptor.GRPCServerOptions` attach it to a gRPC server.
+- `controlplane/server/grpc_stack.go` shows the required chain order:
+  recovery interceptor, then ready-gate interceptor, then auth interceptor.
+
+Report each of these as a blocking finding:
+
+- **No auth.** A gRPC server on the admin or agent surface without the
+  `controlplane/auth` interceptor chain. A hand-written token check, a
+  header check, or a copy of the interceptor logic is not acceptable; the
+  server must use `controlplane/auth`.
+- **Reused auth material.** A listener that loads certificate, key, or CA
+  files that belong to another lane, or that shares a `tls.Config` with
+  another lane. Each listener has its own certificate lane in its own
+  subpackage (`controlplane/infracerts`, `controlplane/otelcerts`,
+  `controlplane/sdscerts` are the pattern). See "Why not otelcerts" in
+  `controlplane/sdscerts/AGENTS.md`.
+- **mTLS without a pin.** A listener that uses client certificates instead of
+  bearer tokens must set `ClientAuth: tls.RequireAndVerifyClientCert` and pin
+  the peer CN or SAN in `VerifyPeerCertificate`. `clawkerd/listener.go` is the
+  reference. The pull request description must say why bearer authorization
+  does not apply to that listener.
+- **Crash path.** `panic`, `log.Fatal`, or `os.Exit` on the control plane
+  boot or serve path, or a serve goroutine without a `recover`. See
+  "CP crashing is a SECURITY incident" in `AGENTS.md`. A degraded subsystem
+  must emit a structured log line with `event=<subsystem>_unavailable`.
+
+## Priority 3: `CLAUDE.md` files
+
+Every `CLAUDE.md` in this repository is a symbolic link to the file
+`AGENTS.md` in the same directory. Git submodules are exempt.
+
+For each added or changed `CLAUDE.md` in the diff, check the file mode and
+the blob content. A symbolic link has mode `120000`, and its blob content is
+the link target string. Report each of these as a blocking finding:
+
+- A regular file named `CLAUDE.md` (mode `100644` or `100755`).
+- A link whose target is an absolute path.
+- A link whose target is not exactly `AGENTS.md` (for example
+  `../AGENTS.md`, `docs/AGENTS.md`, or `./AGENTS.md`).
+- A link whose sibling `AGENTS.md` does not exist in that directory.
+
+The fix is always the same: move the content to the sibling `AGENTS.md` and
+replace `CLAUDE.md` with a relative link to it.
+
+## Priority 4: standing rules from `AGENTS.md`
+
+Flag these when they appear in the diff. Name the `AGENTS.md` section in the
+comment.
+
+- An error assigned to `_` or otherwise not handled.
+- A meaningful string literal that is not a named constant.
+- A struct literal that omits required fields (the `exhaustruct` linter).
+- A dependency, container image, GitHub Action, or hook without an exact
+  version and digest or commit SHA.
+- A `context.Context` stored in a struct field.
+- An import of `github.com/moby/moby/client` outside `pkg/whail`, of
+  `pkg/whail` outside `internal/docker`, of `golang.org/x/term` outside
+  `internal/term`, of `lipgloss` outside `internal/iostreams`, or of
+  `bubbletea` outside `internal/tui`.
+
+## Do not report
+
+- Formatting that `gofmt`, `golines`, or import ordering already enforce.
+- Word choice in code comments.
+- A finding that a CI check on the same pull request already reports.
+
+## Comment style
+
+- Write in plain, direct English. One sentence, one idea.
+- One finding per comment. Anchor the comment to the line.
+- Name the rule file or `AGENTS.md` section the finding comes from.
+- Give the fix, not only the problem.
+
+## Rule files by path
+
+Read the matching rule file before you review a change in that path. This
+table mirrors the `paths:` front matter in each rule file.
+
+| Path | Rule file |
+| --- | --- |
+| `**/*.go` | `.claude/rules/testing.md` |
+| `internal/**`, `cmd/**` | `.claude/rules/dependency-placement.md` |
+| `internal/cmd/container/**` | `.claude/rules/container-commands.md` |
+| `internal/docker/**`, `pkg/whail/**` | `.claude/rules/docker-client.md` |
+| `controlplane/firewall/envoy_*.go` | `.claude/rules/envoy.md` |
+| `internal/git/**` | `.claude/rules/git.md` |
+| `internal/hostproxy/**` | `.claude/rules/hostproxy.md` |
+| `internal/iostreams/**`, `internal/cmd/**` | `.claude/rules/iostreams.md` |
+| `docs/**` | `.claude/rules/mintlify-docs.md` |
+| `internal/monitor/**`, `cmd/coredns-clawker/plugins/otel/**`, `controlplane/firewall/ebpf/netlogger/**`, `internal/consts/monitoring.go` | `.claude/rules/monitoring.md` |
+| `internal/storage/**`, `internal/config/schema*`, `internal/config/defaults*` | `.claude/rules/storage-schema.md` |
+| `internal/state/**`, `internal/config/**`, `internal/project/**`, `internal/storage/**` | `.claude/rules/store-backed-package.md` |
+| `internal/storeui/**`, `internal/config/storeui/**`, `internal/tui/fieldbrowser*`, `internal/tui/listeditor*` | `.claude/rules/storeui.md` |
+| `internal/tui/**` | `.claude/rules/tui.md` |
+
+`.claude/rules/code-style.md` and `.claude/rules/firewall-uat.md` apply to
+every path.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ own. In each comment:
 ## Priority 2: control plane servers and listeners
 
 Applies to new or changed calls to `grpc.NewServer`, `net.Listen`,
-`net.ListenConfig.Listen`, `http.Server`, and `ListenAndServe` in these paths:
+`net.ListenConfig`, `http.Server`, and `ListenAndServe` in these paths:
 
 - `controlplane/**`
 - `internal/controlplane/**`
@@ -133,8 +133,8 @@ table mirrors the `paths:` front matter in each rule file.
 | `docs/**` | `.claude/rules/mintlify-docs.md` |
 | `internal/monitor/**`, `cmd/coredns-clawker/plugins/otel/**`, `controlplane/firewall/ebpf/netlogger/**`, `internal/consts/monitoring.go` | `.claude/rules/monitoring.md` |
 | `internal/storage/**`, `internal/config/schema*`, `internal/config/defaults*` | `.claude/rules/storage-schema.md` |
-| `internal/state/**`, `internal/config/**`, `internal/project/**`, `internal/storage/**` | `.claude/rules/store-backed-package.md` |
-| `internal/storeui/**`, `internal/config/storeui/**`, `internal/tui/fieldbrowser*`, `internal/tui/listeditor*` | `.claude/rules/storeui.md` |
+| `internal/state/**`, `internal/config/**`, `internal/project/**`, `internal/storage/**`, `internal/storeui/**`, `controlplane/firewall/**` | `.claude/rules/store-backed-package.md` |
+| `internal/storeui/**`, `internal/config/storeui/**`, `internal/tui/fieldbrowser*`, `internal/tui/listeditor*`, `internal/tui/textareaeditor*` | `.claude/rules/storeui.md` |
 | `internal/tui/**` | `.claude/rules/tui.md` |
 
 `.claude/rules/code-style.md` and `.claude/rules/firewall-uat.md` apply to

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -14,8 +14,11 @@ not copy the rule text.
 - `applyTo`: copy the globs from the `paths:` front matter of the rule file.
   Join several globs with a comma.
 - Body: one line that names the rule file to apply.
-- Add `excludeAgent: code-review` when the file is for the Copilot coding
-  agent only, or `excludeAgent: cloud-agent` when it is for code review only.
+- `excludeAgent`: optional. GitHub accepts `"code-review"` or
+  `"cloud-agent"`. With `excludeAgent: "code-review"`, only Copilot cloud
+  agent reads the file. With `excludeAgent: "cloud-agent"`, only Copilot code
+  review reads the file. Without the key, both read it. Source:
+  [Adding repository custom instructions for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions).
 
 ## Template
 

--- a/.github/instructions/README.md
+++ b/.github/instructions/README.md
@@ -1,0 +1,34 @@
+# Path-specific Copilot instructions
+
+Copilot reads files in this directory that match `*.instructions.md`. This
+`README.md` is not one of them; it documents the convention. There are no
+instruction files here yet.
+
+## Convention
+
+One file per rule in `.claude/rules/`. The file points at the rule; it does
+not copy the rule text.
+
+- File name: `<rule>.instructions.md`, where `<rule>` is the base name of
+  the file in `.claude/rules/`.
+- `applyTo`: copy the globs from the `paths:` front matter of the rule file.
+  Join several globs with a comma.
+- Body: one line that names the rule file to apply.
+- Add `excludeAgent: code-review` when the file is for the Copilot coding
+  agent only, or `excludeAgent: cloud-agent` when it is for code review only.
+
+## Template
+
+```markdown
+---
+applyTo: "internal/git/**"
+---
+
+Apply the rules in `.claude/rules/git.md` to these files.
+```
+
+## Related files
+
+- `.github/copilot-instructions.md`: repository-wide review priorities and
+  the path-to-rule table that stands in for these files until they exist.
+- `.github/skills/code-review/SKILL.md`: the review procedure.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: code-review
+description: Review a pull request in this repository. Use this when asked to review a pull request, a diff, or a branch.
+---
+
+Follow these steps in order. `.github/copilot-instructions.md` defines each
+priority in full and the comment style; this file is the procedure.
+
+## 1. Lint suppression
+
+Search every added or changed line in the diff for `//nolint`, `// nolint`,
+`#nosec`, and `//lint:ignore`. Search `.golangci.yml` changes for
+`exclusions`, `exclude`, and `nolintlint`. List every hit as `file:line`.
+Report each hit as its own comment (priority 1).
+
+## 2. Control plane servers and listeners
+
+Search the diff under `controlplane/`, `internal/controlplane/`,
+`cmd/clawkercp/`, and `clawkerd/` for `grpc.NewServer`, `net.Listen`,
+`ListenConfig.Listen`, `http.Server`, and `ListenAndServe`. For each hit:
+
+1. Confirm the gRPC server attaches the `controlplane/auth` interceptor in
+   the chain order used by `controlplane/server/grpc_stack.go`.
+2. Confirm the certificate, key, and CA files come from a lane that belongs
+   to this listener only. Compare against `controlplane/infracerts`,
+   `controlplane/otelcerts`, and `controlplane/sdscerts`.
+3. If the listener uses client certificates instead of bearer tokens, confirm
+   `tls.RequireAndVerifyClientCert` and a CN or SAN pin in
+   `VerifyPeerCertificate`, and confirm the pull request description gives
+   the reason.
+4. Confirm there is no `panic`, `log.Fatal`, or `os.Exit`, and that each
+   serve goroutine has a `recover`.
+
+Report each failed check as a blocking comment (priority 2).
+
+## 3. `CLAUDE.md` files
+
+For each `CLAUDE.md` in the diff, read the file mode and the blob content.
+Pass only when the mode is `120000` and the content is exactly `AGENTS.md`,
+and a file named `AGENTS.md` exists in the same directory. Git submodules are
+exempt. Report each failure as a blocking comment (priority 3).
+
+## 4. Version pins
+
+For each added `FROM` line, `uses:` line, `rev:` line, or image constant in
+Go source, confirm it carries a `@sha256:` digest or a full commit SHA.
+Report each miss (priority 4).
+
+## 5. Standing rules
+
+Apply the remaining priority 4 rules and the path-to-rule table in
+`.github/copilot-instructions.md`.
+
+## 6. Report
+
+Write each comment as `.github/copilot-instructions.md` describes: one
+finding per comment, the rule source named, the fix given.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -17,7 +17,7 @@ Report each hit as its own comment (priority 1).
 
 Search the diff under `controlplane/`, `internal/controlplane/`,
 `cmd/clawkercp/`, and `clawkerd/` for `grpc.NewServer`, `net.Listen`,
-`ListenConfig.Listen`, `http.Server`, and `ListenAndServe`. For each hit:
+`net.ListenConfig`, `http.Server`, and `ListenAndServe`. For each hit:
 
 1. Confirm the gRPC server attaches the `controlplane/auth` interceptor in
    the chain order used by `controlplane/server/grpc_stack.go`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,9 @@ Every `CLAUDE.md` must be a relative symbolic link to the sibling `AGENTS.md`: `
 * `.claude/rules/` — Auto-loaded guidelines (code style, testing, package rules)
 * `.claude/docs/` — On-demand reference (architecture, design, key concepts)
 * `internal/*/CLAUDE.md` — Package-specific API references (lazy-loaded)
+* `.github/copilot-instructions.md` — Copilot code review priorities and comment style
+* `.github/instructions/` — Path-scoped Copilot instructions; each file mirrors the `paths:` front matter of a `.claude/rules/` file (empty for now)
+* `.github/skills/` — Copilot skills; `code-review/SKILL.md` is the review procedure
 
 ### Completion Gate
 


### PR DESCRIPTION
## Summary

- Add `.github/copilot-instructions.md` with ordered review priorities: lint suppression markers, control plane listener auth and certificate lanes, `CLAUDE.md` symlink shape, and the standing `AGENTS.md` rules. Includes a path-to-rule table that mirrors `.claude/rules/*` `paths:` front matter.
- Add `.github/skills/code-review/SKILL.md` with the review procedure Copilot follows.
- Add `.github/instructions/README.md` documenting the path-specific instruction file convention. No instruction files yet.
- Point to the new files from the `AGENTS.md` Documentation section.

## Test plan

- [x] `prek run` hooks pass on commit
- [x] No regular `CLAUDE.md` file added
- [ ] Copilot review on this PR references the new instructions or skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

