### PR TITLE
chore(dev): trim dev image installs, Codex multi-agent, go list guidance

### DIFF
--- a/.clawker.yaml
+++ b/.clawker.yaml
@@ -17,6 +17,8 @@ harnesses:
       claude mcp add -s local serena -- uvx --from git+https://github.com/oraios/serena@949a27ef1e5fda1a6e7b561e777bcece345c6ffd serena start-mcp-server --context claude-code --project "$(pwd)" --enable-web-dashboard false
       claude mcp add -s local -t http deepwiki https://mcp.deepwiki.com/mcp
       claude mcp add --scope local context7 -- npx -y @upstash/context7-mcp --api-key "$CONTEXT7_API_KEY"
+      claude plugin marketplace add DietrichGebert/ponytail
+      claude plugin install ponytail@ponytail
   codex:
     post_init: |
       uvx --from git+https://github.com/oraios/serena@949a27ef1e5fda1a6e7b561e777bcece345c6ffd serena setup codex
@@ -24,6 +26,8 @@ harnesses:
       codex mcp add deepwiki --url https://mcp.deepwiki.com/mcp
       codex mcp add context7 --env PATH="$PATH" --env SSL_CERT_FILE="$SSL_CERT_FILE" --env CURL_CA_BUNDLE="$CURL_CA_BUNDLE" --env NODE_USE_SYSTEM_CA=1 -- npx -y @upstash/context7-mcp --api-key "$CONTEXT7_API_KEY"
       sed -i -e '/^\[mcp_servers\.serena\]$/a startup_timeout_sec = 30' -e '/^\[mcp_servers\.context7\]$/a startup_timeout_sec = 30' "$CODEX_HOME/config.toml"
+      codex plugin marketplace add DietrichGebert/ponytail
+      codex plugin add ponytail@ponytail
 build:
   stacks:
     - go
@@ -42,43 +46,45 @@ build:
           grep " ${GH_FILE}\$" "${CHECKSUMS_FILE}" | sha256sum -c - && \
           tar -C /usr/local -xzf "${GH_FILE}" --strip-components=1 && \
           rm -f "${GH_FILE}" "${CHECKSUMS_FILE}"
-      - |-
-        COSIGN_VERSION=v3.0.5 && \
-          ARCH=$(dpkg --print-architecture) && \
-          case "$ARCH" in \
-            amd64) COSIGN_ARCH=amd64 ;; \
-            arm64) COSIGN_ARCH=arm64 ;; \
-            *) \
-              echo "Unsupported architecture for Cosign: $ARCH" >&2; \
-              exit 1; \
-              ;; \
-          esac && \
-          COSIGN_FILE="cosign-linux-${COSIGN_ARCH}" && \
-          CHECKSUMS_FILE="cosign_checksums.txt" && \
-          curl -fsSLO "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${COSIGN_FILE}" && \
-          curl -fsSLO "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${CHECKSUMS_FILE}" && \
-          grep " ${COSIGN_FILE}\$" "${CHECKSUMS_FILE}" | sha256sum -c - && \
-          install -m 755 "${COSIGN_FILE}" /usr/local/bin/cosign && \
-          rm -f "${COSIGN_FILE}" "${CHECKSUMS_FILE}"
-      - |-
-        SYFT_VERSION=v1.42.3 && \
-          ARCH=$(dpkg --print-architecture) && \
-          case "$ARCH" in \
-            amd64) SYFT_ARCH=amd64 ;; \
-            arm64) SYFT_ARCH=arm64 ;; \
-            armhf) SYFT_ARCH=armv7 ;; \
-            *) \
-              echo "Unsupported architecture for Syft: $ARCH" >&2; \
-              exit 1; \
-              ;; \
-          esac && \
-          SYFT_FILE="syft_${SYFT_VERSION#v}_linux_${SYFT_ARCH}.tar.gz" && \
-          CHECKSUMS_FILE="syft_${SYFT_VERSION#v}_checksums.txt" && \
-          curl -fsSLO "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${SYFT_FILE}" && \
-          curl -fsSLO "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${CHECKSUMS_FILE}" && \
-          grep " ${SYFT_FILE}\$" "${CHECKSUMS_FILE}" | sha256sum -c - && \
-          tar -C /usr/local/bin -xzf "${SYFT_FILE}" syft && \
-          rm -f "${SYFT_FILE}" "${CHECKSUMS_FILE}"
+      # Situational: verify a release signature locally (docs/threat-model.mdx). Enable when needed.
+      # - |-
+      #   COSIGN_VERSION=v3.0.5 && \
+      #     ARCH=$(dpkg --print-architecture) && \
+      #     case "$ARCH" in \
+      #       amd64) COSIGN_ARCH=amd64 ;; \
+      #       arm64) COSIGN_ARCH=arm64 ;; \
+      #       *) \
+      #         echo "Unsupported architecture for Cosign: $ARCH" >&2; \
+      #         exit 1; \
+      #         ;; \
+      #     esac && \
+      #     COSIGN_FILE="cosign-linux-${COSIGN_ARCH}" && \
+      #     CHECKSUMS_FILE="cosign_checksums.txt" && \
+      #     curl -fsSLO "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${COSIGN_FILE}" && \
+      #     curl -fsSLO "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${CHECKSUMS_FILE}" && \
+      #     grep " ${COSIGN_FILE}\$" "${CHECKSUMS_FILE}" | sha256sum -c - && \
+      #     install -m 755 "${COSIGN_FILE}" /usr/local/bin/cosign && \
+      #     rm -f "${COSIGN_FILE}" "${CHECKSUMS_FILE}"
+      # Situational: inspect a release SBOM locally. Enable when needed.
+      # - |-
+      #   SYFT_VERSION=v1.42.3 && \
+      #     ARCH=$(dpkg --print-architecture) && \
+      #     case "$ARCH" in \
+      #       amd64) SYFT_ARCH=amd64 ;; \
+      #       arm64) SYFT_ARCH=arm64 ;; \
+      #       armhf) SYFT_ARCH=armv7 ;; \
+      #       *) \
+      #         echo "Unsupported architecture for Syft: $ARCH" >&2; \
+      #         exit 1; \
+      #         ;; \
+      #     esac && \
+      #     SYFT_FILE="syft_${SYFT_VERSION#v}_linux_${SYFT_ARCH}.tar.gz" && \
+      #     CHECKSUMS_FILE="syft_${SYFT_VERSION#v}_checksums.txt" && \
+      #     curl -fsSLO "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${SYFT_FILE}" && \
+      #     curl -fsSLO "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/${CHECKSUMS_FILE}" && \
+      #     grep " ${SYFT_FILE}\$" "${CHECKSUMS_FILE}" | sha256sum -c - && \
+      #     tar -C /usr/local/bin -xzf "${SYFT_FILE}" syft && \
+      #     rm -f "${SYFT_FILE}" "${CHECKSUMS_FILE}"
       - |-
         YQ_VERSION=v4.53.3 && \
           ARCH=$(dpkg --print-architecture) && \
@@ -98,16 +104,13 @@ build:
       - go install gotest.tools/gotestsum@latest
       - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
       - go install golang.org/x/vuln/cmd/govulncheck@latest
-      - go install golang.org/x/tools/cmd/goimports@latest
-      - go install honnef.co/go/tools/cmd/staticcheck@latest
-      - go install golang.org/dl/go1.27.1@v0.0.0-20260901195035-4393e4265563 && go1.27.1 download
       - go install github.com/matryer/moq@latest
-      - go install github.com/goreleaser/goreleaser/v2@latest
-      - go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-      - go install github.com/bufbuild/buf/cmd/buf@latest
-      - go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      # Proto tools: run `make proto-tools` for the pinned buf, protoc-gen-go, and protoc-gen-go-grpc.
+      # Situational: local release dry run. Enable when needed.
+      # go install github.com/goreleaser/goreleaser/v2@latest
       - uv tool install semgrep
-      - curl https://sh.rustup.rs -sSf | sh -s -- -y
+      # Situational: Rust toolchain for the QUIC (quiche) firewall UAT client. Enable when needed.
+      # curl https://sh.rustup.rs -sSf | sh -s -- -y
       - |-
         WEBSOCAT_VERSION=v1.14.1 && \
           ARCH=$(dpkg --print-architecture) && \

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,6 @@
 [features]
 hooks = true
+multi_agent = true
 
 [agents.test-hunter]
 config_file = "../.agents/skills/test-hunter/agents/codex.toml"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Keep `.agents/` independent of any harness. Store native settings and tool-speci
 - Unit tests without Docker: `make test`
 - Build, integration tests, embeds, hooks, and completion checks: [dev-checks skill](.agents/skills/dev-checks/SKILL.md).
 - CLI, config, naming, package boundaries, and terminal behavior: Serena `project-guide` memory.
+- Package dependency and layering questions: run `go list -deps ./<pkg>` or `go list -f '{{.ImportPath}} {{.Imports}}' ./...` and answer from that output.
 - Agent file layout and native tool settings: [agent-files skill](.agents/skills/agent-files/SKILL.md).
 - Shared skills: `.agents/skills/`. Each `SKILL.md` description names its trigger; invoke the matching one. Behavioral and situational guidance is a skill, not a memory.
 


### PR DESCRIPTION
## Summary

- Trim `.clawker.yaml` dev image installs. Remove tools nothing in the container calls: goimports and staticcheck run inside golangci-lint, the base image already ships Go 1.27.1, and `make proto-tools` installs the pinned buf and protoc plugins. Comment out situational installs (cosign, syft, goreleaser, rustup) with a reason each. Saves about 5GB per image build.
- Install the ponytail plugin for both harnesses.
- Enable Codex `multi_agent`.
- Point agents at `go list` for package dependency and layering questions.

Supersedes #531. The graphify trial ended: on Go it gave one orientation hop that Serena already covers, and its extractor drops all package import edges.

## Test plan

- [x] `yq` parses `.clawker.yaml`; `root_run` 3 items, `user_run` 10
- [x] prek hooks still find golangci-lint, semgrep, govulncheck, gotestsum (all `language = "system"`)
- [x] Rebuild dev image and confirm size drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
