### PR TITLE
ci(pr): run each check only when its inputs changed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,11 @@ name: Docs
 
 on:
   workflow_call:
+    inputs:
+      run_docs:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -9,6 +14,7 @@ permissions:
 jobs:
   docs:
     name: Generated Docs Check
+    if: inputs.run_docs
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -2,6 +2,11 @@ name: Licenses
 
 on:
   workflow_call:
+    inputs:
+      run_licenses:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -9,6 +14,7 @@ permissions:
 jobs:
   licenses:
     name: License Check
+    if: inputs.run_licenses
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Lint
 
 on:
   workflow_call:
+    inputs:
+      run_golangci_lint:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -10,6 +15,7 @@ permissions:
 jobs:
   golangci-lint:
     name: golangci-lint
+    if: inputs.run_golangci_lint
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -2,6 +2,11 @@ name: Plugin
 
 on:
   workflow_call:
+    inputs:
+      run_dockerfile_drift:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -9,6 +14,7 @@ permissions:
 jobs:
   dockerfile-drift:
     name: Dockerfile template drift check
+    if: inputs.run_dockerfile_drift
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,68 @@ permissions:
   actions: read
 
 jobs:
+  # Classifies the PR's changed paths so each check below runs only when its
+  # inputs changed. A gated job that does not run is reported as skipped,
+  # which GitHub counts as success for a required status check; the gate must
+  # sit on the job inside the reusable workflow (via the run_* input), never
+  # on the caller job or the workflow trigger, or the required check never
+  # reports and the PR hangs on "Expected". Every gate is fail-open: a missing
+  # output (this job failed) runs the check. Main runs every check on every
+  # push, so a wrong classification here is caught there.
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+      deps: ${{ steps.classify.outputs.deps }}
+      bpf: ${{ steps.classify.outputs.bpf }}
+      licenses: ${{ steps.classify.outputs.licenses }}
+      docs: ${{ steps.classify.outputs.docs }}
+      plugin: ${{ steps.classify.outputs.plugin }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # HEAD is the PR merge commit; HEAD^1 is the base branch tip.
+          fetch-depth: 2
+
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --name-only HEAD^1 HEAD > changed.txt
+          echo "Changed files:"; sed 's/^/  /' changed.txt
+
+          # Files the CI gates themselves depend on: run everything.
+          all='^\.github/(workflows|actions)/|^Makefile$|^Dockerfile|^\.golangci\.yml$|^scripts/'
+          # Files no Go, BPF, or scanner job reads.
+          text='\.(md|mdx)$|^docs/|^\.(agents|claude|codex|serena|github)/|(^|/)(LICENSE|NOTICE)[^/]*$'
+          deps='^go\.(mod|sum)$'
+          bpf='(^|/)controlplane/firewall/ebpf/'
+          licenses='^go\.(mod|sum)$|(^|/)(LICENSE|NOTICE)[^/]*$'
+          docs='^cmd/|^internal/(cmd|cmdutil|config|consts|docs)/|^docs/'
+          plugin='^internal/bundler/assets/|^clawker-plugin$|^\.gitmodules$'
+
+          if grep -qE "$all" changed.txt; then
+            for k in code deps bpf licenses docs plugin; do echo "$k=true"; done | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          any()  { grep -qE  "$1" changed.txt && echo true || echo false; }
+          rest() { grep -qvE "$1" changed.txt && echo true || echo false; }
+          {
+            echo "code=$(rest "$text")"
+            echo "deps=$(any "$deps")"
+            echo "bpf=$(any "$bpf")"
+            echo "licenses=$(any "$licenses")"
+            echo "docs=$(any "$docs")"
+            echo "plugin=$(any "$plugin")"
+          } | tee -a "$GITHUB_OUTPUT"
+
   security:
     name: Security
+    needs: changes
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/security.yml
     permissions:
       contents: read
@@ -25,35 +85,58 @@ jobs:
       security-events: write
       actions: read
     with:
-      run_dependency_review: true
+      run_dependency_review: ${{ needs.changes.outputs.deps != 'false' }}
+      run_semgrep: ${{ needs.changes.outputs.code != 'false' }}
+      run_govulncheck: ${{ needs.changes.outputs.code != 'false' }}
 
   lint:
     name: Lint
+    needs: changes
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/lint.yml
     permissions:
       contents: read
       actions: read
+    with:
+      run_golangci_lint: ${{ needs.changes.outputs.code != 'false' }}
 
   test:
     name: Test
+    needs: changes
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/test.yml
     permissions:
       contents: read
+    with:
+      run_unit: ${{ needs.changes.outputs.code != 'false' }}
+      run_bpf: ${{ needs.changes.outputs.bpf != 'false' }}
 
   licenses:
     name: Licenses
+    needs: changes
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/licenses.yml
     permissions:
       contents: read
+    with:
+      run_licenses: ${{ needs.changes.outputs.licenses != 'false' }}
 
   docs:
     name: Docs
+    needs: changes
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/docs.yml
     permissions:
       contents: read
+    with:
+      run_docs: ${{ needs.changes.outputs.docs != 'false' }}
 
   plugin:
     name: Plugin
+    needs: changes
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/plugin.yml
     permissions:
       contents: read
+    with:
+      run_dockerfile_drift: ${{ needs.changes.outputs.plugin != 'false' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,21 +16,24 @@ permissions:
   actions: read
 
 jobs:
-  # Classifies the PR's changed paths so each check below runs only when its
-  # inputs changed. A gated job that does not run is reported as skipped,
-  # which GitHub counts as success for a required status check; the gate must
-  # sit on the job inside the reusable workflow (via the run_* input), never
-  # on the caller job or the workflow trigger, or the required check never
-  # reports and the PR hangs on "Expected". Every gate is fail-open: a missing
-  # output (this job failed) runs the check. Main runs every check on every
-  # push, so a wrong classification here is caught there.
+  # Classifies the PR's changed paths so each check below runs only when the
+  # files it reads changed. A gated job that does not run is reported as
+  # skipped, which GitHub counts as success for a required status check; the
+  # gate must sit on the job inside the reusable workflow (via the run_*
+  # input), never on the caller job or the workflow trigger, or the required
+  # check never reports and the PR hangs on "Expected". Every gate is
+  # fail-open: a missing output (this job failed) runs the check. Main runs
+  # every check on every push, so a wrong classification here is caught there.
   changes:
     name: Changed paths
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     outputs:
-      code: ${{ steps.classify.outputs.code }}
-      deps: ${{ steps.classify.outputs.deps }}
+      semgrep: ${{ steps.classify.outputs.semgrep }}
+      govulncheck: ${{ steps.classify.outputs.govulncheck }}
+      dependency_review: ${{ steps.classify.outputs.dependency_review }}
+      lint: ${{ steps.classify.outputs.lint }}
+      unit: ${{ steps.classify.outputs.unit }}
       bpf: ${{ steps.classify.outputs.bpf }}
       licenses: ${{ steps.classify.outputs.licenses }}
       docs: ${{ steps.classify.outputs.docs }}
@@ -49,29 +52,26 @@ jobs:
           git diff --name-only HEAD^1 HEAD > changed.txt
           echo "Changed files:"; sed 's/^/  /' changed.txt
 
-          # Files the CI gates themselves depend on: run everything.
-          all='^\.github/(workflows|actions)/|^Makefile$|^Dockerfile|^\.golangci\.yml$|^scripts/'
-          # Files no Go, BPF, or scanner job reads.
-          text='\.(md|mdx)$|^docs/|^\.(agents|claude|codex|serena|github)/|(^|/)(LICENSE|NOTICE)[^/]*$'
-          deps='^go\.(mod|sum)$'
-          bpf='(^|/)controlplane/firewall/ebpf/'
-          licenses='^go\.(mod|sum)$|(^|/)(LICENSE|NOTICE)[^/]*$'
-          docs='^cmd/|^internal/(cmd|cmdutil|config|consts|docs)/|^docs/'
-          plugin='^internal/bundler/assets/|^clawker-plugin$|^\.gitmodules$'
+          # Files no Go build, scanner, or generator reads.
+          text='\.(md|mdx)$|^docs/|^\.(agents|claude|codex|serena|github|semgrep)/|(^|/)(LICENSE|NOTICE)[^/]*$|^\.golangci\.yml$|^prek\.toml$|^scripts/|^clawker-plugin$'
+          # The composite action every Go job builds the embedded binaries with.
+          action='^\.github/actions/'
+          wf='^\.github/workflows/'
+          gomod='^go\.(mod|sum)$'
 
-          if grep -qE "$all" changed.txt; then
-            for k in code deps bpf licenses docs plugin; do echo "$k=true"; done | tee -a "$GITHUB_OUTPUT"
-            exit 0
-          fi
           any()  { grep -qE  "$1" changed.txt && echo true || echo false; }
           rest() { grep -qvE "$1" changed.txt && echo true || echo false; }
+          go=$(rest "$text")
           {
-            echo "code=$(rest "$text")"
-            echo "deps=$(any "$deps")"
-            echo "bpf=$(any "$bpf")"
-            echo "licenses=$(any "$licenses")"
-            echo "docs=$(any "$docs")"
-            echo "plugin=$(any "$plugin")"
+            echo "semgrep=$([ "$go" = true ] && echo true || any "$wf|^\.semgrep/")"
+            echo "govulncheck=$([ "$go" = true ] && echo true || any "$action|${wf}security\.yml$")"
+            echo "dependency_review=$(any "$gomod|${wf}security\.yml$")"
+            echo "lint=$([ "$go" = true ] && echo true || any "$action|${wf}lint\.yml$|^\.golangci\.yml$")"
+            echo "unit=$([ "$go" = true ] && echo true || any "$action|${wf}test\.yml$")"
+            echo "bpf=$(any "(^|/)controlplane/firewall/ebpf/|^Makefile$|${wf}test\.yml$")"
+            echo "licenses=$(any "$gomod|(^|/)(LICENSE|NOTICE)[^/]*$|^scripts/gen-notice\.sh$|^Makefile$|$action|${wf}licenses\.yml$")"
+            echo "docs=$(any "^cmd/|^internal/(cmd|cmdutil|config|consts|docs)/|^docs/|^Makefile$|$action|${wf}docs\.yml$")"
+            echo "plugin=$(any "^internal/bundler/assets/|^clawker-plugin$|^\.gitmodules$|${wf}plugin\.yml$")"
           } | tee -a "$GITHUB_OUTPUT"
 
   security:
@@ -85,9 +85,9 @@ jobs:
       security-events: write
       actions: read
     with:
-      run_dependency_review: ${{ needs.changes.outputs.deps != 'false' }}
-      run_semgrep: ${{ needs.changes.outputs.code != 'false' }}
-      run_govulncheck: ${{ needs.changes.outputs.code != 'false' }}
+      run_dependency_review: ${{ needs.changes.outputs.dependency_review != 'false' }}
+      run_semgrep: ${{ needs.changes.outputs.semgrep != 'false' }}
+      run_govulncheck: ${{ needs.changes.outputs.govulncheck != 'false' }}
 
   lint:
     name: Lint
@@ -98,7 +98,7 @@ jobs:
       contents: read
       actions: read
     with:
-      run_golangci_lint: ${{ needs.changes.outputs.code != 'false' }}
+      run_golangci_lint: ${{ needs.changes.outputs.lint != 'false' }}
 
   test:
     name: Test
@@ -108,7 +108,7 @@ jobs:
     permissions:
       contents: read
     with:
-      run_unit: ${{ needs.changes.outputs.code != 'false' }}
+      run_unit: ${{ needs.changes.outputs.unit != 'false' }}
       run_bpf: ${{ needs.changes.outputs.bpf != 'false' }}
 
   licenses:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,25 +52,31 @@ jobs:
           git diff --name-only HEAD^1 HEAD > changed.txt
           echo "Changed files:"; sed 's/^/  /' changed.txt
 
-          # Files no Go build, scanner, or generator reads.
-          text='\.(md|mdx)$|^docs/|^\.(agents|claude|codex|serena|github|semgrep)/|(^|/)(LICENSE|NOTICE)[^/]*$|^\.golangci\.yml$|^prek\.toml$|^scripts/|^clawker-plugin$'
-          # The composite action every Go job builds the embedded binaries with.
-          action='^\.github/actions/'
+          # Go source tree: every file under a Go directory is a build input
+          # (sources, go:embed assets, testdata, BPF C, proto), except the
+          # agent instruction files. Root-level build inputs are listed by name.
+          # Anything else at the root (.goreleaser.yaml, .clawker.yaml, prek.toml,
+          # dotfiles, top-level markdown) is not a CI input.
+          gosrc='^(cmd|internal|pkg|controlplane|clawkerd|test|api)/|^go\.(mod|sum)$|^buf(\.gen)?\.yaml$'
+          # Files inside Go directories that no Go job reads.
+          notinput='(^|/)(AGENTS|CLAUDE)\.md$|(^|/)(LICENSE|NOTICE)[^/]*$'
+          # Build tooling every Go job runs through.
+          build='^Makefile$|^\.github/actions/'
           wf='^\.github/workflows/'
           gomod='^go\.(mod|sum)$'
 
-          any()  { grep -qE  "$1" changed.txt && echo true || echo false; }
-          rest() { grep -qvE "$1" changed.txt && echo true || echo false; }
-          go=$(rest "$text")
+          grep -vE "$notinput" changed.txt > inputs.txt || true
+          any() { grep -qE "$1" inputs.txt && echo true || echo false; }
+          go=$(any "$gosrc")
           {
-            echo "semgrep=$([ "$go" = true ] && echo true || any "$wf|^\.semgrep/")"
-            echo "govulncheck=$([ "$go" = true ] && echo true || any "$action|${wf}security\.yml$")"
-            echo "dependency_review=$(any "$gomod|${wf}security\.yml$")"
-            echo "lint=$([ "$go" = true ] && echo true || any "$action|${wf}lint\.yml$|^\.golangci\.yml$")"
-            echo "unit=$([ "$go" = true ] && echo true || any "$action|${wf}test\.yml$")"
+            echo "semgrep=$([ "$go" = true ] && echo true || any "$wf|^\.semgrep|^Dockerfile|^scripts/")"
+            echo "govulncheck=$([ "$go" = true ] && echo true || any "$build|${wf}security\.yml$")"
+            echo "dependency_review=$(any "$gomod|$wf")"
+            echo "lint=$([ "$go" = true ] && echo true || any "$build|^\.golangci\.yml$|${wf}lint\.yml$")"
+            echo "unit=$([ "$go" = true ] && echo true || any "$build|${wf}test\.yml$")"
             echo "bpf=$(any "(^|/)controlplane/firewall/ebpf/|^Makefile$|${wf}test\.yml$")"
-            echo "licenses=$(any "$gomod|(^|/)(LICENSE|NOTICE)[^/]*$|^scripts/gen-notice\.sh$|^Makefile$|$action|${wf}licenses\.yml$")"
-            echo "docs=$(any "^cmd/|^internal/(cmd|cmdutil|config|consts|docs)/|^docs/|^Makefile$|$action|${wf}docs\.yml$")"
+            echo "licenses=$(grep -qE "(^|/)(LICENSE|NOTICE)[^/]*$" changed.txt && echo true || any "$gomod|^scripts/gen-notice\.sh$|$build|${wf}licenses\.yml$")"
+            echo "docs=$(any "^cmd/|^internal/(cmd|cmdutil|config|consts|docs)/|^docs/|$build|${wf}docs\.yml$")"
             echo "plugin=$(any "^internal/bundler/assets/|^clawker-plugin$|^\.gitmodules$|${wf}plugin\.yml$")"
           } | tee -a "$GITHUB_OUTPUT"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,6 +7,14 @@ on:
         required: false
         type: boolean
         default: false
+      run_semgrep:
+        required: false
+        type: boolean
+        default: true
+      run_govulncheck:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -26,7 +34,7 @@ jobs:
     timeout-minutes: 10
     # Dependabot PRs have limited token permissions and only change
     # go.mod/go.sum — SAST scanning is not useful on dependency changes
-    if: (github.actor != 'dependabot[bot]')
+    if: inputs.run_semgrep && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -101,6 +109,7 @@ jobs:
 
   govulncheck:
     name: govulncheck SCA
+    if: inputs.run_govulncheck
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,15 @@ name: Test
 
 on:
   workflow_call:
+    inputs:
+      run_unit:
+        required: false
+        type: boolean
+        default: true
+      run_bpf:
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -9,6 +18,7 @@ permissions:
 jobs:
   unit:
     name: Unit Tests
+    if: inputs.run_unit
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -36,6 +46,7 @@ jobs:
     # binary runs under sudo via `make test-bpf` — and the pinned BPF apt
     # toolchain, which only resolves on ubuntu-24.04.
     name: BPF Prog-Run Tests
+    if: inputs.run_bpf
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Every PR ran every check. A new **Changed paths** job classifies the diff (merge commit vs base tip, plain `git diff`, no third-party action) and each reusable workflow takes a `run_*` boolean input that gates its job.

Why gate inside the reusable workflow: a job skipped by an `if:` reports **skipped**, which GitHub counts as success for a required status check. Skipping the caller job or path-filtering the trigger would leave `Lint / golangci-lint` etc. stuck on "Expected". The repo already uses this pattern for Dependency Review.

**Go inputs** = every file under `cmd/ internal/ pkg/ controlplane/ clawkerd/ test/ api/` (sources, `go:embed` assets, testdata, BPF C, proto) plus `go.mod`, `go.sum`, `buf*.yaml`. Excluded inside those dirs: `AGENTS.md`, `CLAUDE.md`, `LICENSE*`, `NOTICE*`. Nothing else at the root is a Go input (`.goreleaser.yaml`, `.clawker.yaml`, `.syft.yaml`, `prek.toml`, dotfiles, top-level markdown all trigger nothing).

| Check | Runs when |
|---|---|
| Semgrep | Go inputs, `.github/workflows/`, `.semgrep*`, `Dockerfile*`, `scripts/` |
| govulncheck | Go inputs, `Makefile`, `.github/actions/`, `security.yml` |
| Dependency review | `go.mod`, `go.sum`, `.github/workflows/` |
| golangci-lint | Go inputs, `Makefile`, `.github/actions/`, `.golangci.yml`, `lint.yml` |
| Unit tests | Go inputs, `Makefile`, `.github/actions/`, `test.yml` |
| BPF prog-run tests | `controlplane/firewall/ebpf/`, `Makefile`, `test.yml` |
| License check | `go.mod`, `go.sum`, `LICENSE*`, `NOTICE*`, `scripts/gen-notice.sh`, `Makefile`, `.github/actions/`, `licenses.yml` |
| Generated docs | `cmd/`, `internal/{cmd,cmdutil,config,consts,docs}/`, `docs/`, `Makefile`, `.github/actions/`, `docs.yml` |
| Dockerfile drift | `internal/bundler/assets/`, `clawker-plugin` pointer, `.gitmodules`, `plugin.yml` |
| Gitleaks, agent compatibility | always (any file can leak a secret; any rename can break an instruction link) |

- Fail-open: if the classifier fails, every check runs (`!cancelled()` + `!= 'false'`).
- Inputs default `true`; `main.yml` is untouched and still runs everything on every push, so a misclassification here is caught post-merge.

## Test plan

- [x] Classifier run locally against 27 fixture change sets (docs-only, Go, embedded `.md`, golden, proto, schema, go.mod, BPF, each workflow file, composite action, Makefile, `.golangci.yml`, goreleaser/syft, `.clawker.yaml`, dotfiles, `Dockerfile.controlplane`, both submodule pointers, LICENSE in a Go dir, `gen-notice.sh`, other scripts, semgrep rules, prek.toml, CHANGELOG). Each output matched the table.
- [x] `semgrep --config p/github-actions --config .semgrep/` clean on the workflows.
- [ ] This PR edits every workflow file, so its own run fires every gated job (each `<x>.yml` change triggers that workflow's jobs). First real skip proof is the next PR that touches only docs or agent files: Lint/Test/Security nested jobs must show skipped and the merge box green. Any required check on "Expected" means the gate placement is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
