### PR TITLE
chore(hooks): run docs-check for every config schema file

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -106,7 +106,7 @@ id = "docs-check"
 name = "Generated docs freshness"
 entry = "make docs-check"
 language = "system"
-files = '^(cmd/|internal/cmd/|internal/docs/|internal/config/schema\.go)'
+files = '^(cmd/|internal/cmd/|internal/docs/|internal/config/([^/]*_)?schema\.go$)'
 pass_filenames = false
 priority = "scan"
 


### PR DESCRIPTION
## Summary

The local `docs-check` prek hook matched only `internal/config/schema.go`. The component schema files (`bundle_schema.go`, `harness_schema.go`, `monitoring_schema.go`, `stack_schema.go`) also feed `cmd/gen-docs`, so a change there regenerated docs only in CI.

The hook now matches every `([^/]*_)?schema.go` file in `internal/config`, excluding tests. CI (`docs.yml`) is unchanged and still runs `make docs-check` on every PR.

## Test plan

- [x] `git ls-files | grep -E <pattern>` lists exactly the five production schema files
- [x] `make docs-check` on `main` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)