### PR TITLE
docs: adopt Mintlify Product Guide layout

### DIFF
--- a/cmd/gen-docs/configuration.mdx.tmpl
+++ b/cmd/gen-docs/configuration.mdx.tmpl
@@ -1,7 +1,6 @@
 ---
 title: "Configuration"
 description: "Reference for .clawker.yaml project configuration"
-icon: "gear"
 keywords: ["security", "AI container sandbox", "Claude Code", "Anthropic", "clawker.yaml", "agent configuration"]
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -33,7 +33,7 @@ Mintlify parses **all** `.md`/`.mdx` files as MDX — there is no per-file way t
 
 - Layout: Mintlify **Product Guide** template (`mintlify/templates/product-guide`): theme `almond`, lucide icons, global sidebar anchors (Home, GitHub, Releases), `navigation.directory: card`, groups with icons and `expanded: true` (except CLI Reference), navbar links empty with GitHub star-count button (`navbar.primary` must be an external URL; it opens a new tab)
 - Palette (canonical, do not change): amber (`#f59e0b` primary, `#fbbf24` light, `#d97706` dark); background `#09090b` with grid decoration; dark-only (`appearance.strict: true`)
-- Fonts: theme default (no `fonts` key)
+- Fonts: theme default. Do not add a `font` key; the schema key is `fonts` and a `font` block is ignored
 - Feature card on the homepage uses an amber gradient instead of the template's leaf images
 - Icons: `icons.library` is `lucide`; use lucide names in `icon=` props (`settings`, `zap`, `layers`, `boxes`, `box`, `package`, `shield`, `key`, `terminal`)
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -3,11 +3,11 @@
 ## File Conventions
 
 - `docs/docs.json` — Mintlify config (theme, nav, colors, integrations). **Not** `mint.json` (legacy name)
-- `docs/index.mdx` — Homepage
+- `docs/index.mdx` — Homepage. `mode: frame` landing page in the Product Guide template layout (hero, feature card, product cards, common tasks grid) with the prose sections below in `.product-guide-prose`
 - `docs/*.mdx` — Hand-authored pages (quickstart, installation, etc.). Exception: `docs/configuration.mdx` is **auto-generated** (from `cmd/gen-docs/configuration.mdx.tmpl` + schema struct tags — never edit directly)
 - `docs/cli-reference/*.md` — Auto-generated CLI reference (**never edit directly**). Generated via Makefile, checked in, freshness verified in CI (covers `docs/cli-reference/` and `docs/configuration.mdx`)
 - `docs/architecture.mdx`, `docs/design.mdx`, `docs/testing.md` — Developer docs with Mintlify frontmatter
-- `docs/custom.css` — Dark terminal theme overrides (surface colors, glassmorphism navbar, amber hover glow)
+- `docs/custom.css` — Mintlify Product Guide template `style.css` (sidebar anchor styling, frame-mode landing page, feature card) with amber palette
 - `docs/favicon.svg` — `>_` terminal prompt icon (amber `#f59e0b` on dark `#09090b`)
 - `docs/assets/` — Image assets directory
 
@@ -31,19 +31,16 @@ Mintlify parses **all** `.md`/`.mdx` files as MDX — there is no per-file way t
 
 ## Theming
 
-- Theme: `maple`, dark-only (`appearance.strict: true`)
-- Palette: amber (`#f59e0b` primary, `#fbbf24` light, `#d97706` dark)
-- Background: `#09090b` with grid decoration
-- Fonts: Fontshare CDN — Clash Display (headings, weight 600) + Satoshi (body, weight 400)
-- `custom.css` surfaces: `#111113` (sidebar, cards, footer), `#1a1a1f` (code blocks)
-- Glassmorphism navbar: `rgba(9,9,11,0.85)` with `backdrop-filter: blur(12px)`
-- Card hover: amber border glow (`rgba(245,158,11,0.4)`)
-- Code font: SF Mono → Cascadia Code → Fira Code → JetBrains Mono → monospace
+- Layout: Mintlify **Product Guide** template (`mintlify/templates/product-guide`): theme `almond`, lucide icons, global sidebar anchors (Home, GitHub, Releases), `navigation.directory: card`, groups with icons and `expanded: true` (except CLI Reference), navbar links empty with GitHub star-count button (`navbar.primary` must be an external URL; it opens a new tab)
+- Palette (canonical, do not change): amber (`#f59e0b` primary, `#fbbf24` light, `#d97706` dark); background `#09090b` with grid decoration; dark-only (`appearance.strict: true`)
+- Fonts: theme default (no `fonts` key)
+- Feature card on the homepage uses an amber gradient instead of the template's leaf images
+- Icons: `icons.library` is `lucide`; use lucide names in `icon=` props (`settings`, `zap`, `layers`, `boxes`, `box`, `package`, `shield`, `key`, `terminal`)
 
 ## Navigation Structure
 
-Sidebar groups: Quickstart, Security, Guides, CLI Reference (13 collapsible sub-groups: Top-Level Shortcuts, Container, Image, Volume, Network, Worktree, Monitor, Settings, Project, Firewall, Control Plane, Auth, Skill), Developer Guide.
-Navbar: Home → clawker.dev, GitHub link, Install button → /installation.
+Sidebar groups: Get started, Running Agents, Security, Building images, Extensions, Operations, Under the hood, Developer guide, CLI Reference (collapsible sub-groups per command family). Only top-level groups carry icons; pages never set `icon:` in frontmatter. A group's overview page uses `sidebarTitle: "Overview"` so the group name is not repeated (see `index.mdx`, `security.mdx`).
+Navbar: GitHub star-count button only. Sidebar global anchors: Home, GitHub, Releases.
 
 ## Architecture
 

--- a/docs/aliases.mdx
+++ b/docs/aliases.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Command Aliases"
 description: "Define shortcuts that expand to full clawker commands — shipped defaults, positional placeholders, and team sharing via project config"
-icon: "bolt"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "self-hosted", "open source", "command aliases", "CLI shortcuts", "clawker alias"]
 ---
 

--- a/docs/authoring-bundles.mdx
+++ b/docs/authoring-bundles.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Authoring Bundles"
 description: "Package harnesses, stacks, and monitoring extensions into a distributable bundle — layout, the bundle.yaml manifest, validation, and publishing"
-icon: "box-open"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "bundle", "authoring", "publishing"]
 ---
 

--- a/docs/authoring-harnesses.mdx
+++ b/docs/authoring-harnesses.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Authoring Harnesses"
 description: "Write a coding-agent harness — the harness.yaml manifest (version, stacks, volumes, seeds, staging, egress) and its Dockerfile fragment"
-icon: "code-branch"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "harness", "authoring", "egress floor"]
 ---
 

--- a/docs/authoring-monitoring.mdx
+++ b/docs/authoring-monitoring.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Authoring Monitoring Extensions"
 description: "Write a monitoring extension — the monitoring.yaml manifest (log lanes, metrics) plus the index templates, ingest pipelines, and saved objects it ships"
-icon: "chart-line"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "monitoring", "observability", "OpenSearch", "authoring"]
 ---
 

--- a/docs/authoring-stacks.mdx
+++ b/docs/authoring-stacks.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Authoring Stacks"
 description: "Write a language-runtime stack — the stack.yaml manifest and the root/user Dockerfile fragments that provision a toolchain"
-icon: "code"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "stacks", "authoring", "Dockerfile"]
 ---
 

--- a/docs/bundles.mdx
+++ b/docs/bundles.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Bundles"
 description: "Install, list, update, and remove distributed bundles — the packaging unit that ships harnesses, stacks, and monitoring extensions"
-icon: "box"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "bundle", "extensions", "install"]
 ---
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Configuration"
 description: "Reference for .clawker.yaml project configuration"
-icon: "gear"
 keywords: ["security", "AI container sandbox", "Claude Code", "Anthropic", "clawker.yaml", "agent configuration"]
 ---
 

--- a/docs/container-internals.mdx
+++ b/docs/container-internals.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Container Internals"
 description: "How Clawker containers are built, initialized, and managed — workspace mounting, harness state persistence, git integration, and the container lifecycle"
-icon: "microchip"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "container lifecycle", "workspace mounting", "clawkerd"]
 ---
 

--- a/docs/control-plane.mdx
+++ b/docs/control-plane.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Control Plane"
 description: "The clawker control plane — what it is, what it does, and how to interact with it"
-icon: "tower-control"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "self-hosted", "open source", "control plane", "mTLS", "agent registry"]
 ---
 

--- a/docs/credentials.mdx
+++ b/docs/credentials.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Credential Forwarding"
 description: "SSH, GPG, and Git HTTPS credential forwarding into containers, and how coding-agent harnesses authenticate"
-icon: "key"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "credential forwarding", "SSH agent", "GPG signing", "OAuth"]
 ---
 

--- a/docs/custom-images.mdx
+++ b/docs/custom-images.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Image Customization"
 description: "How Clawker builds per-project images — the substrate base, system packages, language stacks, build instructions, and injection points"
-icon: "layer-group"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "Docker image", "stacks", "build customization"]
 ---
 

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,69 +1,152 @@
-/* clawker.dev design alignment — dark terminal aesthetic with amber accents */
+/* Product Guide template styling (mintlify/templates/product-guide) with clawker's amber palette. */
 
-/* ── Surface colors ─────────────────────────────────────────────────── */
-
-/* Sidebar */
-#sidebar,
-.sidebar,
-[class*="sidebar"] nav {
-  background: #111113 !important;
+:root {
+  --default-border-color: var(--gray-200);
 }
 
-/* Navbar — glassmorphism */
-#navbar,
-nav[class*="navbar"],
-header[class*="navbar"],
-[class*="TopbarContainer"] {
-  background: rgba(9, 9, 11, 0.85) !important;
-  backdrop-filter: blur(12px) !important;
-  -webkit-backdrop-filter: blur(12px) !important;
+.dark {
+  --default-border-color: var(--gray-800);
 }
 
-/* Footer */
-footer,
-[class*="footer"] {
-  background: #111113 !important;
+#sidebar .nav-dropdown-trigger {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  padding-left: 0.375rem;
 }
 
-/* ── Cards ──────────────────────────────────────────────────────────── */
-
-[class*="Card"],
-.card,
-[class*="card-"] {
-  background: #111113 !important;
-  border-color: rgba(139, 139, 158, 0.15) !important;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+#sidebar .nav-dropdown-trigger:hover {
+  background-color: rgb(0 0 0 / 0.04) !important;
 }
 
-[class*="Card"]:hover,
-.card:hover,
-[class*="card-"]:hover {
-  border-color: rgba(245, 158, 11, 0.4) !important;
-  box-shadow: 0 0 20px rgba(245, 158, 11, 0.08) !important;
+.dark #sidebar .nav-dropdown-trigger:hover {
+  background-color: rgb(255 255 255 / 0.06) !important;
 }
 
-/* ── Code blocks ────────────────────────────────────────────────────── */
-
-pre,
-pre[class*="code"],
-[class*="codeblock"],
-[class*="CodeBlock"] {
-  background: #1a1a1f !important;
+#sidebar .nav-dropdown-trigger .nav-dropdown-item-icon,
+.nav-dropdown-content .nav-dropdown-item-icon {
+  border: none !important;
+  background: transparent !important;
+  height: auto !important;
+  width: auto !important;
+  padding: 0 !important;
 }
 
-code {
-  font-family: "SF Mono", "Cascadia Code", "Fira Code", "JetBrains Mono", monospace !important;
+.nav-dropdown-content .nav-dropdown-item-description {
+  display: none !important;
 }
 
-/* ── Borders ────────────────────────────────────────────────────────── */
-
-[class*="sidebar"] nav,
-#sidebar {
-  border-color: rgba(139, 139, 158, 0.15) !important;
+#sidebar .nav-anchor span {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
 }
 
-nav[class*="navbar"],
-header[class*="navbar"],
-[class*="TopbarContainer"] {
-  border-color: rgba(139, 139, 158, 0.15) !important;
+body:has([data-product-guide-index]) #sidebar a.nav-anchor[href='/'] {
+  color: rgb(var(--primary)) !important;
+  font-weight: 600 !important;
+}
+
+body:has([data-product-guide-index]) #sidebar a.nav-anchor[href='/'] span {
+  color: inherit !important;
+}
+
+body:has([data-product-guide-index]) #sidebar a.nav-anchor[href='/'] svg {
+  background-color: rgb(var(--primary)) !important;
+}
+
+.dark body:has([data-product-guide-index]) #sidebar a.nav-anchor[href='/'] {
+  color: rgb(var(--primary-light)/var(--tw-text-opacity,1)) !important;
+}
+
+.dark body:has([data-product-guide-index]) #sidebar a.nav-anchor[href='/'] svg {
+  background-color: rgb(var(--primary-light)/var(--tw-text-opacity,1)) !important;
+}
+
+:is(#content-area[data-current-path='/'], [data-current-path='/'] #content-area):has([data-product-guide-index]) {
+  background: transparent !important;
+  padding: 0 !important;
+}
+
+:is(#content-area[data-current-path='/'], [data-current-path='/'] #content-area):has([data-product-guide-index]) > div:first-child {
+  background: transparent !important;
+  padding-right: 0 !important;
+  padding-bottom: 0 !important;
+  padding-left: 0 !important;
+}
+
+[data-product-guide-index] a:not(.product-guide-feature-card) {
+  background-color: #fafafa !important;
+}
+
+.dark [data-product-guide-index] a:not(.product-guide-feature-card) {
+  background-color: #09090b !important;
+}
+
+.product-guide-feature-card {
+  grid-column: 1 / -1;
+  display: flex !important;
+  flex-direction: column !important;
+  justify-content: space-between !important;
+  min-height: 140px;
+  background: linear-gradient(135deg, #d97706 0%, #f59e0b 55%, #fbbf24 100%) !important;
+  border: none !important;
+  box-shadow: none !important;
+  color: white !important;
+  .dark & {
+    background: linear-gradient(135deg, #1a1a1f 0%, #3a2604 60%, #7c4a03 100%) !important;
+  }
+}
+
+.product-guide-feature-card > div {
+  display: flex !important;
+  flex: 1;
+  flex-direction: column !important;
+  justify-content: space-between !important;
+}
+
+.product-guide-feature-card :is(h2, h3, p, span, svg) {
+  color: white !important;
+}
+
+.product-guide-feature-card :is(svg, [class*='icon']) {
+  background-color: white !important;
+  width: 1.5em !important;
+  height: 1.5em !important;
+  margin-top: 2px;
+}
+
+.product-guide-feature-card-title {
+  font-size: 1.1em;
+  font-weight: 500;
+}
+
+.product-guide-feature-card :is(h2, h3, p, span, svg).product-guide-feature-card-description {
+  font-size: 0.95em;
+  font-weight: 400;
+  color: rgb(var(--gray-50) / 62.5%) !important;
+  .dark & {
+    color: rgb(var(--gray-50) / 50%) !important;
+  }
+}
+
+/* Prose sections below the landing grid (frame mode has no prose container). */
+[data-product-guide-index] .product-guide-prose h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+[data-product-guide-index] .product-guide-prose p,
+[data-product-guide-index] .product-guide-prose li {
+  line-height: 1.7;
+  margin-bottom: 0.75rem;
+}
+
+[data-product-guide-index] .product-guide-prose ul {
+  padding-left: 1.25rem;
+  list-style: disc;
 }

--- a/docs/docker-hygiene.mdx
+++ b/docs/docker-hygiene.mdx
@@ -1,7 +1,6 @@
 ---
 title: Docker Hygiene
 description: Managing disk space with clawker's Docker resources
-icon: "broom"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "self-hosted", "open source", "Docker resources", "disk space"]
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "maple",
+  "theme": "almond",
   "name": "Clawker",
   "favicon": "/favicon.svg",
+  "icons": {
+    "library": "lucide"
+  },
   "description": "Clawker is a free, open-source, self-hosted AI coding agent sandbox. Run Claude Code in Docker on your own machine with a deny-by-default egress firewall, prompt-injection and data-exfiltration protection, git credential forwarding, and parallel git-worktree agents.",
   "seo": {
     "metatags": {
@@ -51,20 +54,10 @@
     "options": ["copy", "view", "claude"]
   },
   "navbar": {
-    "links": [
-      {
-        "label": "Home",
-        "href": "https://clawker.dev"
-      },
-      {
-        "label": "GitHub",
-        "href": "https://github.com/schmitthub/clawker"
-      }
-    ],
+    "links": [],
     "primary": {
-      "type": "button",
-      "label": "Install",
-      "href": "/installation"
+      "type": "github",
+      "href": "https://github.com/schmitthub/clawker"
     }
   },
   "footer": {
@@ -80,23 +73,42 @@
   },
   "redirects": [],
   "navigation": {
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Home",
+          "icon": "house",
+          "href": "/"
+        },
+        {
+          "anchor": "GitHub",
+          "icon": "github",
+          "href": "https://github.com/schmitthub/clawker"
+        },
+        {
+          "anchor": "Releases",
+          "icon": "scroll-text",
+          "href": "https://github.com/schmitthub/clawker/releases"
+        }
+      ]
+    },
+    "directory": "card",
     "groups": [
       {
         "group": "Get started",
+        "icon": "rocket",
+        "expanded": true,
         "pages": [
           "index",
           "quickstart",
-          "installation"
-        ]
-      },
-      {
-        "group": "Configuration",
-        "pages": [
+          "installation",
           "configuration"
         ]
       },
       {
         "group": "Running Agents",
+        "icon": "play",
+        "expanded": true,
         "pages": [
           "worktrees",
           "aliases"
@@ -104,6 +116,8 @@
       },
       {
         "group": "Security",
+        "icon": "shield",
+        "expanded": true,
         "pages": [
           "threat-model",
           "security",
@@ -114,12 +128,16 @@
       },
       {
         "group": "Building images",
+        "icon": "layers",
+        "expanded": true,
         "pages": [
           "custom-images"
         ]
       },
       {
-        "group": "Bundles & extensions",
+        "group": "Extensions",
+        "icon": "package",
+        "expanded": true,
         "pages": [
           "bundles",
           "harnesses",
@@ -129,6 +147,8 @@
       },
       {
         "group": "Operations",
+        "icon": "activity",
+        "expanded": true,
         "pages": [
           "monitoring",
           "docker-hygiene"
@@ -136,6 +156,8 @@
       },
       {
         "group": "Under the hood",
+        "icon": "cpu",
+        "expanded": true,
         "pages": [
           "container-internals",
           "control-plane"
@@ -143,6 +165,8 @@
       },
       {
         "group": "Developer guide",
+        "icon": "code",
+        "expanded": true,
         "pages": [
           {
             "group": "Authoring",
@@ -165,6 +189,7 @@
       },
       {
         "group": "CLI Reference",
+        "icon": "terminal",
         "pages": [
           "cli-reference/clawker",
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,18 +34,6 @@
     },
     "decoration": "grid"
   },
-  "font": {
-    "heading": {
-      "url": "https://cdn.fontshare.com/wf/DK2FOA46SRWJ5HXWWU5TK4N4CMHYD236/FPEAXZZSH5L2K5MTJFRIWD2MC32IJMN3/THOOS4VOCKT7H2XEB27NQDYM2NYS4AAR.woff2",
-      "format": "woff2",
-      "weight": "600"
-    },
-    "body": {
-      "url": "https://cdn.fontshare.com/wf/NWBQYJIM7GCZ5XWD7D26ARB3VDY55ZRT/K63EV2KZIGKLE7RANQ2U42S6SVHU5RJ7/X6XYTKIVDUW7GZTZPZNN4EUM5KH54KHF.woff2",
-      "format": "woff2",
-      "weight": "400"
-    }
-  },
   "styling": {
     "codeblocks": "dark",
     "eyebrows": "breadcrumbs"

--- a/docs/firewall.mdx
+++ b/docs/firewall.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Egress Firewall"
 description: "Clawker's deny-by-default egress firewall for sandboxing AI coding agents: eBPF cgroup egress enforcement, CoreDNS, and Envoy deliver network isolation and data exfiltration prevention. Architecture, configuration, CLI commands, and troubleshooting."
-icon: "fire-flame-curved"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "egress firewall", "eBPF", "Envoy", "CoreDNS", "network isolation"]
 ---
 

--- a/docs/firewall.mdx
+++ b/docs/firewall.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Egress Firewall — Network Isolation for AI Agents"
+title: "Egress Firewall"
 description: "Clawker's deny-by-default egress firewall for sandboxing AI coding agents: eBPF cgroup egress enforcement, CoreDNS, and Envoy deliver network isolation and data exfiltration prevention. Architecture, configuration, CLI commands, and troubleshooting."
 icon: "fire-flame-curved"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "egress firewall", "eBPF", "Envoy", "CoreDNS", "network isolation"]

--- a/docs/harnesses.mdx
+++ b/docs/harnesses.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Harnesses"
 description: "Select and run coding-agent harnesses — the built-in claude and codex, loose local harnesses, and bundled harnesses"
-icon: "cubes"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "harness", "multi-agent"]
 ---
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,28 +3,120 @@ title: "Clawker"
 sidebarTitle: "Overview"
 description: "Free, open-source extensible sandbox to run coding agents — Claude Code, OpenAI Codex, Opencode, Pi and more — in Docker on your own machine. A local self-hosted AI coding agent sandbox with a deny-by-default egress firewall, prompt-injection and data-exfiltration protection, git credential forwarding, and parallel git-worktree agents — no cloud, no subscription."
 keywords: ["AI coding agent sandbox", "AI agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "Codex sandbox", "self-hosted", "open source", "egress firewall", "prompt injection protection", "data exfiltration", "network isolation", "deny-by-default", "parallel coding agents", "git worktree", "devcontainer alternative"]
+mode: frame
 ---
+
+<div data-product-guide-index className="flex w-full flex-col gap-8 max-w-5xl mx-auto px-4 md:px-8 lg:px-12 py-10 lg:gap-14 lg:py-16">
+  <div className="flex max-w-[540px] flex-col gap-2 self-center text-center">
+    <h1 className="text-[30px] font-medium leading-9 tracking-tight text-gray-900 dark:text-gray-50">
+      Clawker
+    </h1>
+    <p className="text-balance text-base leading-relaxed tracking-tight text-gray-600 dark:text-gray-400">
+      Free, open-source sandbox for running coding agents in Docker on your own machine, behind a deny-by-default egress firewall.
+    </p>
+  </div>
+
+  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+    <Card
+      title={<span className="product-guide-feature-card-title">Quickstart</span>}
+      icon="rocket"
+      href="/quickstart"
+      className="product-guide-feature-card"
+      size={28}
+    >
+      <span className="product-guide-feature-card-description">Install, initialize a project, and start your first agent in minutes.</span>
+    </Card>
+
+    <a href="/security" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+      <Icon icon="shield" color="rgb(var(--primary))" size={18} className="shrink-0" />
+      <div className="flex flex-col gap-1">
+        <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Security</span>
+        <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Threat model, egress firewall, credential forwarding, and observability.</span>
+      </div>
+    </a>
+    <a href="/worktrees" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+      <Icon icon="play" color="rgb(var(--primary))" size={18} className="shrink-0" />
+      <div className="flex flex-col gap-1">
+        <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Running agents</span>
+        <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Parallel agents on git worktrees and one-word command aliases.</span>
+      </div>
+    </a>
+    <a href="/bundles" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+      <Icon icon="package" color="rgb(var(--primary))" size={18} className="shrink-0" />
+      <div className="flex flex-col gap-1">
+        <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Bundles & extensions</span>
+        <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Harnesses, stacks, and monitoring extensions you can install or author.</span>
+      </div>
+    </a>
+    <a href="/cli-reference/clawker" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+      <Icon icon="terminal" color="rgb(var(--primary))" size={18} className="shrink-0" />
+      <div className="flex flex-col gap-1">
+        <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">CLI reference</span>
+        <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Every command, flag, and subcommand.</span>
+      </div>
+    </a>
+  </div>
+
+  <hr className="border-0 border-t border-border" />
+
+  <div className="flex flex-col gap-4">
+    <h2 className="font-serif text-xl font-medium leading-normal text-gray-900 dark:text-gray-50">Common tasks</h2>
+
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <a href="/installation" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+        <Icon icon="download" color="rgb(var(--primary))" size={18} className="shrink-0" />
+        <div className="flex flex-col gap-1">
+          <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Install Clawker</span>
+          <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Homebrew, curl, or build from source.</span>
+        </div>
+      </a>
+      <a href="/configuration" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+        <Icon icon="settings" color="rgb(var(--primary))" size={18} className="shrink-0" />
+        <div className="flex flex-col gap-1">
+          <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Configure a project</span>
+          <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Set up .clawker.yaml for images, workspaces, and security.</span>
+        </div>
+      </a>
+      <a href="/firewall" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+        <Icon icon="globe-lock" color="rgb(var(--primary))" size={18} className="shrink-0" />
+        <div className="flex flex-col gap-1">
+          <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Allow a domain</span>
+          <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Add path-scoped egress rules to the deny-by-default firewall.</span>
+        </div>
+      </a>
+      <a href="/worktrees" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+        <Icon icon="git-branch" color="rgb(var(--primary))" size={18} className="shrink-0" />
+        <div className="flex flex-col gap-1">
+          <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Run agents on worktrees</span>
+          <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Spin up agents on separate branches with automatic worktree management.</span>
+        </div>
+      </a>
+      <a href="/monitoring" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+        <Icon icon="activity" color="rgb(var(--primary))" size={18} className="shrink-0" />
+        <div className="flex flex-col gap-1">
+          <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Monitor agents</span>
+          <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">OpenTelemetry, OpenSearch, and Prometheus for agent observability.</span>
+        </div>
+      </a>
+      <a href="/custom-images" className="rounded-2xl flex flex-col gap-4 border bg-gray-50 p-4 outline-none shadow-sm shadow-gray-950/5 transition hover:border-primary hover:shadow-md dark:bg-gray-950 dark:shadow-black/20 dark:hover:border-primary">
+        <Icon icon="layers" color="rgb(var(--primary))" size={18} className="shrink-0" />
+        <div className="flex flex-col gap-1">
+          <span className="font-serif text-base font-medium text-gray-900 dark:text-gray-50">Build a custom image</span>
+          <span className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">Layer packages, language stacks, and build steps on the base image.</span>
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <hr className="border-0 border-t border-border" />
+
+  <div className="product-guide-prose text-gray-700 dark:text-gray-300">
 
 **Clawker is a free, open-source, local AI coding agent sandbox.** It runs coding-agent CLIs like [Claude Code](https://code.claude.com/docs), [OpenAI Codex](https://learn.chatgpt.com/docs/codex/cli), [OpenCode](https://opencode.ai/docs), [Pi](https://pi.dev/docs/latest), or any other harness — inside isolated Docker containers on your own machine — no cloud, no subscription, your repo stays on your own machine, never uploaded to a vendor sandbox.
 
 The rise of agentic AI has been meteoric, but in the rush to ship model harnesses the industry keeps skipping the risks that come with them. Letting an agent run in permissible modes on your bare-metal machine is fast — until a prompt injection turns it into a data-exfiltration tool with full access to your credentials and network. The harness itself needs a harness.
 
 Clawker is that harness. It pairs real network isolation — a **deny-by-default egress firewall** that blocks outbound traffic except to domains you allow — with git credential forwarding and parallel git-worktree agents, so you get the convenience of local, parallel coding agents *and* the network security to run them safely. It fills the gap between cloud agent sandboxes (isolated, but your code leaves your machine and you pay for it) and other local agent runners (free, but with no egress control): self-hosted agent infrastructure that is both fully local and security-deep.
-
-<CardGroup cols={2}>
-  <Card title="Quick Start" icon="terminal" href="/quickstart">
-    Get up and running with Clawker in minutes
-  </Card>
-  <Card title="Installation" icon="square-terminal" href="/installation">
-    All installation methods: Homebrew, curl, source build
-  </Card>
-  <Card title="Configuration" icon="sliders" href="/configuration">
-    Configure projects with .clawker.yaml
-  </Card>
-  <Card title="CLI Reference" icon="code" href="/cli-reference/clawker">
-    Complete command reference for all CLI commands
-  </Card>
-</CardGroup>
 
 ## What Is an Agent?
 
@@ -57,3 +149,6 @@ You (CLI) -> Clawker -> pkg/whail (label-isolated Docker engine) -> Docker SDK -
 ```
 
 Every container, volume, network, and image created by Clawker is tagged with `dev.clawker.*` labels. Clawker only sees and manages its own resources -- it cannot touch anything outside its label scope.
+
+  </div>
+</div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Clawker: Local extensible AI Coding Agent Sandbox"
+title: "Clawker"
 sidebarTitle: "Overview"
 description: "Free, open-source extensible sandbox to run coding agents — Claude Code, OpenAI Codex, Opencode, Pi and more — in Docker on your own machine. A local self-hosted AI coding agent sandbox with a deny-by-default egress firewall, prompt-injection and data-exfiltration protection, git credential forwarding, and parallel git-worktree agents — no cloud, no subscription."
 keywords: ["AI coding agent sandbox", "AI agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "Codex sandbox", "self-hosted", "open source", "egress firewall", "prompt injection protection", "data exfiltration", "network isolation", "deny-by-default", "parallel coding agents", "git worktree", "devcontainer alternative"]

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Installation"
 description: "Install clawker on macOS or Linux via Homebrew, install script, or source. Set up a free, open-source, self-hosted sandbox to run coding agents — Claude Code, OpenAI Codex, and more — in Docker on your own machine."
-icon: "download"
 keywords: ["install clawker", "AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted AI coding agent", "local AI coding agent", "open-source agent sandbox", "devcontainer alternative", "Homebrew", "macOS", "Linux", "Docker", "Anthropic", "OpenAI"]
 ---
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Install Clawker — Self-Hosted Coding Agent Sandbox"
+title: "Installation"
 description: "Install clawker on macOS or Linux via Homebrew, install script, or source. Set up a free, open-source, self-hosted sandbox to run coding agents — Claude Code, OpenAI Codex, and more — in Docker on your own machine."
 icon: "download"
 keywords: ["install clawker", "AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted AI coding agent", "local AI coding agent", "open-source agent sandbox", "devcontainer alternative", "Homebrew", "macOS", "Linux", "Docker", "Anthropic", "OpenAI"]

--- a/docs/monitoring-extensions.mdx
+++ b/docs/monitoring-extensions.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Monitoring Extensions"
 description: "Select the monitoring extensions your project contributes to the observability stack — the built-in claude-code extension, loose local extensions, and bundled extensions"
-icon: "gauge-high"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "monitoring", "observability", "OpenSearch", "extensions"]
 ---
 

--- a/docs/monitoring.mdx
+++ b/docs/monitoring.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Monitoring"
 description: "Set up the OpenSearch + OpenSearch Dashboards + Prometheus monitoring stack for agent observability"
-icon: "chart-mixed"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "OpenSearch", "Prometheus", "agent observability"]
 ---
 

--- a/docs/observability.mdx
+++ b/docs/observability.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Egress Observability"
 description: "Per-decision-point eBPF egress event records — what netlogger emits, where it lands, and how to use it"
-icon: "binoculars"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "self-hosted", "open source", "eBPF", "OpenTelemetry", "egress audit"]
 ---
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quickstart: Self-Hosted AI Coding Agent Sandbox"
+title: "Quickstart"
 description: "Run coding agents — Claude Code, OpenAI Codex, and more — in Docker on your own machine. Install clawker, initialize a project, and launch your first sandboxed AI coding agent — free, local, and open-source."
 icon: "rocket"
 keywords: ["AI agent sandbox", "AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted AI coding agent", "local AI coding agent", "open-source agent sandbox", "devcontainer alternative", "parallel coding agents", "git worktree agents", "egress firewall", "Anthropic", "OpenAI", "Docker"]

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Quickstart"
 description: "Run coding agents — Claude Code, OpenAI Codex, and more — in Docker on your own machine. Install clawker, initialize a project, and launch your first sandboxed AI coding agent — free, local, and open-source."
-icon: "rocket"
 keywords: ["AI agent sandbox", "AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted AI coding agent", "local AI coding agent", "open-source agent sandbox", "devcontainer alternative", "parallel coding agents", "git worktree agents", "egress firewall", "Anthropic", "OpenAI", "Docker"]
 ---
 
@@ -205,25 +204,25 @@ clawker firewall bypass 5m --agent dev  # Temporary unrestricted access
 ## What's Next
 
 <CardGroup cols={2}>
-  <Card title="Configuration" icon="gear" href="/configuration">
+  <Card title="Configuration" icon="settings" href="/configuration">
     Full `.clawker.yaml` reference with layered config and monorepo support
   </Card>
-  <Card title="Command Aliases" icon="bolt" href="/aliases">
+  <Card title="Command Aliases" icon="zap" href="/aliases">
     One-word shortcuts for full agent launches — shipped defaults, placeholders, team sharing
   </Card>
   <Card title="Security & Firewall" icon="shield" href="/security">
     Understand the deny-by-default firewall and how to configure domain access
   </Card>
-  <Card title="Custom Images" icon="layer-group" href="/custom-images">
+  <Card title="Custom Images" icon="layers" href="/custom-images">
     Packages, language stacks, Dockerfile instructions, and injection points
   </Card>
-  <Card title="Harnesses" icon="cubes" href="/harnesses">
+  <Card title="Harnesses" icon="boxes" href="/harnesses">
     Select and run coding-agent harnesses beyond the built-in claude and codex
   </Card>
-  <Card title="Stacks" icon="cube" href="/stacks">
+  <Card title="Stacks" icon="box" href="/stacks">
     Language toolchains you layer into an image — the built-in stacks and how to author your own
   </Card>
-  <Card title="Bundles" icon="box" href="/bundles">
+  <Card title="Bundles" icon="package" href="/bundles">
     Install distributed bundles of harnesses, stacks, and monitoring extensions
   </Card>
   <Card title="Credential Forwarding" icon="key" href="/credentials">

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Security — Sandbox for AI Coding Agents"
+title: "Security"
 description: "How clawker's self-hosted AI coding agent sandbox secures coding agents like Claude Code and Codex: deny-by-default egress firewall, container isolation, unprivileged execution, Docker socket scoping, and credential forwarding — free, local, no cloud."
 icon: "shield"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "container security", "egress firewall", "Linux capabilities"]

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Security"
+sidebarTitle: "Overview"
 description: "How clawker's self-hosted AI coding agent sandbox secures coding agents like Claude Code and Codex: deny-by-default egress firewall, container isolation, unprivileged execution, Docker socket scoping, and credential forwarding — free, local, no cloud."
-icon: "shield"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "container security", "egress firewall", "Linux capabilities"]
 ---
 

--- a/docs/stacks.mdx
+++ b/docs/stacks.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Stacks"
 description: "Language-runtime definitions you layer into an image — the built-in stacks, loose local stacks, and bundled stacks"
-icon: "cube"
 keywords: ["AI coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "coding agent sandbox", "self-hosted", "open source", "stacks", "language runtime", "node", "go", "python", "rust"]
 ---
 

--- a/docs/threat-model.mdx
+++ b/docs/threat-model.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Threat Model"
 description: "Clawker's threat model for sandboxing AI coding agents: prompt injection protection through deny-by-default network isolation, data exfiltration prevention, container isolation, the attack surfaces it mitigates, and what you're responsible for."
-icon: "crosshairs"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "threat model", "prompt injection", "AI agent security", "agent containment"]
 ---
 

--- a/docs/threat-model.mdx
+++ b/docs/threat-model.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Threat Model — Prompt Injection & Exfiltration Protection"
+title: "Threat Model"
 description: "Clawker's threat model for sandboxing AI coding agents: prompt injection protection through deny-by-default network isolation, data exfiltration prevention, container isolation, the attack surfaces it mitigates, and what you're responsible for."
 icon: "crosshairs"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "Claude Code sandbox", "self-hosted", "open source", "threat model", "prompt injection", "AI agent security", "agent containment"]

--- a/docs/worktrees.mdx
+++ b/docs/worktrees.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Worktrees"
 description: "Git worktree integration for multi-branch agent workflows"
-icon: "code-branch"
 keywords: ["AI coding agent sandbox", "coding agent sandbox", "run coding agents in Docker", "Claude Code", "Codex", "self-hosted", "open source", "git worktree", "parallel agents", "multi-agent"]
 ---
 


### PR DESCRIPTION
## Summary

- Switch the docs site to the Mintlify Product Guide template: `almond` theme, lucide icons, global sidebar anchors (Home, GitHub, Releases), card directory, and a `mode: frame` landing page (hero, feature card, product cards, common-tasks grid) with the existing prose kept below.
- Keep clawker's amber palette, `#09090b` grid background, and favicon unchanged.
- Remove per-page frontmatter `icon:` (also from `cmd/gen-docs/configuration.mdx.tmpl`, regenerated) so only top-level groups carry icons.
- Fold Configuration into Get started, rename "Bundles & extensions" to "Extensions", give the Security overview page `sidebarTitle: Overview` so group names are not repeated.
- Replace the navbar Install button with the GitHub star button (`navbar.primary` must be an external URL and always opens a new tab).
- Update `docs/AGENTS.md` theming and navigation notes.

## Test plan

- [x] `mint dev --docs-directory docs`: landing page renders hero, feature card, cards, and prose sections
- [x] Sidebar: icons only on group headers; no duplicated group/page names
- [x] Generated docs freshness check passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)